### PR TITLE
PaX/GrSecurity Linux 3.8.y compat: Use __no_const on struct ctl_table

### DIFF
--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -29,6 +29,7 @@
 #include <linux/kmod.h>
 #include <linux/seq_file.h>
 #include <linux/proc_compat.h>
+#include <linux/version.h>
 #include <spl-debug.h>
 
 #ifdef SS_DEBUG_SUBSYS
@@ -36,6 +37,12 @@
 #endif
 
 #define SS_DEBUG_SUBSYS SS_PROC
+
+#if defined(CONSTIFY_PLUGIN) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0)
+typedef struct ctl_table __no_const spl_ctl_table;
+#else
+typedef struct ctl_table spl_ctl_table;
+#endif
 
 #ifdef DEBUG_KMEM
 static unsigned long table_min = 0;
@@ -323,7 +330,7 @@ SPL_PROC_HANDLER(proc_force_bug)
 SPL_PROC_HANDLER(proc_console_max_delay_cs)
 {
         int rc, max_delay_cs;
-        struct ctl_table dummy = *table;
+        spl_ctl_table dummy = *table;
         long d;
 	SENTRY;
 
@@ -355,7 +362,7 @@ SPL_PROC_HANDLER(proc_console_max_delay_cs)
 SPL_PROC_HANDLER(proc_console_min_delay_cs)
 {
         int rc, min_delay_cs;
-        struct ctl_table dummy = *table;
+        spl_ctl_table dummy = *table;
         long d;
 	SENTRY;
 
@@ -387,7 +394,7 @@ SPL_PROC_HANDLER(proc_console_min_delay_cs)
 SPL_PROC_HANDLER(proc_console_backoff)
 {
         int rc, backoff;
-        struct ctl_table dummy = *table;
+        spl_ctl_table dummy = *table;
 	SENTRY;
 
         dummy.data = &backoff;
@@ -417,7 +424,7 @@ SPL_PROC_HANDLER(proc_domemused)
 {
         int rc = 0;
         unsigned long min = 0, max = ~0, val;
-        struct ctl_table dummy = *table;
+        spl_ctl_table dummy = *table;
 	SENTRY;
 
         dummy.data = &val;
@@ -444,7 +451,7 @@ SPL_PROC_HANDLER(proc_doslab)
 {
         int rc = 0;
         unsigned long min = 0, max = ~0, val = 0, mask;
-        struct ctl_table dummy = *table;
+        spl_ctl_table dummy = *table;
         spl_kmem_cache_t *skc;
         SENTRY;
 


### PR DESCRIPTION
The PaX team started constifying `struct ctl_table` as of their Linux
3.8.0 patchset. This lead to zfsonlinux/spl#225 and Gentoo bug #463012.

While investigating our options, I learned that there is a preprocessor
directive called CONSTIFY_PLUGIN that we can use to detect the presence
of the PaX changes and adjust the code accordingly.

The PaX Team had suggested adopting ctl_table_no_const, but supporting
older kernels required declaring that whenever the CONSTIFY_PLUGIN was
set. Future compiler changes could potentially cause that to break in
the presence of -Werror, so instead we define our own spl_ctl_table
typdef and use that. This should be compatible with all PaX kernels.

This introduces a Linux kernel version number check to prevent a build
failure on versions of the PaX GCC plugin that existed for kernels
before Linux 3.8.0. Affected versions of the PaX plugin will trigger a
compiler error when they see no_const cast on a non-constified
structure.  Ordinarily, we would need an autotools check to catch that.
However, it is safe to do a kernel version check instead of an autotools
check in this specific instance because the affected versions of the PaX
GCC plugin only exist for Linux kernels before 3.8.0 and the
constification of `struct ctl_table` by the PaX developers only occurs
in Linux 3.8.0 and later.

Closes zfsonlinux/spl#225

Signed-off-by: Richard Yao ryao@gentoo.org
