### PR TITLE
Linux 3.7 compat, __clear_close_on_exec() removed

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -42,9 +42,6 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_SET_NORMALIZED_TIMESPEC_INLINE
 	SPL_AC_TIMESPEC_SUB
 	SPL_AC_INIT_UTSNAME
-	SPL_AC_FDTABLE_HEADER
-	SPL_AC_FILES_FDTABLE
-	SPL_AC_CLEAR_CLOSE_ON_EXEC
 	SPL_AC_UACCESS_HEADER
 	SPL_AC_KMALLOC_NODE
 	SPL_AC_MONOTONIC_CLOCK
@@ -1185,60 +1182,6 @@ AC_DEFUN([SPL_AC_INIT_UTSNAME], [
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_INIT_UTSNAME, 1, [init_utsname() is available])
-	],[
-		AC_MSG_RESULT(no)
-	])
-])
-
-dnl #
-dnl # 2.6.26 API change,
-dnl # definition of struct fdtable relocated to linux/fdtable.h
-dnl #
-AC_DEFUN([SPL_AC_FDTABLE_HEADER], [
-	SPL_CHECK_HEADER([linux/fdtable.h], [FDTABLE], [], [])
-])
-
-dnl #
-dnl # 2.6.14 API change,
-dnl # check whether 'files_fdtable()' exists
-dnl #
-AC_DEFUN([SPL_AC_FILES_FDTABLE], [
-	AC_MSG_CHECKING([whether files_fdtable() is available])
-	SPL_LINUX_TRY_COMPILE([
-		#include <linux/sched.h>
-		#include <linux/file.h>
-		#ifdef HAVE_FDTABLE_HEADER
-		#include <linux/fdtable.h>
-		#endif
-	],[
-		struct files_struct *files = current->files;
-		struct fdtable *fdt __attribute__ ((unused));
-		fdt = files_fdtable(files);
-	],[
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_FILES_FDTABLE, 1, [files_fdtable() is available])
-	],[
-		AC_MSG_RESULT(no)
-	])
-])
-
-dnl #
-dnl # 3.4.0 API change,
-dnl # check whether '__clear_close_on_exec()' exists
-dnl #
-AC_DEFUN([SPL_AC_CLEAR_CLOSE_ON_EXEC], [
-	AC_MSG_CHECKING([whether __clear_close_on_exec() is available])
-	SPL_LINUX_TRY_COMPILE([
-		#include <linux/fdtable.h>
-	],[
-		struct fdtable *fdt = NULL;
-		int fd = 0;
-
-		__clear_close_on_exec(fd, fdt);
-	],[
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_CLEAR_CLOSE_ON_EXEC, 1,
-			  [__clear_close_on_exec() is available])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/include/linux/file_compat.h
+++ b/include/linux/file_compat.h
@@ -89,9 +89,5 @@ extern kern_path_locked_t kern_path_locked_fn;
 # define spl_kern_path_locked(name, path)	kern_path_locked_fn(name, path)
 #endif /* HAVE_KERN_PATH_LOCKED */
 
-#ifndef HAVE_CLEAR_CLOSE_ON_EXEC
-#define __clear_close_on_exec(fd, fdt)	FD_CLR(fd, fdt->close_on_exec)
-#endif
-
 #endif /* SPL_FILE_COMPAT_H */
 


### PR DESCRIPTION
Commit torvalds/linux@b8318b0 moved the __clear_close_on_exec()
function out of include/linux/fdtable.h and in to fs/file.c
making it unavailable to the SPL.

Now as it turns out we only used this function to tear down
some test infrastructure for the vn_getf()/vn_releasef() SPLAT
regression tests.  Rather than implement even more autoconf
compatibilty code to handle this we just remove the test case.
This also allows us to drop three existing autoconf tests.

This does mean the SPLAT tests will no longer verify these
functions but historically they have never been a problem.
And if we feel we absolutely need this test coverage I'm
sure a more portable version of the test case could be added.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #183
