### PR TITLE
Add __moddi3 implementation

### DIFF
--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -213,6 +213,13 @@ __umoddi3(uint64_t dividend, uint64_t divisor)
 }
 EXPORT_SYMBOL(__umoddi3);
 
+uint64_t
+__moddi3(int64_t dividend, int64_t divisor)
+{
+	return (dividend - (divisor * __divdi3(dividend, divisor)));
+}
+EXPORT_SYMBOL(__moddi3);
+
 #if defined(__arm) || defined(__arm__)
 /*
  * Implementation of 64-bit (un)signed division for 32-bit arm machines.


### PR DESCRIPTION
After modprobing the spl module with the latest code,
the 32-bit systems warns about "Unknown symbol __moddi3"
and will not load zfs kernel module. Add the __moddi3 implementation
based on the code and comments in spl-generic.c.

Signed-off-by: Ying Zhu casualfisher@gmail.com
