### PR TITLE
Report bytes reserved in txg history file

### DIFF
--- a/include/sys/kstat.h
+++ b/include/sys/kstat.h
@@ -176,6 +176,7 @@ typedef struct kstat_txg {
         u_longlong_t       txg;         /* txg id */
         kstat_txg_state_t  state;       /* txg state */
         hrtime_t           birth;       /* birth time stamp */
+        u_longlong_t       nreserved;   /* number of bytes reserved */
         u_longlong_t       nread;       /* number of bytes read */
         u_longlong_t       nwritten;    /* number of bytes written */
         uint_t             reads;       /* number of read operations */

--- a/module/spl/spl-kstat.c
+++ b/module/spl/spl-kstat.c
@@ -83,9 +83,9 @@ kstat_seq_show_headers(struct seq_file *f)
                         break;
                 case KSTAT_TYPE_TXG:
                         seq_printf(f,
-                                   "%-8s %-5s %-13s %-12s %-12s %-8s %-8s "
-                                   "%-12s %-12s %-12s\n",
-                                   "txg", "state", "birth",
+                                   "%-8s %-5s %-13s %-12s %-12s %-12s %-8s "
+                                   "%-8s %-12s %-12s %-12s\n",
+                                   "txg", "state", "birth", "nreserved",
                                    "nread", "nwritten", "reads", "writes",
                                    "otime", "qtime", "stime");
                         break;
@@ -215,10 +215,11 @@ kstat_seq_show_txg(struct seq_file *f, kstat_txg_t *ktp)
 	}
 
         seq_printf(f,
-                   "%-8llu %-5c %-13llu %-12llu %-12llu %-8u %-8u "
+                   "%-8llu %-5c %-13llu %-12llu %-12llu %-12llu %-8u %-8u "
                    "%12lld %12lld %12lld\n", ktp->txg, state, ktp->birth,
-                    ktp->nread, ktp->nwritten, ktp->reads, ktp->writes,
-                    ktp->open_time, ktp->quiesce_time, ktp->sync_time);
+                    ktp->nreserved, ktp->nread, ktp->nwritten, ktp->reads,
+                    ktp->writes, ktp->open_time, ktp->quiesce_time,
+                    ktp->sync_time);
 	return 0;
 }
 


### PR DESCRIPTION
Add a column in the txg history file for reporting the number of bytes
reserved for each txg. This should provide some visibility into the
ratio of reserved space to space actually written for each txg.

Signed-off-by: Prakash Surya surya1@llnl.gov
