### PR TITLE
call_usermodehelper() should wait for process

### DIFF
--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -536,7 +536,7 @@ hostid_exec(void)
 	 * '/usr/bin/hostid' and redirect the result to /proc/sys/spl/hostid
 	 * for us to use.  It's a horrific solution but it will do for now.
 	 */
-	rc = call_usermodehelper(argv[0], argv, envp, 1);
+	rc = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 	if (rc)
 		printk("SPL: Failed user helper '%s %s %s', rc = %d\n",
 		       argv[0], argv[1], argv[2], rc);
@@ -607,7 +607,7 @@ set_kallsyms_lookup_name(void)
 	                 NULL };
 	int rc;
 
-	rc = call_usermodehelper(argv[0], argv, envp, 1);
+	rc = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 
 	/*
 	 * Due to I/O buffering the helper may return successfully before

--- a/module/splat/splat-linux.c
+++ b/module/splat/splat-linux.c
@@ -24,6 +24,7 @@
 \*****************************************************************************/
 
 #include <sys/kmem.h>
+#include <linux/kmod.h>
 #include "splat-internal.h"
 
 #define SPLAT_LINUX_NAME		"linux"
@@ -166,7 +167,7 @@ splat_linux_drop_slab(struct file *file)
 	                 NULL };
 	int rc;
 
-	rc = call_usermodehelper(argv[0], argv, envp, 1);
+	rc = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 	if (rc)
 		splat_vprint(file, SPLAT_LINUX_TEST3_NAME,
 	            "Failed user helper '%s %s %s', rc = %d\n",

--- a/module/splat/splat-vnode.c
+++ b/module/splat/splat-vnode.c
@@ -25,6 +25,7 @@
 \*****************************************************************************/
 
 #include <sys/vnode.h>
+#include <linux/kmod.h>
 #include "splat-internal.h"
 
 #define SPLAT_VNODE_NAME		"vnode"
@@ -75,7 +76,7 @@ splat_vnode_user_cmd(struct file *file, void *arg,
 	                 NULL };
 	int rc;
 
-	rc = call_usermodehelper(sh_path, argv, envp, 1);
+	rc = call_usermodehelper(sh_path, argv, envp, UMH_WAIT_PROC);
 	if (rc) {
 		splat_vprint(file, name,
 			     "Failed command: %s %s %s (%d)\n",


### PR DESCRIPTION
As of Linux 3.4 the UMH_WAIT_\* constants were renumbered.  In
particular, the meaning of "1" changed from UMH_WAIT_PROC (wait for
process to complete), to UMH_WAIT_EXEC (wait for the exec, but not the
process).  A number of call sites used the number 1 instead of the
constant name, so the behavior was not as expected on kernels with
this change.
