### PR TITLE
Replace current_kernel_time() with getnstimeofday()

### DIFF
--- a/module/spl/spl-time.c
+++ b/module/spl/spl-time.c
@@ -40,7 +40,9 @@ extern unsigned long long monotonic_clock(void);
 void
 __gethrestime(timestruc_t *ts)
 {
-	struct timespec tspec = current_kernel_time();
+	struct timespec tspec;
+
+	getnstimeofday(&tspec);
 
 	ts->tv_sec = tspec.tv_sec;
 	ts->tv_nsec = tspec.tv_nsec;

--- a/module/splat/splat-kmem.c
+++ b/module/splat/splat-kmem.c
@@ -682,7 +682,7 @@ splat_kmem_cache_thread_test(struct file *file, void *arg, char *name,
 		goto out_kcp;
 	}
 
-	start = current_kernel_time();
+	getnstimeofday(&start);
 
 	for (i = 0; i < SPLAT_KMEM_THREADS; i++) {
 		thr = thread_create(NULL, 0,
@@ -707,7 +707,7 @@ splat_kmem_cache_thread_test(struct file *file, void *arg, char *name,
 	/* Sleep until all thread have finished */
 	wait_event(kcp->kcp_ctl_waitq, splat_kmem_cache_test_threads(kcp, 0));
 
-	stop = current_kernel_time();
+	getnstimeofday(&stop);
 	delta = timespec_sub(stop, start);
 
 	splat_vprint(file, name,
@@ -1203,7 +1203,7 @@ splat_kmem_test13(struct file *file, void *arg)
 	kmem_cache_thread_t *kct;
 	dummy_page_t *dp;
 	struct list_head list;
-	struct timespec start, delta = { 0, 0 };
+	struct timespec start, stop, delta = { 0, 0 };
 	int size, count, slabs, fails = 0;
 	int i, rc = 0, max_time = 10;
 
@@ -1250,7 +1250,7 @@ splat_kmem_test13(struct file *file, void *arg)
 	i = 0;
 	slabs = kcp->kcp_cache->skc_slab_total;
 	INIT_LIST_HEAD(&list);
-	start = current_kernel_time();
+	getnstimeofday(&start);
 
 	/* Apply memory pressure */
 	while (kcp->kcp_cache->skc_slab_total > (slabs >> 2)) {
@@ -1259,7 +1259,8 @@ splat_kmem_test13(struct file *file, void *arg)
 			splat_kmem_cache_test_debug(
 			    file, SPLAT_KMEM_TEST13_NAME, kcp);
 
-		delta = timespec_sub(current_kernel_time(), start);
+		getnstimeofday(&stop);
+		delta = timespec_sub(stop, start);
 		if (delta.tv_sec >= max_time) {
 			splat_vprint(file, SPLAT_KMEM_TEST13_NAME,
 				     "Failed to reclaim 3/4 of cache in %ds, "


### PR DESCRIPTION
current_kernel_time() is used by the SPLAT, but it is not meant for
performance measurement. We modify the SPLAT to use getnstimeofday(),
which is equivalent to the gethrestime() function on Solaris.
Additionally, we update gethrestime() to invoke getnstimeofday().

Signed-off-by: Richard Yao ryao@gentoo.org
