### PR TITLE
BE_IN16 and BE_IN32 for lz4 compression

### DIFF
--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -34,4 +34,13 @@
 #define BE_32(x)	cpu_to_be32(x)
 #define BE_64(x)	cpu_to_be64(x)
 
+#define BE_IN8(xa) \
+	*((uint8_t *)(xa))
+
+#define BE_IN16(xa) \
+	(((uint16_t)BE_IN8(xa) << 8) | BE_IN8((uint8_t *)(xa)+1))
+
+#define BE_IN32(xa) \
+	(((uint32_t)BE_IN16(xa) << 16) | BE_IN16((uint8_t *)(xa)+2))
+
 #endif /* SPL_BYTEORDER_H */


### PR DESCRIPTION
definition of BE_IN16 and BE_IN32 for lz4 compression
