### PR TITLE
Ignore slab cache age and delay in direct reclaim

### DIFF
--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -1914,7 +1914,8 @@ spl_kmem_cache_reap_now(spl_kmem_cache_t *skc)
 	if (skc->skc_reclaim)
 		skc->skc_reclaim(skc->skc_private);
 
-	spl_slab_reclaim(skc, skc->skc_reap, 0);
+	/* Reclaim from the cache, ignoring it's age and delay. */
+	spl_slab_reclaim(skc, skc->skc_reap, 1);
 	clear_bit(KMC_BIT_REAPING, &skc->skc_flags);
 	atomic_dec(&skc->skc_ref);
 


### PR DESCRIPTION
When memory pressure triggers direct memory reclaim, a slab's age and
delay should not prevent it from being freed. This patch ensures these
values are ignored, allowing an empty slab to be freed in this code path
no matter the value of it's age and delay.

Signed-off-by: Prakash Surya surya1@llnl.gov
