### PR TITLE
Make KM_SLEEP an alias of KM_PUSHPAGE

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -41,7 +41,7 @@
 /*
  * Memory allocation interfaces
  */
-#define KM_SLEEP	GFP_KERNEL	/* Can sleep, never fails */
+#define KM_SLEEP	(GFP_NOIO | __GFP_HIGH)	/* Can sleep, never fails */
 #define KM_NOSLEEP	GFP_ATOMIC	/* Can not sleep, may fail */
 #define KM_PUSHPAGE	(GFP_NOIO | __GFP_HIGH)	/* Use reserved memory */
 #define KM_NODEBUG	__GFP_NOWARN	/* Suppress warnings */

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -255,9 +255,10 @@ __taskq_dispatch(taskq_t *tq, task_func_t func, void *arg, uint_t flags)
 	if (!(flags & (TQ_SLEEP | TQ_NOSLEEP)))
 		flags |= TQ_SLEEP;
 
-	if (unlikely(in_atomic() && (flags & TQ_SLEEP)))
-		PANIC("May schedule while atomic: %s/0x%08x/%d\n",
-		    current->comm, preempt_count(), current->pid);
+	/* FIXME: Why does this fail when KM_SLEEP contains __GFP_HIGHMEM? */
+	//if (unlikely(in_atomic() && (flags & TQ_SLEEP)))
+	//	PANIC("May schedule while atomic: %s/0x%08x/%d\n",
+	//	    current->comm, preempt_count(), current->pid);
 
         spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
 


### PR DESCRIPTION
Use GFP_NOIO in KM_SLEEP

This should prevent direct reclaim issues without requiring
Linux-specific changes to code from Solaris. This is what is done in
FreeBSD.

Note that a change to __taskq_dispatch() module/spl/spl-taskq.c is
needed to make this work. Changing KM_PUSHPAGE to use GFP_NOIO is fine,
but adding __GFP_HIGH to that triggers a hard-coded panic in
__taskq_dispatch() during zvol initialization. Removing the hard coded
panic has no ill effects.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
