### PR TITLE
Set hw_serial also when we read /etc/hostid

### DIFF
--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -566,6 +566,9 @@ zone_get_hostid(void *zone)
 		    (rc = hostid_read()) && (rc = hostid_exec()))
 			return HW_INVALID_HOSTID;
 
+                (void) snprintf(hw_serial, HW_HOSTID_LEN, "%lu", spl_hostid);
+                hw_serial[HW_HOSTID_LEN - 1] = '\0';
+
 		printk(KERN_NOTICE "SPL: using hostid 0x%08x\n",
 			(unsigned int) spl_hostid);
 	}

--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -513,8 +513,6 @@ SPL_PROC_HANDLER(proc_dohostid)
                 if (str == end)
                         SRETURN(-EINVAL);
 
-                (void) snprintf(hw_serial, HW_HOSTID_LEN, "%lu", spl_hostid);
-                hw_serial[HW_HOSTID_LEN - 1] = '\0';
                 *ppos += *lenp;
         } else {
                 len = snprintf(str, sizeof(str), "%lx", spl_hostid);


### PR DESCRIPTION
By jumping through userspace, hostid_exec triggers a write to the proc
write helper for hostid. This, in addition to setting hostid, writes
the hostid into the hw_serial string. This isn't done for the
hostid_read path. The fix is to factor this code out to
zone_get_hostid.

The side-effect of not having hw_serial set is that no hostid is
written to pools on "zpool export". Check that
/proc/sys/kernel/spl/hw_serial is "<none>", create a new pool, and
export it. Verify that zdb -CC -e yourpool doesn't show your hostid.
Run "hostid 1> /proc/sys/kernel/spl/hostid" and redo the above. Now
your pool has a hostid.

This is partially described in:
https://groups.google.com/a/zfsonlinux.org/forum/#!topic/zfs-discuss/UekOyCd1OO0
