### PR TITLE
Add spl_kmem_cache_expire module option

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -377,9 +377,13 @@ typedef enum kmem_cbrc {
 #define KMC_ALLOC		(1 << KMC_BIT_ALLOC)
 #define KMC_MAX			(1 << KMC_BIT_MAX)
 
-#define KMC_REAP_CHUNK			INT_MAX
-#define KMC_DEFAULT_SEEKS		1
+#define KMC_REAP_CHUNK		INT_MAX
+#define KMC_DEFAULT_SEEKS	1
 
+#define KMC_EXPIRE_AGE		0x1     /* Due to age */
+#define KMC_EXPIRE_MEM		0x2     /* Due to low memory */
+
+extern unsigned int spl_kmem_cache_expire;
 extern struct list_head spl_kmem_cache_list;
 extern struct rw_semaphore spl_kmem_cache_sem;
 

--- a/module/splat/splat-kmem.c
+++ b/module/splat/splat-kmem.c
@@ -810,7 +810,12 @@ splat_kmem_test8(struct file *file, void *arg)
 {
 	kmem_cache_priv_t *kcp;
 	kmem_cache_thread_t *kct;
+	unsigned int spl_kmem_cache_expire_old;
 	int i, rc = 0;
+
+	/* Enable cache aging just for this test if it is disabled */
+	spl_kmem_cache_expire_old = spl_kmem_cache_expire;
+	spl_kmem_cache_expire = KMC_EXPIRE_AGE;
 
 	kcp = splat_kmem_cache_test_kcp_alloc(file, SPLAT_KMEM_TEST8_NAME,
 					      256, 0, 0);
@@ -882,6 +887,8 @@ out_cache:
 out_kcp:
 	splat_kmem_cache_test_kcp_free(kcp);
 out:
+	spl_kmem_cache_expire = spl_kmem_cache_expire_old;
+
 	return rc;
 }
 
@@ -898,7 +905,12 @@ splat_kmem_test9(struct file *file, void *arg)
 {
 	kmem_cache_priv_t *kcp;
 	kmem_cache_thread_t *kct;
+	unsigned int spl_kmem_cache_expire_old;
 	int i, rc = 0, count = SPLAT_KMEM_OBJ_COUNT * 128;
+
+	/* Enable cache aging just for this test if it is disabled */
+	spl_kmem_cache_expire_old = spl_kmem_cache_expire;
+	spl_kmem_cache_expire = KMC_EXPIRE_AGE;
 
 	kcp = splat_kmem_cache_test_kcp_alloc(file, SPLAT_KMEM_TEST9_NAME,
 					      256, 0, 0);
@@ -968,6 +980,8 @@ out_cache:
 out_kcp:
 	splat_kmem_cache_test_kcp_free(kcp);
 out:
+	spl_kmem_cache_expire = spl_kmem_cache_expire_old;
+
 	return rc;
 }
 


### PR DESCRIPTION
Cache aging was implemented because it was part of the default Solaris
kmem_cache behavior.  The idea is that per-cpu objects which haven't been
accessed in several seconds should be returned to the cache.  On the other
hand Linux slabs never move objects back to the slabs unless there is
memory pressure on the system.

This behavior is now configurable through the 'spl_kmem_cache_expire'
module option.  The value is a bit mask with the following meaning.

  0x1 - Solaris style cache aging eviction is enabled.
  0x2 - Linux style low memory eviction is enabled.

Both methods may be safely enabled simultaneously, but by default
both are disabled.  It has never been clear if the kmem cache aging
(which has been around from day one) actually does any good.  It has
however been the source of numerous bugs so I wouldn't mind retiring
it entirely.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #210
