### PR TITLE
Support debug and debug-devel sub packages

### DIFF
--- a/spl-modules.spec.in
+++ b/spl-modules.spec.in
@@ -194,10 +194,10 @@
 %if %{defined el5} || %{defined el6} || %{defined ch5}
  %if %{undefined kver}
   %define klnk           %{_usrsrc}/kernels/*/include/config
-  %define kver_kern      %((echo X; %{__cat} %{klnk}/kernel.release
-                            2>/dev/null | %{__grep} -v debug) | tail -1)
-  %define kver_dbug      %((echo X; %{__cat} %{klnk}/kernel.release
-                            2>/dev/null | %{__grep} debug) | tail -1)
+  %define kver_kern      %((echo X; ((%{__cat} %{klnk}/kernel.release
+                            2>/dev/null) | %{__grep} -v debug)) | tail -1)
+  %define kver_dbug      %((echo X; ((%{__cat} %{klnk}/kernel.release
+                            2>/dev/null) | %{__grep} debug)) | tail -1)
  %else
   %define kver_kern      %{kver}
   %define kver_dbug      %{kver}.debug


### PR DESCRIPTION
This commit adds support for building debug and debug-devel sub packages
of the spl-modules main package. This is to allow building packages
which are built against a debug kernel. By default, only packages are
built against a regular non-debug kernel. This can be toggled by passing
the '--with kernel-debug' parameter to rpmbuild.

Examples:

```
# To build packages against only the non-debug kernel
$ rpmbuild --rebuild --with kernel --without kernel-debug $SRPM

# To build packages against only the debug kernel
$ rpmbuild --rebuild --without kernel --with kernel-debug $SRPM

# To build packages against debug and non-debug kernel
$ rpmbuild --rebuild --with kernel --with kernel-debug $SRPM
```

Note: Only the RHEL 5/6 and CHAOS 5 distributions are supported for
      building the debug and debug-devel packages.

Signed-off-by: Prakash Surya surya1@llnl.gov
