### PR TITLE
Add module versioning

### DIFF
--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -759,3 +759,4 @@ module_exit(spl_fini);
 MODULE_AUTHOR("Lawrence Livermore National Labs");
 MODULE_DESCRIPTION("Solaris Porting Layer");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(SPL_META_VERSION "-" SPL_META_RELEASE);

--- a/module/splat/splat-ctl.c
+++ b/module/splat/splat-ctl.c
@@ -721,3 +721,4 @@ spl_module_exit(splat_fini);
 MODULE_AUTHOR("Lawrence Livermore National Labs");
 MODULE_DESCRIPTION("Solaris Porting LAyer Tests");
 MODULE_LICENSE("GPL");
+MODULE_VERSION(SPL_META_VERSION "-" SPL_META_RELEASE);


### PR DESCRIPTION
Use the standard Linux MODULE_VERSION macro to expose the installed
spl and splat module versions.  This will also automatically add a
checksum of the .c files and headers in "srcversion".  See:

  /sys/module/spl/version
  /sys/module/spl/srcversion
  /sys/module/splat/version
  /sys/module/splat/srcversion

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue zfsonlinux/zfs#1923
