### PR TITLE
Handle any invalidate_inodes_check prototype

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -2072,9 +2072,10 @@ AC_DEFUN([SPL_AC_KERNEL_INVALIDATE_INODES], [
 	AC_MSG_CHECKING([whether invalidate_inodes_check() is available])
 	SPL_LINUX_TRY_COMPILE_SYMBOL([
 		#include <linux/fs.h>
-	], [
-		invalidate_inodes_check(NULL, 0);
-	], [invalidate_inodes_check], [], [
+		#ifndef invalidate_inodes
+		#error invalidate_inodes is not a macro
+		#endif
+	], [ ], [invalidate_inodes_check], [], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_INVALIDATE_INODES_CHECK, 1,
 		          [invalidate_inodes_check() is available])


### PR DESCRIPTION
In the comments of commit 723aa3b0c2eed070f7eeadd2ce2d87f46da6d0f8, @mmatuska reported that the test for `invalidate_inodes_check()` is broken if `invalidate_inodes()` takes two arguments.

This patch fixes the issue by resorting to another approach for detecting `invalidate_inodes_check()`: is simply checks if `invalidate_inodes` is defined as a macro. If it is, then it concludes that `invalidate_inodes_check()` is available. This will continue to work even if the prototype of `invalidate_inodes_check()` changes over time.

Fixes #148.
