### PR TITLE
Add make rule for building Arch Linux packages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 include $(top_srcdir)/config/rpm.am
 include $(top_srcdir)/config/deb.am
 include $(top_srcdir)/config/tgz.am
+include $(top_srcdir)/config/arch.am
 
 if CONFIG_USER
 USER_DIR = lib cmd scripts

--- a/PKGBUILD-spl-modules.in
+++ b/PKGBUILD-spl-modules.in
@@ -1,0 +1,23 @@
+# Maintainer: Prakash Surya <surya1@llnl.gov>
+pkgname=@SPL_META_NAME@-modules
+pkgver=@SPL_META_VERSION@
+pkgrel=@SPL_META_RELEASE@
+pkgdesc="Contains kernel modules for emulating Solaris style primatives in the linux kernel."
+arch=(x86_64)
+url="git://github.com/zfsonlinux/spl.git"
+license=(@LICENSE@)
+source=(@SPL_META_NAME@-@SPL_META_VERSION@.tar.gz)
+
+build() {
+	cd $srcdir/@SPL_META_NAME@-@SPL_META_VERSION@
+	./configure --with-config=kernel \
+	            --prefix=/usr \
+	            --sysconfdir=/etc \
+	            --libexecdir=/usr/lib
+	make
+}
+
+package() {
+	cd $srcdir/@SPL_META_NAME@-@SPL_META_VERSION@
+	make DESTDIR=$pkgdir install
+}

--- a/PKGBUILD-spl.in
+++ b/PKGBUILD-spl.in
@@ -1,0 +1,23 @@
+# Maintainer: Prakash Surya <surya1@llnl.gov>
+pkgname=@SPL_META_NAME@
+pkgver=@SPL_META_VERSION@
+pkgrel=@SPL_META_RELEASE@
+pkgdesc="Contains the support utilities for the spl."
+arch=(x86_64)
+url="git://github.com/zfsonlinux/spl.git"
+license=(@LICENSE@)
+source=(@SPL_META_NAME@-@SPL_META_VERSION@.tar.gz)
+
+build() {
+	cd $srcdir/@SPL_META_NAME@-@SPL_META_VERSION@
+	./configure --with-config=user \
+	            --prefix=/usr \
+	            --sysconfdir=/etc \
+	            --libexecdir=/usr/lib
+	make
+}
+
+package() {
+	cd $srcdir/@SPL_META_NAME@-@SPL_META_VERSION@
+	make DESTDIR=$pkgdir install
+}

--- a/config/arch.am
+++ b/config/arch.am
@@ -1,0 +1,40 @@
+###############################################################################
+# Written by Prakash Surya <surya1@llnl.gov>
+###############################################################################
+# Build targets for RPM packages.
+###############################################################################
+
+sarch-modules:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-modules" sarch-common
+
+sarch-utils:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}" sarch-common
+
+sarch: sarch-modules sarch-utils
+
+arch-modules:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-modules" arch-common
+
+arch-utils:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}" arch-common
+
+arch: arch-modules arch-utils
+
+arch-local:
+	@(if test "${HAVE_MAKEPKG}" = "no"; then \
+		echo -e "\n" \
+	"*** Required util ${MAKEPKG} missing.  Please install the\n" \
+	"*** package for your distribution which provides ${MAKEPKG},\n" \
+	"*** re-run configure, and try again.\n"; \
+		exit 1; \
+	fi;)
+
+sarch-common: dist
+	pkgbuild=PKGBUILD-$(pkg); \
+	$(MAKE) $(AM_MAKEFLAGS) arch-local || exit 1; \
+	$(MAKEPKG) --allsource --skipinteg --nodeps -p $$pkgbuild || exit 1;
+
+arch-common: dist
+	pkgbuild=PKGBUILD-$(pkg); \
+	$(MAKE) $(AM_MAKEFLAGS) arch-local || exit 1; \
+	$(MAKEPKG) --skipinteg -p $$pkgbuild || exit 1;

--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -298,6 +298,48 @@ AC_DEFUN([SPL_AC_DPKG], [
 ])
 
 dnl #
+dnl # Check for pacman+makepkg to build Arch Linux packages.  If these
+dnl # tools are missing it is non-fatal but you will not be able to
+dnl # build Arch Linux packages and will be warned if you try too.
+dnl #
+AC_DEFUN([SPL_AC_PACMAN], [
+	PACMAN=pacman
+	MAKEPKG=makepkg
+
+	AC_MSG_CHECKING([whether $PACMAN is available])
+	tmp=$($PACMAN --version 2>/dev/null)
+	AS_IF([test -n "$tmp"], [
+		PACMAN_VERSION=$(echo $tmp |
+		                 $AWK '/Pacman/ { print $[3] }' |
+		                 $SED 's/^v//')
+		HAVE_PACMAN=yes
+		AC_MSG_RESULT([$HAVE_PACMAN ($PACMAN_VERSION)])
+	],[
+		HAVE_PACMAN=no
+		AC_MSG_RESULT([$HAVE_PACMAN])
+	])
+
+	AC_MSG_CHECKING([whether $MAKEPKG is available])
+	tmp=$($MAKEPKG --version 2>/dev/null)
+	AS_IF([test -n "$tmp"], [
+		MAKEPKG_VERSION=$(echo $tmp | $AWK '/makepkg/ { print $[3] }')
+		HAVE_MAKEPKG=yes
+		AC_MSG_RESULT([$HAVE_MAKEPKG ($MAKEPKG_VERSION)])
+	],[
+		HAVE_MAKEPKG=no
+		AC_MSG_RESULT([$HAVE_MAKEPKG])
+	])
+
+	AC_SUBST(HAVE_PACMAN)
+	AC_SUBST(PACMAN)
+	AC_SUBST(PACMAN_VERSION)
+
+	AC_SUBST(HAVE_MAKEPKG)
+	AC_SUBST(MAKEPKG)
+	AC_SUBST(MAKEPKG_VERSION)
+])
+
+dnl #
 dnl # Until native packaging for various different packing systems
 dnl # can be added the least we can do is attempt to use alien to
 dnl # convert the RPM packages to the needed package type.  This is
@@ -341,6 +383,8 @@ AC_DEFUN([SPL_AC_DEFAULT_PACKAGE], [
 		VENDOR=slackware ;
 	elif test -f /etc/gentoo-release ; then
 		VENDOR=gentoo ;
+	elif test -f /etc/arch-release ; then
+		VENDOR=arch ;
 	else
 		VENDOR= ;
 	fi
@@ -355,6 +399,7 @@ AC_DEFUN([SPL_AC_DEFAULT_PACKAGE], [
 		ubuntu)     DEFAULT_PACKAGE=deb ;;
 		debian)     DEFAULT_PACKAGE=deb ;;
 		slackware)  DEFAULT_PACKAGE=tgz ;;
+		arch)       DEFAULT_PACKAGE=arch;;
 		*)          DEFAULT_PACKAGE=rpm ;;
 	esac
 
@@ -369,6 +414,7 @@ AC_DEFUN([SPL_AC_PACKAGE], [
 	SPL_AC_RPM
 	SPL_AC_DPKG
 	SPL_AC_ALIEN
+	SPL_AC_PACMAN
 	SPL_AC_DEFAULT_PACKAGE
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,8 @@ AC_CONFIG_FILES([
 	scripts/Makefile
 	spl.spec
 	spl-modules.spec
+	PKGBUILD-spl
+	PKGBUILD-spl-modules
 ])
 
 AC_OUTPUT


### PR DESCRIPTION
Added the necessary build infrastructure for building packages
compatible with the Arch Linux distribution. As such, one can now run:

```
$ ./configure
$ make pkg     # Alternatively, one can run 'make arch' as well
```

on an Arch Linux machine to create two binary package compatible with
the pacman package managter, one for the spl userland utilties and
another for the spl kernel modules. The new packages can then be
installed by running:

```
# pacman -U $package.pkg.tar.xz
```

In addition, source-only packages suitable for an Arch Linux chroot
environment or remote builder can also be built using the 'sarch' make
rule.

NOTE: Since the source dist tarball is created on the fly from the head
of the build tree, it's MD5 hash signature will be continually influx.
As a result, the md5sum variable was intentionally omitted from the
PKGBUILD files, and the '--skipinteg' makepkg option is used. This may
or may not have any serious security implications, as the source tarball
is not being downloaded from an outside source.

Signed-off-by: Prakash Surya surya1@llnl.gov
