### PR TITLE
Fix HAVE_MUTEX_OWNER_TASK_STRUCT autotools check on PPC64

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -1268,6 +1268,7 @@ AC_DEFUN([SPL_AC_MUTEX_OWNER_TASK_STRUCT], [
 	EXTRA_KCFLAGS="-Werror"
 	SPL_LINUX_TRY_COMPILE([
 		#include <linux/mutex.h>
+		#include <linux/sched.h>
 	],[
 		struct mutex mtx __attribute__ ((unused));
 		mtx.owner = current;


### PR DESCRIPTION
The HAVE_MUTEX_OWNER_TASK_STRUCT fails on PPC64 with the following
error:

error: 'current' undeclared (first use in this function)

We include linux/sched.h to ensure that current is available.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
