### PR TITLE
Fix `make distclean` for `--with-config=user`

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -7,8 +7,11 @@ modules:
 	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
 
 clean:
-	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
-	if [ -f @LINUX_SYMBOLS@ ]; then $(RM) @LINUX_SYMBOLS@; fi
+	@# Only cleanup the kernel build directories when CONFIG_KERNEL
+	@# is defined.  This indicates that kernel modules should be built.
+@CONFIG_KERNEL_TRUE@	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
+
+	if [ -f '@LINUX_SYMBOLS@' ]; then $(RM) '@LINUX_SYMBOLS@'; fi
 	if [ -f Module.markers ]; then $(RM) Module.markers; fi
 
 modules_install:


### PR DESCRIPTION
Apply the same fix to SPL that was applied to ZFS earlier at:
zfsonlinux/zfs@d433c206515e567c52ce09589033405a0ae3716e

Additionally quote `@LINUX_SYMBOLS@` because it is a null substitution
in this configuration, which results in a `[ -f  ]` expression that
incorrectly evaluates to true.

```
  # ./configure --with-config=user
  # make distclean

  Making distclean in module
  make[1]: Entering directory `/spl/module'
  make -C  SUBDIRS=`pwd`  clean
  make: Entering an unknown directory
  make: *** SUBDIRS=/spl/module: No such file or directory.  Stop.
```
