### PR TITLE
Return -1 for generic kmem cache shrinker

### DIFF
--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -2122,7 +2122,15 @@ __spl_kmem_cache_generic_shrinker(struct shrinker *shrink,
 	}
 	up_read(&spl_kmem_cache_sem);
 
-	return (unused * sysctl_vfs_cache_pressure) / 100;
+	/*
+	 * After performing reclaim always return -1 to indicate we cannot
+	 * perform additional reclaim.  This prevents shrink_slabs() from
+	 * repeatedly invoking this generic shrinker and potentially spinning.
+	 */
+	if (sc->nr_to_scan)
+		return -1;
+
+	return unused;
 }
 
 SPL_SHRINKER_CALLBACK_WRAPPER(spl_kmem_cache_generic_shrinker);


### PR DESCRIPTION
It has been observed that it's possible to get in a state where
shrink_slabs() will spin repeated invoking the generic kmem cache
shrinker.  It fails to detect it's not making forward progress
reclaiming from the cache and doesn't give up.  To ensure this
never occurs we unconditionally return -1 after reclaiming what
we can.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue zfsonlinux/zfs#1276
Issue zfsonlinux/zfs#1598
