### PR TITLE
3525 persistent l2arc.

### DIFF
--- a/include/sys/debug.h
+++ b/include/sys/debug.h
@@ -145,4 +145,14 @@ do {									\
 #define VERIFY(x)	ASSERT(x)
 
 #endif /* NDEBUG */
+
+/*
+ * Compile-time assertion. The condition 'x' must be constant.
+ */
+#define CTASSERT_GLOBAL(x)             _CTASSERT(x, __LINE__)
+#define CTASSERT(x) {_CTASSERT(x, __LINE__);}
+#define _CTASSERT(x, y)         __CTASSERT(x, y)
+#define __CTASSERT(x, y) \
+	typedef char __attribute__ ((unused)) __compile_time_assertion__ ## y[(x) ? 1 : -1]
+
 #endif /* SPL_DEBUG_H */


### PR DESCRIPTION
This patch just add a CTASSERT macro for compile time assertion, which is used in arc.c.

This macro makes the compile to spit "mixed definition and code"
warning, I can't find a way to avoid it.
