### PR TITLE
Update a comment to reflect new taskq internals

### DIFF
--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -156,19 +156,22 @@ task_done(taskq_t *tq, taskq_ent_t *t)
  * monotonically increasing taskqid and added to the tail of the pending
  * list.  As worker threads become available the tasks are removed from
  * the head of the pending or priority list, giving preference to the
- * priority list.  The tasks are then added to the work list, preserving
- * the ordering by taskqid.  Finally, as tasks complete they are removed
- * from the work list.  This means that the pending and work lists are
- * always kept sorted by taskqid.  Thus the lowest outstanding
- * incomplete taskqid can be determined simply by checking the min
- * taskqid for each head item on the pending, priority, and work list.
- * This value is stored in tq->tq_lowest_id and only updated to the new
- * lowest id when the previous lowest id completes.  All taskqids lower
- * than tq->tq_lowest_id must have completed.  It is also possible
- * larger taskqid's have completed because they may be processed in
- * parallel by several worker threads.  However, this is not a problem
- * because the behavior of taskq_wait_id() is to block until all
- * previously submitted taskqid's have completed.
+ * priority list.  The tasks are then removed from their respective
+ * list, and the taskq_thread servicing the task is added to the active
+ * list, preserving the order using the serviced task's taskqid.
+ * Finally, as tasks complete the taskq_thread servicing the task is
+ * removed from the active list.  This means that the pending task and
+ * active taskq_thread lists are always kept sorted by taskqid. Thus the
+ * lowest outstanding incomplete taskqid can be determined simply by
+ * checking the min taskqid for each head item on the pending, priority,
+ * and active taskq_thread list. This value is stored in
+ * tq->tq_lowest_id and only updated to the new lowest id when the
+ * previous lowest id completes.  All taskqids lower than
+ * tq->tq_lowest_id must have completed.  It is also possible larger
+ * taskqid's have completed because they may be processed in parallel by
+ * several worker threads.  However, this is not a problem because the
+ * behavior of taskq_wait_id() is to block until all previously
+ * submitted taskqid's have completed.
  *
  * XXX: Taskqid_t wrapping is not handled.  However, taskqid_t's are
  * 64-bit values so even if a taskq is processing 2^24 (16,777,216)


### PR DESCRIPTION
As of the removal of the taskq work list made in commit:

```
commit 2c02b71b1411176905228666abf7a50a2e5f85dc
Author: Prakash Surya <surya1@llnl.gov>
Date:   Mon Dec 5 17:32:48 2011 -0800

    Replace tq_work_list and tq_threads in taskq_t

    To lay the ground work for introducing the taskq_dispatch_prealloc()
    interface, the tq_work_list and tq_threads fields had to be replaced
    with new alternatives in the taskq_t structure.
```

the comment above taskq_wait_check has been incorrect. This change is an
attempt at bringing that description more in line with the current
implementation. Essentially, references to the old task work list had to
be updated to reference the new taskq thread active list.

Signed-off-by: Prakash Surya surya1@llnl.gov
Issue #65
