### PR TITLE
Modify KM_PUSHPAGE to use GFP_NOIO instead of GFP_NOFS

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -43,7 +43,7 @@
  */
 #define KM_SLEEP	GFP_KERNEL	/* Can sleep, never fails */
 #define KM_NOSLEEP	GFP_ATOMIC	/* Can not sleep, may fail */
-#define KM_PUSHPAGE	(GFP_NOFS | __GFP_HIGH)	/* Use reserved memory */
+#define KM_PUSHPAGE	(GFP_NOIO | __GFP_HIGH)	/* Use reserved memory */
 #define KM_NODEBUG	__GFP_NOWARN	/* Suppress warnings */
 #define KM_FLAGS	__GFP_BITS_MASK
 #define KM_VMFLAGS	GFP_LEVEL_MASK


### PR DESCRIPTION
The resolution of issue #31 made KM_PUSHPAGE imply GFP_NOFS to avoid
situations where filesystem operations holding locks depending upon
additional filesystem operations that also held those locks. This works
for datasets, but unfortunately, swap on zvols encounters many of the
same deadlocks that filesystem operations encountered before this
change. As such, it is appropriate to modify KM_PUSHPAGE to use
GFP_NOIO.
