### PR TITLE
Constify memory management functions

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -214,9 +214,9 @@ extern unsigned long long vmem_alloc_max;
 #  define vmem_free(ptr, sz)            vmem_free_track((ptr), (sz))
 
 extern void *kmem_alloc_track(size_t, int, const char *, int, int, int);
-extern void kmem_free_track(void *, size_t);
+extern void kmem_free_track(const void *, size_t);
 extern void *vmem_alloc_track(size_t, int, const char *, int);
-extern void vmem_free_track(void *, size_t);
+extern void vmem_free_track(const void *, size_t);
 
 # else /* DEBUG_KMEM_TRACKING */
 /*
@@ -243,9 +243,9 @@ extern void vmem_free_track(void *, size_t);
 #  define vmem_free(ptr, sz)            vmem_free_debug((ptr), (sz))
 
 extern void *kmem_alloc_debug(size_t, int, const char *, int, int, int);
-extern void kmem_free_debug(void *, size_t);
+extern void kmem_free_debug(const void *, size_t);
 extern void *vmem_alloc_debug(size_t, int, const char *, int);
-extern void vmem_free_debug(void *, size_t);
+extern void vmem_free_debug(const void *, size_t);
 
 # endif /* DEBUG_KMEM_TRACKING */
 #else /* DEBUG_KMEM */

--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -385,7 +385,7 @@ EXPORT_SYMBOL(vmem_table);
 EXPORT_SYMBOL(vmem_list);
 
 static kmem_debug_t *
-kmem_del_init(spinlock_t *lock, struct hlist_head *table, int bits, void *addr)
+kmem_del_init(spinlock_t *lock, struct hlist_head *table, int bits, const void *addr)
 {
 	struct hlist_head *head;
 	struct hlist_node *node;
@@ -504,7 +504,7 @@ out:
 EXPORT_SYMBOL(kmem_alloc_track);
 
 void
-kmem_free_track(void *ptr, size_t size)
+kmem_free_track(const void *ptr, size_t size)
 {
 	kmem_debug_t *dptr;
 	SENTRY;
@@ -619,7 +619,7 @@ out:
 EXPORT_SYMBOL(vmem_alloc_track);
 
 void
-vmem_free_track(void *ptr, size_t size)
+vmem_free_track(const void *ptr, size_t size)
 {
 	kmem_debug_t *dptr;
 	SENTRY;
@@ -706,7 +706,7 @@ kmem_alloc_debug(size_t size, int flags, const char *func, int line,
 EXPORT_SYMBOL(kmem_alloc_debug);
 
 void
-kmem_free_debug(void *ptr, size_t size)
+kmem_free_debug(const void *ptr, size_t size)
 {
 	SENTRY;
 
@@ -758,7 +758,7 @@ vmem_alloc_debug(size_t size, int flags, const char *func, int line)
 EXPORT_SYMBOL(vmem_alloc_debug);
 
 void
-vmem_free_debug(void *ptr, size_t size)
+vmem_free_debug(const void *ptr, size_t size)
 {
 	SENTRY;
 


### PR DESCRIPTION
This prevents warnings in ZFS that were caused by changes necessary to
support PaX patched kernels. When debugging is enabled, these warnings
become build failures.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
