### PR TITLE
Linux 3.2 compat: rw_semaphore.wait_lock is raw

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -85,6 +85,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_KERN_PATH_PARENT_SYMBOL
 	SPL_AC_2ARGS_ZLIB_DEFLATE_WORKSPACESIZE
 	SPL_AC_SHRINK_CONTROL_STRUCT
+	SPL_AC_RWSEM_SPINLOCK_IS_RAW
 ])
 
 AC_DEFUN([SPL_AC_MODULE_SYMVERS], [
@@ -1972,4 +1973,30 @@ AC_DEFUN([SPL_AC_SHRINK_CONTROL_STRUCT], [
 	],[
 		AC_MSG_RESULT(no)
 	])
+])
+
+dnl #
+dnl # 3.1 API Change
+dnl #
+dnl # The rw_semaphore.wait_lock member was changed from spinlock_t to
+dnl # raw_spinlock_t at commit ddb6c9b58a19edcfac93ac670b066c836ff729f1.
+dnl #
+AC_DEFUN([SPL_AC_RWSEM_SPINLOCK_IS_RAW], [
+	AC_MSG_CHECKING([whether struct rw_semaphore member wait_lock is raw])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Werror"
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/rwsem.h>
+	],[
+		struct rw_semaphore dummy_semaphore;
+		raw_spinlock_t dummy_lock;
+		dummy_semaphore.wait_lock = dummy_lock;
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(RWSEM_SPINLOCK_IS_RAW, 1,
+		[struct rw_semaphore member wait_lock is raw_spinlock_t])
+	],[
+		AC_MSG_RESULT(no)
+	])
+	EXTRA_KCFLAGS="$tmp_flags"
 ])

--- a/include/sys/rwlock.h
+++ b/include/sys/rwlock.h
@@ -52,9 +52,9 @@ spl_rw_set_owner(krwlock_t *rwp)
 {
         unsigned long flags;
 
-        spin_lock_irqsave(&SEM(rwp)->wait_lock, flags);
+        spl_rwsem_lock_irqsave(&SEM(rwp)->wait_lock, flags);
         rwp->rw_owner = current;
-        spin_unlock_irqrestore(&SEM(rwp)->wait_lock, flags);
+        spl_rwsem_unlock_irqrestore(&SEM(rwp)->wait_lock, flags);
 }
 
 static inline void
@@ -62,9 +62,9 @@ spl_rw_clear_owner(krwlock_t *rwp)
 {
         unsigned long flags;
 
-        spin_lock_irqsave(&SEM(rwp)->wait_lock, flags);
+        spl_rwsem_lock_irqsave(&SEM(rwp)->wait_lock, flags);
         rwp->rw_owner = NULL;
-        spin_unlock_irqrestore(&SEM(rwp)->wait_lock, flags);
+        spl_rwsem_unlock_irqrestore(&SEM(rwp)->wait_lock, flags);
 }
 
 static inline kthread_t *
@@ -73,9 +73,9 @@ rw_owner(krwlock_t *rwp)
         unsigned long flags;
         kthread_t *owner;
 
-        spin_lock_irqsave(&SEM(rwp)->wait_lock, flags);
+        spl_rwsem_lock_irqsave(&SEM(rwp)->wait_lock, flags);
         owner = rwp->rw_owner;
-        spin_unlock_irqrestore(&SEM(rwp)->wait_lock, flags);
+        spl_rwsem_unlock_irqrestore(&SEM(rwp)->wait_lock, flags);
 
         return owner;
 }
@@ -187,14 +187,14 @@ extern int __down_write_trylock_locked(struct rw_semaphore *);
         unsigned long _flags_;                                          \
         int _rc_ = 0;                                                   \
                                                                         \
-        spin_lock_irqsave(&SEM(rwp)->wait_lock, _flags_);               \
+        spl_rwsem_lock_irqsave(&SEM(rwp)->wait_lock, _flags_);           \
         if ((list_empty(&SEM(rwp)->wait_list)) &&                       \
             (SEM(rwp)->activity == 1)) {                                \
                 __up_read_locked(SEM(rwp));                             \
                 VERIFY(_rc_ = __down_write_trylock_locked(SEM(rwp)));   \
                 (rwp)->rw_owner = current;                              \
         }                                                               \
-        spin_unlock_irqrestore(&SEM(rwp)->wait_lock, _flags_);          \
+        spl_rwsem_unlock_irqrestore(&SEM(rwp)->wait_lock, _flags_);      \
         _rc_;                                                           \
 })
 #else


### PR DESCRIPTION
The wait_lock member of the rw_semaphore struct became a raw_spinlock_t
in Linux 3.2 at torvalds/linux@ddb6c9b58a19edcfac93ac670b066c836ff729f1.

Wrap spin_lock_\* function calls in a new spl_rwsem_\* interface to
ensure type safety if raw_spinlock_t becomes architecture specific,
and to satisfy these compiler warnings:

  warning: passing argument 1 of ‘spinlock_check’
    from incompatible pointer type [enabled by default]
  note: expected ‘struct spinlock_t *’
    but argument is of type ‘struct raw_spinlock_t *’

Closes: #76
Closes: zfsonlinux/zfs#463
