### PR TITLE
Linux 3.11 compat: Replace num_physpages with totalram_pages

### DIFF
--- a/include/sys/vmsystm.h
+++ b/include/sys/vmsystm.h
@@ -41,7 +41,7 @@
  */
 #define membar_producer()		smp_wmb()
 
-#define physmem				num_physpages
+#define physmem				totalram_pages
 #define freemem				nr_free_pages()
 #define availrmem			spl_kmem_availrmem()
 

--- a/module/spl/spl-debug.c
+++ b/module/spl/spl-debug.c
@@ -548,7 +548,7 @@ trace_print_to_console(struct spl_debug_header *hdr, int mask, const char *buf,
 static int
 trace_max_debug_mb(void)
 {
-        return MAX(512, ((num_physpages >> (20 - PAGE_SHIFT)) * 80) / 100);
+        return MAX(512, ((totalram_pages >> (20 - PAGE_SHIFT)) * 80) / 100);
 }
 
 static struct trace_page *
@@ -1188,7 +1188,7 @@ spl_debug_init(void)
 
         /* If spl_debug_mb is set to an invalid value or uninitialized
          * then just make the total buffers smp_num_cpus TCD_MAX_PAGES */
-        if (max > (num_physpages >> (20 - 2 - PAGE_SHIFT)) / 5 ||
+        if (max > (totalram_pages >> (20 - 2 - PAGE_SHIFT)) / 5 ||
             max >= 512 || max < 0) {
                 max = TCD_MAX_PAGES;
         } else {


### PR DESCRIPTION
num_physpages was removed by
torvalds/linux@cfa11e08ed39eb28a9eff9a907b20913020c69b5, so lets replace
it with totalram_pages.

This is a bug fix as much as it is a compatibility fix because
num_physpages did not reflect the number of pages actually available to
the kernel:

http://lkml.indiana.edu/hypermail/linux/kernel/0908.2/01001.html

Also, there are known issues with memory calculations when ZFS is in a
Xen dom0. There is a chance that using totalram_pages could resolve
them. This conjecture is untested at the time of writing.

Signed-off-by: Richard Yao ryao@gentoo.org
