### PR TITLE
Define the needed ISA types for Sparc

### DIFF
--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -91,7 +91,35 @@
 #define _BIG_ENDIAN
 #endif
 
-#else /* Currently only x86_64, i386, arm, and powerpc arches supported */
+/* sparc arch specific defines */
+#elif defined(__sparc) || defined(__sparc__)
+
+#if !defined(__sparc)
+#define __sparc
+#endif
+
+#if !defined(__sparc__)
+#define __sparc__
+#endif
+
+#define _BIG_ENDIAN
+#define _SUNOS_VTOC_16
+
+/* sparc64 arch specific defines */
+#elif defined(__sparc64) || defined(__sparc64__)
+
+#if !defined(__sparc64)
+#define __sparc64
+#endif
+
+#if !defined(__sparc64__)
+#define __sparc64__
+#endif
+
+#define _BIG_ENDIAN
+#define _SUNOS_VTOC_16
+
+#else /* Currently x86_64, i386, arm, powerpc, and sparc are supported */
 #error "Unsupported ISA type"
 #endif
 


### PR DESCRIPTION
Add the minimum required ISA types to support the Sparc
architecture.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Closes #317
