### PR TITLE
Add 'Provides:' attributes for '-debug' packages

### DIFF
--- a/spl-modules.spec.in
+++ b/spl-modules.spec.in
@@ -367,6 +367,7 @@ symbols needed for building additional modules which use %{name}.
 %package debug
 Summary:         Solaris Porting Layer Debug Modules
 Group:           Utilities/System
+Provides:        %{name}
 Release:         %{rel_dbug}
 %if %{defined req_dbug}
 Requires:        %{req_dbug}
@@ -384,6 +385,7 @@ rwlock, taskq, thread, time, and vnode APIs.
 %package debug-devel
 Summary:         Solaris Porting Layer Debug Headers and Symbols
 Group:           Development/Libraries
+Provides:        %{name}-devel
 Release:         %{rel_dbug}
 %if %{defined devreq_dbug}
 Requires:        %{devreq_dbug}


### PR DESCRIPTION
The generated '-debug' packages do not set their "Provides" attribute,
causing failed dependencies for packages which depend on "spl-modules"
or "spl-modules-devel". For example, with only the spl-modules-debug
package installed, installing the spl package will fail its dependency
check because it needs "spl-modules".

This patch fixes the problem by allowing the spl-modules-debug and
spl-modules-debug-devel packages to "Provide" spl-modules and
spl-modules-devel respectively.

Signed-off-by: Prakash Surya surya1@llnl.gov
