### PR TITLE
Fix on_each_cpu autotools test

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -1312,8 +1312,9 @@ AC_DEFUN([SPL_AC_3ARGS_ON_EACH_CPU], [
 	AC_MSG_CHECKING([whether on_each_cpu() wants 3 args])
 	SPL_LINUX_TRY_COMPILE([
 		#include <linux/smp.h>
+		static void func(void *arg) {}
 	],[
-		on_each_cpu(NULL, NULL, 0);
+		on_each_cpu(func, NULL, 0);
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_3ARGS_ON_EACH_CPU, 1,


### PR DESCRIPTION
GCC 4.6.3 emits "error: called object '0u' is not a function" when
building the SPL against the Raspberry Pi Linux 3.2.27+ kernel on Gentoo
Linux. This causes the on_each_cpu() autotools check to fail in situations when it
should succeed.

I do not know why this issue does not occur on amd64, but we resolve
this issue by adding a dummy function.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
