### PR TITLE
Support building a spl-modules-dkms sub package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ SUBDIRS = $(USER_DIR) $(KERNEL_DIR)
 AUTOMAKE_OPTIONS = foreign
 EXTRA_DIST  = autogen.sh spl.spec.in spl-modules.spec.in META DISCLAIMER
 EXTRA_DIST += config/config.awk config/rpm.am config/deb.am config/tgz.am
+EXTRA_DIST += dkms.postinst
 noinst_HEADERS = spl_config.h spl.release
 
 distclean-local::

--- a/config/rpm.am
+++ b/config/rpm.am
@@ -18,6 +18,11 @@ endif
 
 srpm: srpm-modules srpm-utils
 
+rpm-dkms: srpm-modules
+if CONFIG_KERNEL
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-modules" dkms-common
+endif
+
 rpm-modules: srpm-modules
 if CONFIG_KERNEL
 	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-modules" rpm-common
@@ -28,7 +33,7 @@ if CONFIG_USER
 	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}" rpm-common
 endif
 
-rpm: rpm-modules rpm-utils
+rpm: rpm-modules rpm-utils rpm-dkms
 
 rpm-local:
 	@(if test "${HAVE_RPMBUILD}" = "no"; then \
@@ -46,6 +51,26 @@ rpm-local:
 	cp $(rpmspec) $(rpmbuild)/SPECS && \
 	mkdir -p $(rpmbuild)/SOURCES && \
 	cp $(distdir).tar.gz $(rpmbuild)/SOURCES)
+
+dkms-common:
+	rpmpkg=$(pkg)-$(SPL_META_VERSION)-$(SPL_META_RELEASE).src.rpm; \
+	rpmspec=$(pkg).spec; \
+	rpmdkms=$(pkg)-dkms-$(SPL_META_VERSION)-$(SPL_META_RELEASE).noarch.rpm;\
+	rpmbuild=`mktemp -t -d $(PACKAGE)-build-$$USER-XXXXXXXX`; \
+	$(MAKE) $(AM_MAKEFLAGS) \
+		rpmbuild="$$rpmbuild" \
+		rpmspec="$$rpmspec" \
+		rpm-local || exit 1; \
+	$(RPMBUILD) \
+		--define "_tmppath $$rpmbuild/TMP" \
+		--define "_topdir $$rpmbuild" \
+		--define "dist %{nil}" \
+		--define "_without_kernel 1" \
+		--define "_without_kernel_debug 1" \
+		--define "_with_kernel_dkms 1" \
+		--nodeps --rebuild $$rpmpkg || exit 1; \
+	cp $$rpmbuild/RPMS/noarch/$$rpmdkms . || exit 1; \
+	$(RM) -R $$rpmbuild
 
 srpm-common: dist
 	rpmpkg=$(pkg)-$(SPL_META_VERSION)-$(SPL_META_RELEASE).src.rpm; \

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,7 @@ AC_CONFIG_FILES([
 	PKGBUILD-spl
 	PKGBUILD-spl-modules
 	spl.release
+	dkms.conf
 ])
 
 AC_OUTPUT

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -1,0 +1,23 @@
+AUTOINSTALL="yes"
+PACKAGE_NAME="@PACKAGE@"
+PACKAGE_VERSION="@VERSION@"
+PRE_BUILD="configure
+  --prefix=/usr
+  --with-config=kernel
+  --with-linux=$(case `lsb_release -is` in
+                   (Debian) echo ${kernel_source_dir/%build/source} ;;
+                   (*)      echo ${kernel_source_dir} ;;
+                 esac)
+  --with-linux-obj=${kernel_source_dir}
+"
+POST_INSTALL="dkms.postinst -a ${arch} -k ${kernelver} -t ${dkms_tree}
+                            -n ${PACKAGE_NAME} -v ${PACKAGE_VERSION}
+"
+REMAKE_INITRD="no"
+MAKE[0]="make"
+BUILT_MODULE_NAME[0]="spl"
+BUILT_MODULE_LOCATION[0]="module/spl/"
+DEST_MODULE_LOCATION[0]="/extra/spl/spl"
+BUILT_MODULE_NAME[1]="splat"
+BUILT_MODULE_LOCATION[1]="module/splat/"
+DEST_MODULE_LOCATION[1]="/extra/splat/splat"

--- a/dkms.postinst
+++ b/dkms.postinst
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+PROG=$0
+
+while getopts "a:k:n:t:v:" opt; do
+	case $opt in
+		a) arch=$OPTARG    ;;
+		k) kver=$OPTARG    ;;
+		n) pkgname=$OPTARG ;;
+		t) tree=$OPTARG    ;;
+		v) pkgver=$OPTARG  ;;
+	esac
+done
+
+if [ -z "${arch}" -o -z "${kver}" -o -z "${pkgname}" -o \
+     -z "${tree}" -o -z "${pkgver}" ]; then
+	echo "Usage: $PROG -a <arch> -k <kver> -n <pkgname>" \
+	     "-t <tree> -v <pkgver>"
+	exit 1
+fi
+
+cp ${tree}/${pkgname}/${pkgver}/build/spl_config.h          \
+   ${tree}/${pkgname}/${pkgver}/build/module/Module.symvers \
+   ${tree}/${pkgname}/${pkgver}/${kver}/${arch}/

--- a/spl-modules.spec.in
+++ b/spl-modules.spec.in
@@ -44,6 +44,17 @@
  %endif
 %endif
 
+# Set using 'rpmbuild ... --with kernel-dkms ...', defaults to disabled.
+%if %{defined _with_kernel_dkms}
+ %define with_kernel_dkms 1
+%else
+ %if %{defined _without_kernel_dkms}
+  %define with_kernel_dkms 0
+ %else
+  %define with_kernel_dkms 0
+ %endif
+%endif
+
 # Set using 'rpmbuild ... --with debug ...', defaults to disabled.
 %if %{defined _with_debug}
  %define kdebug --enable-debug
@@ -118,12 +129,15 @@
 
  %define kpkg_kern       kernel-%{kverextra}
  %define kpkg_dbug       %{nil}
+ %define kpkg_dkms       %{nil}
 
  %define kdevpkg_kern    kernel-source
  %define kdevpkg_dbug    %{nil}
+ %define kdevpkg_dkms    %{nil}
 
  %define kverpkg_kern    %(echo %{kver_kern} | %{__sed} -e 's/-%{kverextra}//g')
  %define kverpkg_dbug    %{nil}
+ %define kverpkg_dkms    %{nil}
 
  # The kernel and rpm versions do not strictly match under SLES11
  # e.g. kernel version 2.6.27.19-5 != rpm version 2.6.27.19-5.1
@@ -165,10 +179,13 @@
 
  %define kpkg_kern       kernel
  %define kpkg_dbug       kernel-debug
+ %define kpkg_dkms       dkms
 
  %define kdevpkg_kern    kernel-devel
  %define kdevpkg_dbug    kernel-debug-devel
+ %define kdevpkg_dkms    dkms
 
+ %define kverpkg_dkms    2.2.0.2
  %if %{defined el6} || %{defined ch5}
   %define kverpkg_kern   %(echo %{kver_kern} | %{__sed} -e 's/.%{_target_cpu}//g')
   %define kverpkg_dbug   %(echo %{kver_dbug} | %{__sed} -e 's/.%{_target_cpu}//g' | %{__sed} -e 's/.debug//g')
@@ -216,10 +233,13 @@
 
  %define kpkg_kern       kernel
  %define kpkg_dbug       kernel-debug
+ %define kpkg_dkms       dkms
 
  %define kdevpkg_kern    kernel-devel
  %define kdevpkg_dbug    kernel-debug-devel
+ %define kdevpkg_dkms    dkms
 
+ %define kverpkg_dkms    2.2.0.2
  %define kverpkg_kern    %(echo %{kver_kern} | %{__sed} -e 's/.%{_target_cpu}//g')
  %define kverpkg_dbug    %(echo %{kver_dbug} | %{__sed} -e 's/.%{_target_cpu}//g' | %{__sed} -e 's/.debug//g')
 
@@ -253,6 +273,7 @@
 
  %define kverpkg_kern    %{kver_kern}
  %define kverpkg_dbug    %{nil}
+ %define kverpkg_dkms    %{nil}
 
  %if %{undefined kdir}
   %define kdir_kern      /lib/modules/%{kver_kern}/build
@@ -285,11 +306,15 @@
 %if %{defined build_src_rpm}
 %define rel_kern         @SPL_META_RELEASE@
 %define rel_dbug         @SPL_META_RELEASE@
+%define rel_dkms         @SPL_META_RELEASE@
 %if %{defined kpkg_kern}
 %define req_kern         %{kpkg_kern}
 %endif
 %if %{defined kpkg_dbug}
 %define req_dbug         %{kpkg_dbug}
+%endif
+%if %{defined kpkg_dkms}
+%define req_dkms         %{kpkg_dkms}
 %endif
 %if %{defined kdevpkg_kern}
 %define devreq_kern      %{kdevpkg_kern}
@@ -302,11 +327,15 @@
 %define relext_dbug      %(echo %{kverpkg_dbug} | %{__sed} -e 's/-/_/g')
 %define rel_kern         @SPL_META_RELEASE@_%{relext_kern}
 %define rel_dbug         @SPL_META_RELEASE@_%{relext_dbug}
+%define rel_dkms         @SPL_META_RELEASE@
 %if %{defined kpkg_kern}
 %define req_kern         %{kpkg_kern} %{koppkg} %{kverpkg_kern}
 %endif
 %if %{defined kpkg_dbug}
 %define req_dbug         %{kpkg_dbug} %{koppkg} %{kverpkg_dbug}
+%endif
+%if %{defined kpkg_dkms}
+%define req_dkms         %{kpkg_dkms} >= %{kverpkg_dkms}
 %endif
 %if %{defined kdevpkg_kern}
 %define devreq_kern      %{kdevpkg_kern} %{koppkg} %{kverpkg_kern}
@@ -398,6 +427,30 @@ Module{s}.symvers symbols needed for building additional modules which
 use %{name}-debug.
 
 %endif
+%if %{?with_kernel_dkms}
+
+%package dkms
+Summary:         Solaris Porting Layer Modules (DKMS)
+Group:           Utilities/System
+Release:         %{rel_dkms}
+Provides:        %{name}
+BuildArch:       noarch
+%if %{defined req_dkms}
+Requires:        %{req_dkms}
+%endif
+%if %{defined kdevpkg_dkms}
+BuildRequires:   %{kdevpkg_dkms}
+%endif
+
+%description dkms
+The %{name}-dkms package contains all the necessary pieces to build and
+install Solaris Porting Layer (SPL) kernel modules with Dynamic Kernel
+Modules Support (DKMS). The SPL modules emulate Solaris style primatives
+in the the linux kernel. They include, but are not limited to: atomic,
+condvar, debug, error, memory, kobject, kstat, mutex, rwlock, taskq,
+thread, time, and vnode APIs.
+
+%endif
 
 %prep
 %setup -n @PACKAGE@-%{version}
@@ -420,6 +473,16 @@ make DESTDIR=$RPM_BUILD_ROOT install
            %{kdebug} %{kdebug_log} %{kdebug_kmem} %{kdebug_kmem_tracking}
 make
 make DESTDIR=$RPM_BUILD_ROOT install
+
+%endif
+%if %{?with_kernel_dkms}
+
+%configure --with-config=kernel \
+           %{kdebug} %{kdebug_log} %{kdebug_kmem} %{kdebug_kmem_tracking}
+make dist
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}/src
+tar -xf @PACKAGE@-%{version}.tar.gz -C $RPM_BUILD_ROOT/%{_prefix}/src
+cp -af dkms.conf $RPM_BUILD_ROOT/%{_prefix}/src/@PACKAGE@-%{version}
 
 %endif
 
@@ -474,5 +537,32 @@ if [ -f /boot/System.map-%{kver_dbug} ]; then
 else
 	/sbin/depmod -a || exit 0
 fi
+
+%endif
+%if %{?with_kernel_dkms}
+
+%files dkms
+%defattr(-,root,root)
+%{_prefix}/src/@PACKAGE@-%{version}/*
+
+%post dkms
+for POSTINST in %{_prefix}/lib/dkms/common.postinst; do
+	if [ -f $POSTINST ]; then
+		$POSTINST @PACKAGE@ %{version}
+		exit $?
+	fi
+	echo "WARNING: $POSTINST does not exist."
+done
+echo -e "ERROR: DKMS version is too old and @PACKAGE@ was not"
+echo -e "built with legacy DKMS support."
+echo -e "You must either rebuild @PACKAGE@ with legacy postinst"
+echo -e "support or upgrade DKMS to a more current version."
+exit 1
+
+%preun dkms
+echo -e
+echo -e "Uninstall of @PACKAGE@ module (version %{version}) beginning:"
+dkms remove -m @PACKAGE@ -v %{version} --all --rpm_safe_upgrade
+exit 0
 
 %endif


### PR DESCRIPTION
This commit adds support for building a spl-modules-dkms sub package
built around Dynamic Kernel Module Support. This is to allow building
packages using the DKMS infrastructure which is intended to ease the
burden of kernel version changes, upgrades, etc.

By default spl-modules-dkms-\* sub package will be built as part of
the 'make rpm' target.  Alternately, you can build only the DKMS
module package using the 'make rpm-dkms' target.

Examples:

```
# To build packaged binaries as well as a dkms packages
$ ./configure && make rpm

# To build only the packaged binary utilities and dkms packages
$ ./configure && make rpm-utils rpm-dkms
```

Note: Only the RHEL 5/6, CHAOS 5, and Fedora distributions are
      supported for building the dkms sub package.

Signed-off-by: Prakash Surya surya1@llnl.gov
Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue zfsonlinux/zfs#535
