### PR TITLE
Move Arch Linux's VENDOR check above Ubuntu's

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -373,6 +373,8 @@ AC_DEFUN([SPL_AC_DEFAULT_PACKAGE], [
 		VENDOR=redhat ;
 	elif test -f /etc/fedora-release ; then
 		VENDOR=fedora ;
+	elif test -f /etc/arch-release ; then
+		VENDOR=arch ;
 	elif test -f /etc/lsb-release ; then
 		VENDOR=ubuntu ;
 	elif test -f /etc/debian_version ; then
@@ -383,8 +385,6 @@ AC_DEFUN([SPL_AC_DEFAULT_PACKAGE], [
 		VENDOR=slackware ;
 	elif test -f /etc/gentoo-release ; then
 		VENDOR=gentoo ;
-	elif test -f /etc/arch-release ; then
-		VENDOR=arch ;
 	else
 		VENDOR= ;
 	fi


### PR DESCRIPTION
If the lsb-release package is installed on an Arch Linux distribution,
the configure step will incorrectly detect the running distribution as
Ubuntu. This is a result of both distributions providing an
/etc/lsb-release file, and the Ubuntu VENDOR check being performed
first.

Since the Arch Linux test check's for a file more specific to the Arch
Linux distribution, moving Arch Linux's VENDOR check above Unbuntu's
check provides a quick and easy solution.

Signed-off-by: Prakash Surya surya1@llnl.gov
Closes #72
