### PR TITLE
Evenly distribute the taskq threads across available CPUs

### DIFF
--- a/man/man5/spl-module-parameters.5
+++ b/man/man5/spl-module-parameters.5
@@ -124,3 +124,15 @@ Spin a maximum of N times to acquire lock
 .sp
 .ne -4
 Default value: \fB0\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBspl_taskq_thread_bind\fR (int)
+.ad
+.RS 12n
+Bind taskq thread to CPU
+.sp
+Default value: \fB0\fR.
+.RE


### PR DESCRIPTION
The problem is described in commit aeeb4e0c0ae75b99ebbaa3056f0afc8e12949532.
However, instead of disabling the binding to CPU altogether we just keep the
last CPU index across calls to taskq_create() and thus achieve even
distribution of the taskq threads across all available CPUs.

The implementation based on assumption that task queues initialization
performed in serial manner.

Signed-off-by: Andrey Vesnovaty andrey.vesnovaty@gmail.com
