### PR TITLE
Add SPLAT_TEST_FINI call for SPLAT_TASKQ_TEST6_ID

### DIFF
--- a/module/splat/splat-taskq.c
+++ b/module/splat/splat-taskq.c
@@ -722,6 +722,7 @@ void
 splat_taskq_fini(splat_subsystem_t *sub)
 {
         ASSERT(sub);
+	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST6_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST5_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST4_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST3_ID);


### PR DESCRIPTION
This change adds the neglected `SPLAT_TEST_FINI` call for the
`SPLAT_TASKQ_TEST6_ID`, just as is done for the other 5 `SPLAT_TASKQ_*`
tests.

Signed-off-by: Prakash Surya surya1@llnl.gov
