### PR TITLE
Declare get_vmalloc_info_fn only when needed

### DIFF
--- a/include/sys/vmsystm.h
+++ b/include/sys/vmsystm.h
@@ -81,8 +81,10 @@ struct vmalloc_info {
 };
 #endif
 
+#ifndef HAVE_GET_VMALLOC_INFO
 typedef void (*get_vmalloc_info_t)(struct vmalloc_info *);
 extern get_vmalloc_info_t get_vmalloc_info_fn;
+#endif
 
 # define VMEM_ALLOC		0x01
 # define VMEM_FREE		0x02


### PR DESCRIPTION
A couple of definitions were outside a preprocessor conditional
statement when they should have been inside it. This caused build
failures for some people.

Closes zfsonlinux/spl#291

Reported-by: Aaron Fineman abyxcos@mnetic.ch
Signed-off-by: Richard Yao ryao@gentoo.org
