### PR TITLE
Illumos #3006

### DIFF
--- a/include/sys/debug.h
+++ b/include/sys/debug.h
@@ -35,10 +35,12 @@
  * ASSERT3S()	- Assert signed X OP Y is true, if not panic.
  * ASSERT3U()	- Assert unsigned X OP Y is true, if not panic.
  * ASSERT3P()	- Assert pointer X OP Y is true, if not panic.
+ * ASSERT0()	- Assert arg is zero, if not panic.
  * VERIFY()	- Verify X is true, if not panic.
  * VERIFY3S()	- Verify signed X OP Y is true, if not panic.
  * VERIFY3U()	- Verify unsigned X OP Y is true, if not panic.
  * VERIFY3P()	- Verify pointer X OP Y is true, if not panic.
+ * VERIFY0()	- Verify arg is zero, if not panic.
  */
 
 #ifndef _SPL_DEBUG_H
@@ -79,10 +81,12 @@ do {									\
 #define VERIFY3U(x,y,z)	VERIFY3_IMPL(x, y, z, uint64_t, "%llu",		\
 				    (unsigned long long))
 #define VERIFY3P(x,y,z)	VERIFY3_IMPL(x, y, z, uintptr_t, "%p", (void *))
+#define	VERIFY0(x)	VERIFY3_IMPL(x, ==, 0, uint64_t, "%llu", (uint64_t))
 
 #define ASSERT3S(x,y,z)	((void)0)
 #define ASSERT3U(x,y,z)	((void)0)
 #define ASSERT3P(x,y,z)	((void)0)
+#define ASSERT0(x)	((void)0)
 
 #else /* Debugging Enabled */
 
@@ -130,10 +134,12 @@ do {									\
 #define VERIFY3U(x,y,z)	VERIFY3_IMPL(x, y, z, uint64_t, "%llu",		\
 				    (unsigned long long))
 #define VERIFY3P(x,y,z)	VERIFY3_IMPL(x, y, z, uintptr_t, "%p", (void *))
+#define	VERIFY0(x)	VERIFY3_IMPL(x, ==, 0, uint64_t, "%llu", (uint64_t))
 
 #define ASSERT3S(x,y,z)	VERIFY3S(x, y, z)
 #define ASSERT3U(x,y,z)	VERIFY3U(x, y, z)
 #define ASSERT3P(x,y,z)	VERIFY3P(x, y, z)
+#define ASSERT0(x)	VERIFY0(x)
 
 #define ASSERTV(x)	x
 #define VERIFY(x)	ASSERT(x)


### PR DESCRIPTION
3006 VERIFY[S,U,P] and ASSERT[S,U,P] frequently check if first argument is zero
Reviewed by Matt Ahrens matthew.ahrens@delphix.com
Reviewed by George Wilson george.wilson@delphix.com
Approved by Eric Schrock eric.schrock@delphix.com

References:
  illumos/illumos-gate@fb09f5aad449c97fe309678f3f604982b563a96f
  https://www.illumos.org/issues/3006

This is a fairly cosmetic change for ZoL, however, it will help in merging
subsequent upstream commits.

For ZoL, this issue requres a commit to both the spl and the zfs
repositories.

Ported-by: Tim Chase tim@chase2k.com
