### PR TITLE
Simplify hostid logic

### DIFF
--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -138,7 +138,6 @@
 /* Missing globals */
 extern char spl_version[32];
 extern unsigned long spl_hostid;
-extern char hw_serial[11];
 
 /* Missing misc functions */
 extern int highbit(unsigned long i);

--- a/include/sys/systeminfo.h
+++ b/include/sys/systeminfo.h
@@ -25,7 +25,6 @@
 #ifndef _SPL_SYSTEMINFO_H
 #define _SPL_SYSTEMINFO_H
 
-#define HW_INVALID_HOSTID	0xFFFFFFFF	/* an invalid hostid */
 #define HW_HOSTID_LEN		11		/* minimum buffer size needed */
 						/* to hold a decimal or hex */
 						/* hostid string */

--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -506,9 +506,6 @@ SPL_PROC_HANDLER(proc_dohostid)
                 if (str == end)
                         SRETURN(-EINVAL);
 
-                (void) snprintf(hw_serial, HW_HOSTID_LEN, "%lu", spl_hostid);
-                hw_serial[HW_HOSTID_LEN - 1] = '\0';
-                *ppos += *lenp;
         } else {
                 len = snprintf(str, sizeof(str), "%lx", spl_hostid);
                 if (*ppos >= len)
@@ -1050,14 +1047,6 @@ static struct ctl_table spl_table[] = {
                 .maxlen   = sizeof(unsigned long),
                 .mode     = 0644,
                 .proc_handler = &proc_dohostid,
-        },
-        {
-                CTL_NAME    (CTL_HW_SERIAL)
-                .procname = "hw_serial",
-                .data     = hw_serial,
-                .maxlen   = sizeof(hw_serial),
-                .mode     = 0444,
-                .proc_handler = &proc_dostring,
         },
 #ifndef HAVE_KALLSYMS_LOOKUP_NAME
         {


### PR DESCRIPTION
There is plenty of compatibility code for a hw_hostid
that isn't used by anything. At the same time, there are apparently
issues with the current hostid logic. coredumb in #zfsonlinux on
freenode reported that Fedora 17 changes its hostid on every boot, which
required force importing his pool. A suggestion by wca was to adopt
FreeBSD's behavior, where it treats hostid as zero if /etc/hostid does
not exist

Adopting FreeBSD's behavior permits us to eliminate plenty of code,
including a userland helper that invokes the system's hostid as a
fallback.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
