### PR TITLE
Wrap trace_set_debug_header in trace_[get|put]_tcd

### DIFF
--- a/module/spl/spl-debug.c
+++ b/module/spl/spl-debug.c
@@ -686,9 +686,8 @@ spl_debug_msg(void *arg, int subsys, int mask, const char *file,
         if (strchr(file, '/'))
                 file = strrchr(file, '/') + 1;
 
-        trace_set_debug_header(&header, subsys, mask, line, 0);
-
         tcd = trace_get_tcd();
+        trace_set_debug_header(&header, subsys, mask, line, 0);
         if (tcd == NULL)
                 goto console;
 


### PR DESCRIPTION
To properly support CONFIG_PREEMPT enabled kernels, we must refrain from
using a CPU index when preemption is enabled. As a result, this change
moves the trace_set_debug_header call (which calls smp_processor_id)
within trace_get_tcd and trace_put_tcd (which disable and enable
preemption respectively).

Signed-off-by: Prakash Surya surya1@llnl.gov
