### PR TITLE
Add new kstat KSTAT_TYPE_READ type

### DIFF
--- a/include/sys/kstat.h
+++ b/include/sys/kstat.h
@@ -43,8 +43,7 @@
 #define KSTAT_TYPE_INTR         2       /* interrupt stats; ks_ndata == 1 */
 #define KSTAT_TYPE_IO           3       /* I/O stats; ks_ndata == 1 */
 #define KSTAT_TYPE_TIMER        4       /* event timer; ks_ndata >= 1 */
-#define KSTAT_TYPE_TXG          5       /* txg sync; ks_ndata >= 1 */
-#define KSTAT_NUM_TYPES         6
+#define KSTAT_NUM_TYPES         5
 
 #define KSTAT_DATA_CHAR         0
 #define KSTAT_DATA_INT32        1
@@ -174,26 +173,6 @@ typedef struct kstat_timer {
         hrtime_t     start_time;           /* previous event start time */
         hrtime_t     stop_time;            /* previous event stop time */
 } kstat_timer_t;
-
-typedef enum kstat_txg_state {
-        TXG_STATE_OPEN      = 1,
-        TXG_STATE_QUIESCING = 2,
-        TXG_STATE_SYNCING   = 3,
-        TXG_STATE_COMMITTED = 4,
-} kstat_txg_state_t;
-
-typedef struct kstat_txg {
-        u_longlong_t       txg;         /* txg id */
-        kstat_txg_state_t  state;       /* txg state */
-        hrtime_t           birth;       /* birth time stamp */
-        u_longlong_t       nread;       /* number of bytes read */
-        u_longlong_t       nwritten;    /* number of bytes written */
-        uint_t             reads;       /* number of read operations */
-        uint_t             writes;      /* number of write operations */
-        hrtime_t           open_time;   /* open time */
-        hrtime_t           quiesce_time;/* quiesce time */
-        hrtime_t           sync_time;   /* sync time */
-} kstat_txg_t;
 
 int spl_kstat_init(void);
 void spl_kstat_fini(void);

--- a/module/spl/spl-kstat.c
+++ b/module/spl/spl-kstat.c
@@ -87,14 +87,6 @@ kstat_seq_show_headers(struct seq_file *f)
                                    "name", "events", "elapsed",
                                    "min", "max", "start", "stop");
                         break;
-                case KSTAT_TYPE_TXG:
-                        seq_printf(f,
-                                   "%-8s %-5s %-13s %-12s %-12s %-8s %-8s "
-                                   "%-12s %-12s %-12s\n",
-                                   "txg", "state", "birth",
-                                   "nread", "nwritten", "reads", "writes",
-                                   "otime", "qtime", "stime");
-                        break;
                 default:
                         PANIC("Undefined kstat type %d\n", ksp->ks_type);
         }
@@ -208,27 +200,6 @@ kstat_seq_show_timer(struct seq_file *f, kstat_timer_t *ktp)
 }
 
 static int
-kstat_seq_show_txg(struct seq_file *f, kstat_txg_t *ktp)
-{
-	char state;
-
-	switch (ktp->state) {
-		case TXG_STATE_OPEN:		state = 'O';	break;
-		case TXG_STATE_QUIESCING:	state = 'Q';	break;
-		case TXG_STATE_SYNCING:		state = 'S';	break;
-		case TXG_STATE_COMMITTED:	state = 'C';	break;
-		default:			state = '?';	break;
-	}
-
-        seq_printf(f,
-                   "%-8llu %-5c %-13llu %-12llu %-12llu %-8u %-8u "
-                   "%12lld %12lld %12lld\n", ktp->txg, state, ktp->birth,
-                    ktp->nread, ktp->nwritten, ktp->reads, ktp->writes,
-                    ktp->open_time, ktp->quiesce_time, ktp->sync_time);
-	return 0;
-}
-
-static int
 kstat_seq_show(struct seq_file *f, void *p)
 {
         kstat_t *ksp = (kstat_t *)f->private;
@@ -259,9 +230,6 @@ kstat_seq_show(struct seq_file *f, void *p)
                         break;
                 case KSTAT_TYPE_TIMER:
                         rc = kstat_seq_show_timer(f, (kstat_timer_t *)p);
-                        break;
-                case KSTAT_TYPE_TXG:
-                        rc = kstat_seq_show_txg(f, (kstat_txg_t *)p);
                         break;
                 default:
                         PANIC("Undefined kstat type %d\n", ksp->ks_type);
@@ -301,9 +269,6 @@ kstat_seq_data_addr(kstat_t *ksp, loff_t n)
                         break;
                 case KSTAT_TYPE_TIMER:
                         rc = ksp->ks_data + n * sizeof(kstat_timer_t);
-                        break;
-                case KSTAT_TYPE_TXG:
-                        rc = ksp->ks_data + n * sizeof(kstat_txg_t);
                         break;
                 default:
                         PANIC("Undefined kstat type %d\n", ksp->ks_type);
@@ -517,10 +482,6 @@ __kstat_create(const char *ks_module, int ks_instance, const char *ks_name,
 	                ksp->ks_ndata = ks_ndata;
                         ksp->ks_data_size = ks_ndata * sizeof(kstat_timer_t);
                         break;
-		case KSTAT_TYPE_TXG:
-			ksp->ks_ndata = ks_ndata;
-			ksp->ks_data_size = ks_ndata * sizeof(kstat_timer_t);
-			break;
                 default:
                         PANIC("Undefined kstat type %d\n", ksp->ks_type);
         }


### PR DESCRIPTION
Add a new kstat type for tracking useful statistics about read.
The new KSTAT_TYPE_READ type can be used to track the following
statistics for each read:
- A unique identifier (uint64_t)
- The time the entry was added to the list (hrtime_t)
  (_not_ wall clock time; relative to the other entries on the list)
- The objset ID (uint64_t)
- The object number (uint64_t)
- The indirection level (uint64_t)
- The block ID (uint64_t)
- The name of the function originating the arc_read call (char[24])
- The arc_flags from the arc_read call (uint32_t)

Signed-off-by: Prakash Surya surya1@llnl.gov
