### PR TITLE
Gentoo Linux is detected as Ubuntu Linux

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -377,6 +377,8 @@ AC_DEFUN([SPL_AC_DEFAULT_PACKAGE], [
 		VENDOR=fedora ;
 	elif test -f /etc/gentoo-release ; then
 		VENDOR=gentoo ;
+	elif test -f /etc/lsb-release ; then
+		VENDOR=ubuntu ;
 	elif test -f /etc/debian_version ; then
 		VENDOR=debian ;
 	elif test -f /etc/SuSE-release ; then
@@ -385,8 +387,6 @@ AC_DEFUN([SPL_AC_DEFAULT_PACKAGE], [
 		VENDOR=slackware ;
 	elif test -f /etc/arch-release ; then
 		VENDOR=arch ;
-	elif test -f /etc/lsb-release ; then
-		VENDOR=ubuntu ;
 	elif test -f /etc/lunar.release ; then
 		VENDOR=lunar ;
 	else

--- a/configure
+++ b/configure
@@ -11495,6 +11495,8 @@ $as_echo_n "checking linux distribution... " >&6; }
 		VENDOR=fedora ;
 	elif test -f /etc/gentoo-release ; then
 		VENDOR=gentoo ;
+	elif test -f /etc/lsb-release ; then
+		VENDOR=ubuntu ;
 	elif test -f /etc/debian_version ; then
 		VENDOR=debian ;
 	elif test -f /etc/SuSE-release ; then
@@ -11503,8 +11505,6 @@ $as_echo_n "checking linux distribution... " >&6; }
 		VENDOR=slackware ;
 	elif test -f /etc/arch-release ; then
 		VENDOR=arch ;
-	elif test -f /etc/lsb-release ; then
-		VENDOR=ubuntu ;
 	elif test -f /etc/lunar.release ; then
 		VENDOR=lunar ;
 	else


### PR DESCRIPTION
Currently, SPL's build system detects Gentoo Linux as Ubuntu Linux.

I have written a patch that synchronizes the behavior with that of the ZFS build system to correct this.
