### PR TITLE
Detect kernels that honor gfp flags passed to vmalloc()

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -87,6 +87,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_2ARGS_ZLIB_DEFLATE_WORKSPACESIZE
 	SPL_AC_SHRINK_CONTROL_STRUCT
 	SPL_AC_RWSEM_SPINLOCK_IS_RAW
+	SPL_AC_PMD_ALLOC_WITH_MASK
 ])
 
 AC_DEFUN([SPL_AC_MODULE_SYMVERS], [
@@ -2055,4 +2056,30 @@ AC_DEFUN([SPL_AC_RWSEM_SPINLOCK_IS_RAW], [
 		AC_MSG_RESULT(no)
 	])
 	EXTRA_KCFLAGS="$tmp_flags"
+])
+
+dnl #
+dnl # Proposed VM Subsystem Bug Fix
+dnl # Make __pte_alloc_kernel() honor gfp flags passed to vmalloc()
+dnl # This is detected by checking a macro that is changed to support this.
+dnl #
+AC_DEFUN([SPL_AC_PMD_ALLOC_WITH_MASK],
+	[AC_MSG_CHECKING([whether pmd_alloc_with_mask exists])
+	SPL_LINUX_TRY_COMPILE([
+		#define CONFIG_MMU
+		#undef RCH_HAS_4LEVEL_HACK
+		#include <linux/mm.h>
+	],[
+		struct mm_struct init_mm;
+		pud_t pud;
+		unsigned long addr;
+		gfp_t gfp_mask;
+		pmd_alloc_with_mask(&init_mm, &pud, addr, gfp_mask);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_PMD_ALLOC_WITH_MASK, 1,
+		          [pmd_alloc_with_mask exists])
+	],[
+		AC_MSG_RESULT(no)
+	])
 ])

--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -843,6 +843,9 @@ kv_alloc(spl_kmem_cache_t *skc, int size, int flags)
 	if (skc->skc_flags & KMC_KMEM) {
 		ptr = (void *)__get_free_pages(flags, get_order(size));
 	} else {
+#ifdef HAVE_PMD_ALLOC_WITH_MASK
+		ptr = __vmalloc(size, flags|__GFP_HIGHMEM, PAGE_KERNEL);
+#else
 		/*
 		 * As part of vmalloc() an __pte_alloc_kernel() allocation
 		 * may occur.  This internal allocation does not honor the
@@ -866,6 +869,7 @@ kv_alloc(spl_kmem_cache_t *skc, int size, int flags)
 		} else {
 			ptr = __vmalloc(size, flags|__GFP_HIGHMEM, PAGE_KERNEL);
 		}
+#endif
 	}
 
 	/* Resulting allocated memory will be page aligned */


### PR DESCRIPTION
zfsonlinux/spl@2092cf68d89a51eb0d6193aeadabb579dfc4b4a0 used PF_MEMALLOC
to workaround a bug in the Linux kernel where allocations did not honor
the gfp flags passed to vmalloc(). Unfortunately, PF_MEMALLOC has the
side effect of permitting allocations to allocate pages outside of
ZONE_NORMAL. This has been observed to result in the depletion of
ZONE_DMA32 on Gentoo Linux. A kernel patch is available in the Gentoo
bug tracker for this issue:

https://bugs.gentoo.org/show_bug.cgi?id=416685

This negates any benefit PF_MEMALLOC provides, so we introduce an
autotools check to disable the use of PF_MEMALLOC on systems with
patched kernels.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
