### PR TITLE
Linux 3.15 compat: NICE_TO_PRIO and vfs_rename

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -1907,7 +1907,28 @@ AC_DEFUN([SPL_AC_4ARGS_VFS_RENAME],
 			AC_DEFINE(HAVE_5ARGS_VFS_RENAME, 1,
 				  [vfs_rename() wants 5 args])
 		],[
-			AC_MSG_ERROR(no)
+			AC_MSG_RESULT(no)
+			dnl #
+			dnl # Linux 3.15 API change
+			dnl # Added flags
+			dnl #
+			AC_MSG_CHECKING([whether vfs_rename() wants 6 args])
+			SPL_LINUX_TRY_COMPILE([
+				#include <linux/fs.h>
+			],[
+				vfs_rename((struct inode *) NULL,
+					(struct dentry *) NULL,
+					(struct inode *) NULL,
+					(struct dentry *) NULL,
+					(struct inode **) NULL,
+					(unsigned int) 0);
+			],[
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_6ARGS_VFS_RENAME, 1,
+					  [vfs_rename() wants 6 args])
+			],[
+				AC_MSG_ERROR(no)
+			])
 		])
 	])
 ])

--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -95,8 +95,12 @@
 #define minclsyspri			(MAX_RT_PRIO)
 #define maxclsyspri			(MAX_PRIO-1)
 
+#ifndef NICE_TO_PRIO
 #define NICE_TO_PRIO(nice)		(MAX_RT_PRIO + (nice) + 20)
+#endif
+#ifndef PRIO_TO_NICE
 #define PRIO_TO_NICE(prio)		((prio) - MAX_RT_PRIO - 20)
+#endif
 
 /* Missing macros
  */

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -417,9 +417,12 @@ vn_rename(const char *oldname, const char *newname, int x1)
 #ifdef HAVE_4ARGS_VFS_RENAME
 	rc = vfs_rename(old_dir->d_inode, old_dentry,
 	    new_dir->d_inode, new_dentry);
-#else
+#elif defined(HAVE_5ARGS_VFS_RENAME)
 	rc = vfs_rename(old_dir->d_inode, old_dentry,
 	    new_dir->d_inode, new_dentry, NULL);
+#else
+	rc = vfs_rename(old_dir->d_inode, old_dentry,
+	    new_dir->d_inode, new_dentry, NULL, 0);
 #endif /* HAVE_4ARGS_VFS_RENAME */
 exit4:
 	unlock_rename(new_dir, old_dir);
@@ -577,9 +580,12 @@ vn_rename(const char *oldname, const char *newname, int x1)
 #ifdef HAVE_4ARGS_VFS_RENAME
 	rc = vfs_rename(old_dir->d_inode, old_dentry,
 	    new_dir->d_inode, new_dentry);
-#else
+#elif defined(HAVE_5ARGS_VFS_RENAME)
 	rc = vfs_rename(old_dir->d_inode, old_dentry,
 	    new_dir->d_inode, new_dentry, NULL);
+#else
+	rc = vfs_rename(old_dir->d_inode, old_dentry,
+	    new_dir->d_inode, new_dentry, NULL, 0);
 #endif /* HAVE_4ARGS_VFS_RENAME */
 exit5:
         dput(new_dentry);


### PR DESCRIPTION
Linux 3.15 changes:
1. NICE_TO_PRIO and PRIO_TO_NICE are now exported.
2. vfs_rename takes an additional flags argument.

Signed-off-by: Chunwei Chen tuxoko@gmail.com
