### PR TITLE
Fix usage of MUTEX macro in mutex_enter_nested

### DIFF
--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -195,7 +195,7 @@ spl_mutex_clear_owner(kmutex_t *mp)
 #ifdef HAVE_GPL_ONLY_SYMBOLS
 # define mutex_enter_nested(mp, sc)                                     \
 ({                                                                      \
-        mutex_lock_nested(MUTEX(mp, sc));                               \
+        mutex_lock_nested(MUTEX(mp), sc);                               \
         spl_mutex_set_owner(mp);                                        \
 })
 #else


### PR DESCRIPTION
A call site of the MUTEX macro had incorrectly placed it's closing
parenthesis, cause two parameters to be passed rather than one. This
change moves the misplaced parenthesis to fix the typographical error.

Signed-off-by: Prakash Surya surya1@llnl.gov
