### PR TITLE
Remove Makefile from non-toplevel .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .libs
 .DS_Store
 modules.order
+Makefile
 
 #
 # Top level generated files specific to this top level dir

--- a/cmd/.gitignore
+++ b/cmd/.gitignore
@@ -1,3 +1,2 @@
-/Makefile
 /spl
 /splat

--- a/include/.gitignore
+++ b/include/.gitignore
@@ -1,1 +1,0 @@
-/Makefile

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,1 +1,0 @@
-/Makefile

--- a/module/.gitignore
+++ b/module/.gitignore
@@ -1,4 +1,3 @@
 /.tmp_versions
-/Makefile
 /Module.markers
 /Module.symvers

--- a/module/spl/.gitignore
+++ b/module/spl/.gitignore
@@ -1,1 +1,0 @@
-/Makefile

--- a/module/splat/.gitignore
+++ b/module/splat/.gitignore
@@ -1,1 +1,0 @@
-/Makefile

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,0 @@
-/Makefile


### PR DESCRIPTION
When building SPL support into the kernel, ./copy-builtin will copy
non-toplevel .gitignore files. These files list /Makefile, which causes
git-archive to omit ./module/{spl,splat}/Makefile. The absence of these
files result in build failures when SPL is selected. ZFS is unaffected
because it puts Makefile in the toplevel .gitignore, which is not
copied. We fix SPL by emulating that behavior.

Reported-by: Fabio Erculiani lxnay@gentoo.org
Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
