### PR TITLE
Make taskqueues mimic loopback device's -20 nice value

### DIFF
--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -443,6 +443,8 @@ taskq_thread(void *args)
 	if (tq->tq_flags & TASKQ_NORECLAIM)
 		current->flags |= PF_MEMALLOC;
 
+	set_user_nice(current, -20);
+
         sigfillset(&blocked);
         sigprocmask(SIG_BLOCK, &blocked, NULL);
         flush_signals(current);


### PR DESCRIPTION
A comparison of swap on zvols with swap on the loopback device revealed
that the loopback device sets the nice value to -20.  An audit of the
code does not reveal any downside to doing that, so we can do it too.
