### PR TITLE
Linux 3.4 compat: __clear_close_on_exec replaces FD_CLR

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -44,6 +44,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_INIT_UTSNAME
 	SPL_AC_FDTABLE_HEADER
 	SPL_AC_FILES_FDTABLE
+	SPL_AC_CLEAR_CLOSE_ON_EXEC
 	SPL_AC_UACCESS_HEADER
 	SPL_AC_KMALLOC_NODE
 	SPL_AC_MONOTONIC_CLOCK
@@ -1171,6 +1172,27 @@ AC_DEFUN([SPL_AC_FILES_FDTABLE], [
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_FILES_FDTABLE, 1, [files_fdtable() is available])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
+dnl # 3.4.0 API change,
+dnl # check whether '__clear_close_on_exec()' exists
+dnl #
+AC_DEFUN([SPL_AC_CLEAR_CLOSE_ON_EXEC], [
+	AC_MSG_CHECKING([whether __clear_close_on_exec() is available])
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/fdtable.h>
+	],[
+		int fd;
+		struct fdtable fdt;
+
+		__clear_close_on_exec(fd, &fdt);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_CLEAR_CLOSE_ON_EXEC, 1, [__clear_close_on_exec() is available])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/module/splat/splat-vnode.c
+++ b/module/splat/splat-vnode.c
@@ -414,7 +414,11 @@ fd_uninstall(int fd)
                 goto out_unlock;
 
         rcu_assign_pointer(fdt->fd[fd], NULL);
+#ifdef HAVE_CLEAR_CLOSE_ON_EXEC
+	__clear_close_on_exec(fd, fdt);
+#else
         FD_CLR(fd, fdt->close_on_exec);
+#endif
 #else
         spin_lock(&files->file_lock);
         if (fd >= files->max_fds)


### PR DESCRIPTION
torvalds/linux@1dce27c5aa6770e9d195f2bb7db1db3d4dde5591 introduced
__clear_close_on_exec() as a replacement for FD_CLR. Further commits
appear to have removed FD_CLR from the Linux source tree. This causes
the following failure:

error: implicit declaration of function '__FD_CLR'
[-Werror=implicit-function-declaration]

To correct this, we introduce an autotools check for
__clear_close_on_exec() and use it whenever it is available.

Signed-off-by: Richard Yao ryao@gentoo.org
