### PR TITLE
Use Linux SLAB allocator for SPL SLAB allocations

### DIFF
--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -841,6 +841,8 @@ EXPORT_SYMBOL(vmem_free_debug);
 struct list_head spl_kmem_cache_list;   /* List of caches */
 struct rw_semaphore spl_kmem_cache_sem; /* Cache list lock */
 
+#ifdef SPL_OWN_SLAB
+
 static int spl_cache_flush(spl_kmem_cache_t *skc,
                            spl_kmem_magazine_t *skm, int flush);
 
@@ -1995,6 +1997,215 @@ spl_kmem_reap(void)
 }
 EXPORT_SYMBOL(spl_kmem_reap);
 
+#else /* SPL_OWN_SLAB */
+
+/*
+ * Create a object cache based on the following arguments:
+ * name		cache name
+ * size		cache object size
+ * align	cache object alignment
+ * ctor		cache object constructor
+ * dtor		cache object destructor
+ * reclaim	cache object reclaim (unused)
+ * priv		cache private data for ctor/dtor/reclaim
+ * vmp		unused must be NULL
+ * flags
+ *	KMC_NOTOUCH	Disable cache object aging (unsupported)
+ *	KMC_NODEBUG	Disable debugging (unsupported)
+ *	KMC_NOMAGAZINE	Disable magazine (unsupported)
+ *	KMC_NOHASH      Disable hashing (unsupported)
+ *	KMC_QCACHE	Disable qcache (unsupported)
+ *	KMC_KMEM	Force kmem backed cache
+ *	KMC_VMEM        Force vmem backed cache (unsupported)
+ *	KMC_OFFSLAB	Locate objects off the slab
+ */
+spl_kmem_cache_t *
+spl_kmem_cache_create(char *name, size_t size, size_t align,
+                      spl_kmem_ctor_t ctor,
+                      spl_kmem_dtor_t dtor,
+                      spl_kmem_reclaim_t reclaim,
+                      void *priv, void *vmp, int flags)
+{
+        spl_kmem_cache_t *skc;
+	int kmem_flags = KM_SLEEP;
+	SENTRY;
+
+        /* We may be called when there is a non-zero preempt_count or
+         * interrupts are disabled is which case we must not sleep.
+	 */
+	if (current_thread_info()->preempt_count || irqs_disabled())
+		kmem_flags = KM_NOSLEEP;
+
+	/* Allocate memory for a new cache wrapper and initialize it. */
+	skc = (spl_kmem_cache_t *)kmem_cache_alloc(spl_slab_cache, kmem_flags);
+
+	if (align) {
+		VERIFY(ISP2(align));
+		VERIFY3U(align, >=, SPL_KMEM_CACHE_ALIGN); /* Min alignment */
+		VERIFY3U(align, <=, PAGE_SIZE);            /* Max alignment */
+	}
+	else
+	{
+		align = SPL_KMEM_CACHE_ALIGN;
+	}
+
+	skc->skc_cache = kmem_cache_create(name,
+		size,
+		align,
+		0,
+		NULL);
+	if (!skc->skc_cache) {
+		SRETURN(NULL);
+	}
+
+	skc->skc_magic = SKC_MAGIC;
+	skc->skc_ctor = ctor;
+	skc->skc_dtor = dtor;
+	skc->skc_private = priv;
+	skc->skc_flags = flags;
+	skc->skc_obj_size = size;
+	atomic_set(&skc->skc_ref, 0);
+
+	INIT_LIST_HEAD(&skc->skc_list);
+	spin_lock_init(&skc->skc_lock);
+
+	down_write(&spl_kmem_cache_sem);
+	list_add_tail(&skc->skc_list, &spl_kmem_cache_list);
+	up_write(&spl_kmem_cache_sem);
+
+	SRETURN(skc);
+
+}
+EXPORT_SYMBOL(spl_kmem_cache_create);
+
+/*
+ * Register a move callback to for cache defragmentation.
+ * XXX: Linux has no such function, but we can use a stub to make ZFS happy.
+ */
+void
+spl_kmem_cache_set_move(spl_kmem_cache_t *skc,
+    kmem_cbrc_t (move)(void *, void *, size_t, void *))
+{
+        ASSERT(move != NULL);
+}
+EXPORT_SYMBOL(spl_kmem_cache_set_move);
+
+/*
+ * Destroy a cache and all objects associated with the cache.
+ */
+void
+spl_kmem_cache_destroy(spl_kmem_cache_t *skc)
+{
+	DECLARE_WAIT_QUEUE_HEAD(wq);
+	SENTRY;
+
+	ASSERT(skc->skc_magic == SKC_MAGIC);
+
+	down_write(&spl_kmem_cache_sem);
+	list_del_init(&skc->skc_list);
+	up_write(&spl_kmem_cache_sem);
+
+	/* Wait until all current callers complete, this is mainly
+	 * to catch the case where a low memory situation triggers a
+	 * cache reaping action which races with this destroy. */
+	wait_event(wq, atomic_read(&skc->skc_ref) == 0);
+
+	spin_lock(&skc->skc_lock);
+
+	/* Validate there are no objects in use and free all the
+	 * spl_kmem_slab_t, spl_kmem_obj_t, and object buffers. */
+	ASSERT3U(skc->skc_obj_alloc, ==, 0);
+
+	kmem_cache_destroy(skc->skc_cache);
+
+	spin_unlock(&skc->skc_lock);
+
+	kmem_cache_free(spl_slab_cache, skc);
+
+	SEXIT;
+}
+EXPORT_SYMBOL(spl_kmem_cache_destroy);
+
+void *
+spl_kmem_cache_alloc(spl_kmem_cache_t *skc, int flags)
+{
+	void *obj = NULL;
+	SENTRY;
+
+	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT(!test_bit(KMC_BIT_DESTROY, &skc->skc_flags));
+	ASSERT(flags & KM_SLEEP);
+	atomic_inc(&skc->skc_ref);
+
+	obj = kmem_cache_alloc(skc->skc_cache, flags);
+
+	if (NULL != obj)
+	{
+		if (skc->skc_ctor)
+			skc->skc_ctor(obj, skc->skc_private, flags);
+
+		spin_lock(&skc->skc_lock);
+		skc->skc_obj_alloc++;
+		spin_unlock(&skc->skc_lock);
+
+	}
+
+	atomic_dec(&skc->skc_ref);
+	SRETURN(obj);
+}
+EXPORT_SYMBOL(spl_kmem_cache_alloc);
+
+/*
+ * Free an object back to the local per-cpu magazine, there is no
+ * guarantee that this is the same magazine the object was originally
+ * allocated from.  We may need to flush entire from the magazine
+ * back to the slabs to make space.
+ */
+void
+spl_kmem_cache_free(spl_kmem_cache_t *skc, void *obj)
+{
+	SENTRY;
+
+	ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT(!test_bit(KMC_BIT_DESTROY, &skc->skc_flags));
+	atomic_inc(&skc->skc_ref);
+
+	if (skc->skc_dtor)
+		skc->skc_dtor(obj, skc->skc_private);
+
+	kmem_cache_free(skc->skc_cache, obj);
+
+	atomic_dec(&skc->skc_ref);
+	SEXIT;
+}
+EXPORT_SYMBOL(spl_kmem_cache_free);
+
+/*
+ * Dummy function to enable us to use the Linux SLAB, which lacks an analogous
+ * function.
+ */
+void
+spl_kmem_cache_reap_now(spl_kmem_cache_t *skc, int count)
+{
+	SENTRY;
+	ASSERT(skc->skc_magic == SKC_MAGIC);
+	SEXIT;
+}
+EXPORT_SYMBOL(spl_kmem_cache_reap_now);
+
+/*
+ * Dummy function to enable us to use the Linux SLAB, which lacks an analogous
+ * function.
+ */
+void
+spl_kmem_reap(void)
+{
+	return;
+}
+EXPORT_SYMBOL(spl_kmem_reap);
+
+#endif /* SPL_OWN_SLAB */
+
 #if defined(DEBUG_KMEM) && defined(DEBUG_KMEM_TRACKING)
 static char *
 spl_sprintf_addr(kmem_debug_t *kd, char *str, int len, int min)
@@ -2210,7 +2421,9 @@ spl_kmem_init(void)
 		SLAB_HWCACHE_ALIGN,
 		NULL);
 
+#ifdef SPL_OWN_SLAB
 	spl_register_shrinker(&spl_kmem_cache_shrinker);
+#endif /* SPL_OWN_SLAB */
 
 #ifdef DEBUG_KMEM
 	kmem_alloc_used_set(0);
@@ -2246,7 +2459,9 @@ spl_kmem_fini(void)
 #endif /* DEBUG_KMEM */
 	SENTRY;
 
+#ifdef SPL_OWN_SLAB
 	spl_unregister_shrinker(&spl_kmem_cache_shrinker);
+#endif /* SPL_OWN_SLAB */
 
 	kmem_cache_destroy(spl_slab_cache);
 

--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -49,7 +49,9 @@ static struct ctl_table_header *spl_header = NULL;
 static struct proc_dir_entry *proc_spl = NULL;
 #ifdef DEBUG_KMEM
 static struct proc_dir_entry *proc_spl_kmem = NULL;
+#ifdef SPL_OWN_SLAB
 static struct proc_dir_entry *proc_spl_kmem_slab = NULL;
+#endif /* SPL_OWN_SLAB */
 #endif /* DEBUG_KMEM */
 struct proc_dir_entry *proc_spl_kstat = NULL;
 
@@ -440,6 +442,7 @@ SPL_PROC_HANDLER(proc_domemused)
         SRETURN(rc);
 }
 
+#ifdef SPL_OWN_SLAB
 SPL_PROC_HANDLER(proc_doslab)
 {
         int rc = 0;
@@ -486,6 +489,7 @@ SPL_PROC_HANDLER(proc_doslab)
 
         SRETURN(rc);
 }
+#endif /* SPL_OWN_SLAB */
 #endif /* DEBUG_KMEM */
 
 SPL_PROC_HANDLER(proc_dohostid)
@@ -617,6 +621,7 @@ SPL_PROC_HANDLER(proc_dofreemem)
         SRETURN(rc);
 }
 
+#ifdef SPL_OWN_SLAB
 #ifdef DEBUG_KMEM
 static void
 slab_seq_show_headers(struct seq_file *f)
@@ -719,6 +724,7 @@ static struct file_operations proc_slab_operations = {
         .release        = seq_release,
 };
 #endif /* DEBUG_KMEM */
+#endif /* SPL_OWN_SLAB */
 
 #ifdef DEBUG_LOG
 static struct ctl_table spl_debug_table[] = {
@@ -956,6 +962,7 @@ static struct ctl_table spl_kmem_table[] = {
                 .mode     = 0444,
                 .proc_handler = &proc_doulongvec_minmax,
         },
+#ifdef SPL_OWN_SLAB
         {
                 CTL_NAME    (CTL_KMEM_SLAB_KMEMTOTAL)
                 .procname = "slab_kmem_total",
@@ -1016,6 +1023,7 @@ static struct ctl_table spl_kmem_table[] = {
                 .mode     = 0444,
                 .proc_handler = &proc_doslab,
         },
+#endif /* SPL_OWN_SLAB */
 	{0},
 };
 #endif /* DEBUG_KMEM */
@@ -1162,6 +1170,7 @@ spl_proc_init(void)
 	if (proc_spl == NULL)
 		SGOTO(out, rc = -EUNATCH);
 
+#ifdef SPL_OWN_SLAB
 #ifdef DEBUG_KMEM
         proc_spl_kmem = proc_mkdir("kmem", proc_spl);
         if (proc_spl_kmem == NULL)
@@ -1173,6 +1182,7 @@ spl_proc_init(void)
 
         proc_spl_kmem_slab->proc_fops = &proc_slab_operations;
 #endif /* DEBUG_KMEM */
+#endif /* SPL_OWN_SLAB */
 
         proc_spl_kstat = proc_mkdir("kstat", proc_spl);
         if (proc_spl_kstat == NULL)

--- a/module/splat/splat-kmem.c
+++ b/module/splat/splat-kmem.c
@@ -29,6 +29,7 @@
 #define SPLAT_KMEM_NAME			"kmem"
 #define SPLAT_KMEM_DESC			"Kernel Malloc/Slab Tests"
 
+#ifdef SPL_OWN_SLAB
 #define SPLAT_KMEM_TEST1_ID		0x0101
 #define SPLAT_KMEM_TEST1_NAME		"kmem_alloc"
 #define SPLAT_KMEM_TEST1_DESC		"Memory allocation test (kmem_alloc)"
@@ -1237,6 +1238,7 @@ splat_kmem_test13(struct file *file, void *arg)
 
 	return rc;
 }
+#endif /* SPL_OWN_SLAB */
 
 splat_subsystem_t *
 splat_kmem_init(void)
@@ -1255,6 +1257,7 @@ splat_kmem_init(void)
 	spin_lock_init(&sub->test_lock);
 	sub->desc.id = SPLAT_SUBSYSTEM_KMEM;
 
+#ifdef SPL_OWN_SLAB
 	SPLAT_TEST_INIT(sub, SPLAT_KMEM_TEST1_NAME, SPLAT_KMEM_TEST1_DESC,
 			SPLAT_KMEM_TEST1_ID, splat_kmem_test1);
 	SPLAT_TEST_INIT(sub, SPLAT_KMEM_TEST2_NAME, SPLAT_KMEM_TEST2_DESC,
@@ -1283,6 +1286,7 @@ splat_kmem_init(void)
 			SPLAT_KMEM_TEST12_ID, splat_kmem_test12);
 	SPLAT_TEST_INIT(sub, SPLAT_KMEM_TEST13_NAME, SPLAT_KMEM_TEST13_DESC,
 			SPLAT_KMEM_TEST13_ID, splat_kmem_test13);
+#endif /* SPL_OWN_SLAB */
 
 	return sub;
 }
@@ -1291,6 +1295,7 @@ void
 splat_kmem_fini(splat_subsystem_t *sub)
 {
 	ASSERT(sub);
+#ifdef SPL_OWN_SLAB
 	SPLAT_TEST_FINI(sub, SPLAT_KMEM_TEST13_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_KMEM_TEST12_ID);
 #ifdef _LP64
@@ -1306,6 +1311,7 @@ splat_kmem_fini(splat_subsystem_t *sub)
 	SPLAT_TEST_FINI(sub, SPLAT_KMEM_TEST3_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_KMEM_TEST2_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_KMEM_TEST1_ID);
+#endif /* SPL_OWN_SLAB */
 
 	kfree(sub);
 }


### PR DESCRIPTION
The SPL SLAB code relied on __vmalloc() for its allocations. The Linux kernel ignores flags passed to __vmalloc(), which required a kernel patch to avoid deadlock. We replace this allocation with allocations from the Linux SLAB to avoid this.

The maximum allocation size of __vmalloc() far exceeded the maximum slab size of the Linux kernel. The kernel is not prepared to satisfy allocations of such size under low memory conditions, which can also caused deadlocks. We change the maximum SLAB size to the maximum supported by Linux to avoid that.

Allocations of spl_kmem_slab_t structures were particularly large, which required suppressing a warning. It could potentially cause failures under the right conditions when loading the module. We replace these allocations with allocations from the SLAB allocator, which should eliminate such problems. It also enables us to do allocations in a way that minimizes the potential for false sharing, which should improve the performance of the SPL SLAB code.

These changes make the SPL SLAB implementation a wrapper for the Linux SLAB allocator. The Linux SLAB objects are the SPL slabs from which SPL SLAB objects are created. This is the partial rewrite I promised in zfsonlinux/spl#145.
