### PR TITLE
Fix spl_kmem_init_kallsyms_lookup() panic

### DIFF
--- a/include/linux/kallsyms_compat.h
+++ b/include/linux/kallsyms_compat.h
@@ -34,6 +34,7 @@
 
 #else
 
+extern wait_queue_head_t spl_kallsyms_lookup_name_waitq;
 typedef unsigned long (*kallsyms_lookup_name_t)(const char *);
 extern kallsyms_lookup_name_t spl_kallsyms_lookup_name_fn;
 #define spl_kallsyms_lookup_name(name) spl_kallsyms_lookup_name_fn(name)

--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -546,6 +546,8 @@ SPL_PROC_HANDLER(proc_dokallsyms_lookup_name)
 
                 spl_kallsyms_lookup_name_fn =
 			(kallsyms_lookup_name_t)simple_strtoul(str, &end, 16);
+		wake_up(&spl_kallsyms_lookup_name_waitq);
+
 		if (str == end)
 			SRETURN(-EINVAL);
 


### PR DESCRIPTION
Due to I/O buffering the helper may return successfully before
the proc handler has a chance to execute.  To catch this case
wait up to 1 second to verify spl_kallsyms_lookup_name_fn was
updated to a non SYMBOL_POISON value.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue zfsonlinux/zfs#699
Issue zfsonlinux/zfs#859
