### PR TITLE
Call kthread_create() correctly with fixed arguments.

### DIFF
--- a/module/spl/spl-thread.c
+++ b/module/spl/spl-thread.c
@@ -148,10 +148,13 @@ spl_kthread_create(int (*func)(void *), void *data, const char namefmt[], ...)
 {
 	struct task_struct *tsk;
 	va_list args;
+	char name[TASK_COMM_LEN];
 
 	va_start(args, namefmt);
+	vsnprintf(name, sizeof(name), namefmt, args);
+	va_end(args);
 	do {
-		tsk = kthread_create(func, data, namefmt, args);
+		tsk = kthread_create(func, data, "%s", name);
 		if (IS_ERR(tsk)) {
 			if (signal_pending(current)) {
 				clear_thread_flag(TIF_SIGPENDING);


### PR DESCRIPTION
The kernel's kthread_create() function is defined as "..." and there is
no va_list variant at the moment.  The task name is pre-formatted into
a local buffer and passed to kthread_create() with fixed arguments.

Fixes #347.
