### PR TITLE
Support kuid_t/kgid_t types for Linux 3.8+

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -71,6 +71,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_INODE_TRUNCATE_RANGE
 	SPL_AC_FS_STRUCT_SPINLOCK
 	SPL_AC_CRED_STRUCT
+	SPL_AC_KUIDGID_T
 	SPL_AC_GROUPS_SEARCH
 	SPL_AC_PUT_TASK_STRUCT
 	SPL_AC_5ARGS_PROC_HANDLER
@@ -1827,6 +1828,28 @@ AC_DEFUN([SPL_AC_CRED_STRUCT], [
 	])
 ])
 
+
+dnl #
+dnl # User namespaces, use kuid_t in place of uid_t
+dnl # where available. Not strictly a user namespaces thing
+dnl # but it should prevent surprises
+dnl #
+AC_DEFUN([SPL_AC_KUIDGID_T], [
+	AC_MSG_CHECKING([whether kuid_t/kgid_t is available])
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/uidgid.h>
+	], [
+		kuid_t userid = KUIDT_INIT(0);
+		kgid_t groupid = KGIDT_INIT(0);
+	
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_KUIDGID_T, 1, [kuid_t/kgid_t in use])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
 dnl #
 dnl # Custom SPL patch may export this symbol.
 dnl #
@@ -1834,8 +1857,15 @@ AC_DEFUN([SPL_AC_GROUPS_SEARCH],
 	[AC_MSG_CHECKING([whether groups_search() is available])
 	SPL_LINUX_TRY_COMPILE_SYMBOL([
 		#include <linux/cred.h>
+		#ifdef HAVE_KUIDGID_T
+		#include <linux/uidgid.h>
+		#endif
 	], [
+		#ifdef HAVE_KUIDGID_T
+		groups_search(NULL, KGIDT_INIT(0));
+		#else
 		groups_search(NULL, 0);
+		#endif
 	], [groups_search], [], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_GROUPS_SEARCH, 1, [groups_search() is available])

--- a/include/sys/cred.h
+++ b/include/sys/cred.h
@@ -29,6 +29,8 @@
 #include <sys/types.h>
 #include <sys/vfs.h>
 
+#include <sys/uidgid.h>
+
 #ifdef HAVE_CRED_STRUCT
 
 typedef struct cred cred_t;

--- a/include/sys/uidgid.h
+++ b/include/sys/uidgid.h
@@ -1,0 +1,27 @@
+/*
+ * Someone put a copyright here I guess.
+ *
+ *
+ */
+
+#ifndef _SPL_UIDGID_H
+#define _SPL_UIDGID_H
+
+
+
+#ifdef HAVE_KUIDGID_T
+
+ /* Linux still defines uid_t and gid_t as typedefs so we have to
+  * go with #define directives, or else convert to k[ug]id_t everywhere
+  * with that being the new typedef when this conversion is not in use.
+  * We stick with the classic uid/gid names and #define where needed.
+  */
+ #include <linux/uidgid.h>
+ #define uid_t kuid_t
+ #define gid_t kgid_t
+
+#endif
+
+
+
+#endif

--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -41,6 +41,7 @@
 #include <sys/time.h>
 #include <sys/uio.h>
 #include <sys/sunldi.h>
+#include <sys/uidgid.h>
 
 /*
  * Prior to linux-2.6.33 only O_DSYNC semantics were implemented and


### PR DESCRIPTION
When CONFIG_UIDGID_STRICT_TYPE_CHECKS is enabled kuid_t becomes a
structure (to be treated as an opaque data type) rather than a new
name for the integer-type of uid_t. Similar for gid_t.

The User Namespaces option introduced as working as Linux 3.8 requires
this option to be enabled so we now support compiling with this option.
This is implemented by checking for the kuid_t type and #define the
existing uid_t/gid_t to the k-versions.
