### PR TITLE
rpm: Add buildroot option to kmod build

### DIFF
--- a/rpm/fedora/spl-kmod.spec.in
+++ b/rpm/fedora/spl-kmod.spec.in
@@ -44,7 +44,7 @@ BuildRequires:  %{_bindir}/kmodtool
 # Kmodtool does its magic here.  A patched version of kmodtool is shipped
 # with the source rpm until kmod development packages are supported upstream.
 # https://bugzilla.rpmfusion.org/show_bug.cgi?id=2714
-%{expand:%(sh %{SOURCE10} --target %{_target_cpu} --repo %{repo} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+%{expand:%(sh %{SOURCE10} --target %{_target_cpu} --repo %{repo} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null) }
 
 
 %description
@@ -56,7 +56,7 @@ several interfaces provided by the Solaris kernel.
 %{?kmodtool_check}
 
 # Print kmodtool output for debugging purposes:
-sh %{SOURCE10} --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --devel %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+sh %{SOURCE10} --target %{_target_cpu}  --repo %{repo} --kmodname %{name} --devel %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null
 
 %if %{with debug}
     %define debug --enable-debug

--- a/rpm/generic/spl-kmod.spec.in
+++ b/rpm/generic/spl-kmod.spec.in
@@ -44,7 +44,7 @@ Conflicts:      %{module}-dkms
 # Kmodtool does its magic here.  A patched version of kmodtool is shipped
 # because the latest versions may not be available for your distribution.
 # https://bugzilla.rpmfusion.org/show_bug.cgi?id=2714
-%{expand:%(bash %{SOURCE10} --target %{_target_cpu} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+%{expand:%(bash %{SOURCE10} --target %{_target_cpu} --kmodname %{name} --devel %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null) }
 
 
 %description
@@ -56,7 +56,7 @@ several interfaces provided by the Solaris kernel.
 %{?kmodtool_check}
 
 # Print kmodtool output for debugging purposes:
-bash %{SOURCE10} --target %{_target_cpu}  --kmodname %{name} --devel  %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+bash %{SOURCE10} --target %{_target_cpu}  --kmodname %{name} --devel  %{?prefix:--prefix "%{?prefix}"} %{?kernels:--for-kernels "%{?kernels}"} %{?kernelbuildroot:--buildroot "%{?kernelbuildroot}"} 2>/dev/null
 
 %if %{with debug}
     %define debug --enable-debug

--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -37,6 +37,7 @@ kernel_versions_to_build_for=
 prefix=
 filterfile=
 target=
+buildroot=
 
 error_out()
 {
@@ -305,9 +306,9 @@ print_customrpmtemplate ()
 {
 	for kernel in ${1}
 	do
-		if 	[[ -e "/usr/src/kernels/${kernel}" ]] ; then
+		if [[ -e "${buildroot}/usr/src/kernels/${kernel}" ]] ; then
 			# this looks like a Fedora/RH kernel -- print a normal template (which includes the proper BR) and be happy :)
-			kernel_versions="${kernel_versions}${kernel}___%{_usrsrc}/kernels/${kernel} "
+			kernel_versions="${kernel_versions}${kernel}___${buildroot}%{_usrsrc}/kernels/${kernel} "
 
 			# parse kernel versions string and print template
 			local kernel_verrelarch=${kernel%%${kernels_known_variants}}
@@ -382,7 +383,6 @@ myprog_help ()
 	echo "Usage: $(basename ${0}) [OPTIONS]"
 	echo $'\n'"Creates a template to be used during kmod building"
 	echo $'\n'"Available options:"
-	# FIXME	echo " --datadir <dir>     -- look for our shared files in <dir>"
 	echo " --filterfile <file>  -- filter the results with grep --file <file>"
 	echo " --for-kernels <list> -- created templates only for these kernels"
 	echo " --kmodname <file>    -- name of the kmod (required)"
@@ -390,6 +390,7 @@ myprog_help ()
 	echo " --noakmod            -- no akmod package"
 	echo " --repo <name>        -- use buildsys-build-<name>-kerneldevpkgs"
 	echo " --target <arch>      -- target-arch (required)"
+	echo " --buildroot <dir>    -- Build root (place to look for build files)"
 }
 
 while [ "${1}" ] ; do
@@ -477,6 +478,11 @@ while [ "${1}" ] ; do
 		--current)
 			shift
 			build_kernels="current"
+			;;
+		--buildroot)
+			shift
+			buildroot="${1}"
+			shift
 			;;
 		--help)
 			myprog_help


### PR DESCRIPTION
This allows rpmbuild to define buildroot to point to where kernel data is located.
