### PR TITLE
Modify gethrestime to use current_kernel_time()

### DIFF
--- a/module/spl/spl-time.c
+++ b/module/spl/spl-time.c
@@ -40,11 +40,10 @@ extern unsigned long long monotonic_clock(void);
 void
 __gethrestime(timestruc_t *ts)
 {
-        struct timeval tv;
+	struct timespec tspec = current_kernel_time();
 
-	do_gettimeofday(&tv);
-	ts->tv_sec = tv.tv_sec;
-	ts->tv_nsec = tv.tv_usec * NSEC_PER_USEC;
+	ts->tv_sec = tspec.tv_sec;
+	ts->tv_nsec = tspec.tv_nsec;
 }
 EXPORT_SYMBOL(__gethrestime);
 


### PR DESCRIPTION
This allows us to get nanosecond resolution. It also means
we use the same time source as utimensat(now) etc.

Should fix issue #255. 

Note I have only tested on kernel 3.2. From a quick glance this should be okay for other kernel versions.

Also note that there is a discrepancy between the time returned from current_kernel_time() and from 'strace -ttt' for the syscall. I haven't investigated why.
