### PR TITLE
Support parallel build trees (VPATH builds)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,9 @@
 
 ACLOCAL_AMFLAGS = -I config
 
-include $(top_srcdir)/config/rpm.am
-include $(top_srcdir)/config/deb.am
-include $(top_srcdir)/config/tgz.am
+include config/rpm.am
+include config/deb.am
+include config/tgz.am
 
 SUBDIRS = include rpm
 if CONFIG_USER
@@ -40,11 +40,11 @@ dist-hook:
 		$(distdir)/META
 
 ctags:
-	$(RM) $(top_srcdir)/tags
+	$(RM) tags
 	find $(top_srcdir) -name .git -prune -o -name '*.[hc]' | xargs ctags
 
 etags:
-	$(RM) $(top_srcdir)/TAGS
+	$(RM) TAGS
 	find $(top_srcdir) -name .pc -prune -o -name '*.[hc]' | xargs etags -a
 
 tags: ctags etags

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -6,9 +6,9 @@ DEFAULT_INCLUDES += \
 noinst_PROGRAMS = spl
 sbin_PROGRAMS = splat
 
-spl_SOURCES = spl.c
+spl_SOURCES = $(top_srcdir)/cmd/spl.c
 
-splat_SOURCES = splat.c
+splat_SOURCES = $(top_srcdir)/cmd/splat.c
 splat_LDFLAGS = $(top_builddir)/lib/libcommon.la
 
-EXTRA_DIST = splat.h
+EXTRA_DIST = $(top_srcdir)/cmd/splat.h

--- a/include/util/Makefile.am
+++ b/include/util/Makefile.am
@@ -2,7 +2,7 @@ COMMON_H =
 
 KERNEL_H = \
 	$(top_srcdir)/include/util/qsort.h \
-        $(top_srcdir)/include/util/sscanf.h
+	$(top_srcdir)/include/util/sscanf.h
 
 USER_H =
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/config/Rules.am
 
 noinst_LTLIBRARIES = libcommon.la
-libcommon_la_SOURCES = list.c
+libcommon_la_SOURCES = $(top_srcdir)/lib/list.c
 
-EXTRA_DIST = list.h
+EXTRA_DIST = $(top_srcdir)/lib/list.h

--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -1,4 +1,4 @@
-dist_man_MANS = splat.1
+dist_man_MANS = $(top_srcdir)/man/man1/splat.1
 
 install-data-local:
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(mandir)/man1"

--- a/man/man5/Makefile.am
+++ b/man/man5/Makefile.am
@@ -1,4 +1,4 @@
-dist_man_MANS = spl-module-parameters.5
+dist_man_MANS = $(top_srcdir)/man/man5/spl-module-parameters.5
 
 install-data-local:
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(mandir)/man5"

--- a/module/spl/Makefile.in
+++ b/module/spl/Makefile.in
@@ -1,27 +1,30 @@
 # Makefile.in for spl kernel module
 
+src = @abs_top_srcdir@/module/spl
+obj = @abs_builddir@
+
 MODULE := spl
 EXTRA_CFLAGS = $(SPL_MODULE_CFLAGS) @KERNELCPPFLAGS@
 
 # Solaris porting layer module
 obj-$(CONFIG_SPL) := $(MODULE).o
 
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-debug.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-proc.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-kmem.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-thread.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-taskq.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-rwlock.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-vnode.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-err.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-time.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-kobj.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-generic.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-atomic.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-mutex.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-kstat.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-condvar.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-xdr.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-cred.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-tsd.o
-$(MODULE)-objs += @top_srcdir@/module/spl/spl-zlib.o
+$(MODULE)-objs += spl-debug.o
+$(MODULE)-objs += spl-proc.o
+$(MODULE)-objs += spl-kmem.o
+$(MODULE)-objs += spl-thread.o
+$(MODULE)-objs += spl-taskq.o
+$(MODULE)-objs += spl-rwlock.o
+$(MODULE)-objs += spl-vnode.o
+$(MODULE)-objs += spl-err.o
+$(MODULE)-objs += spl-time.o
+$(MODULE)-objs += spl-kobj.o
+$(MODULE)-objs += spl-generic.o
+$(MODULE)-objs += spl-atomic.o
+$(MODULE)-objs += spl-mutex.o
+$(MODULE)-objs += spl-kstat.o
+$(MODULE)-objs += spl-condvar.o
+$(MODULE)-objs += spl-xdr.o
+$(MODULE)-objs += spl-cred.o
+$(MODULE)-objs += spl-tsd.o
+$(MODULE)-objs += spl-zlib.o

--- a/module/splat/Makefile.in
+++ b/module/splat/Makefile.in
@@ -1,25 +1,28 @@
 # Makefile.in for splat kernel module
 
+src = @abs_top_srcdir@/module/splat
+obj = @abs_builddir@
+
 MODULE := splat
 EXTRA_CFLAGS = $(SPL_MODULE_CFLAGS) @KERNELCPPFLAGS@
 
 # Solaris Porting LAyer Tests
 obj-$(CONFIG_SPL) := $(MODULE).o
 
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-ctl.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-kmem.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-taskq.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-random.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-mutex.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-condvar.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-thread.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-rwlock.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-time.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-vnode.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-kobj.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-atomic.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-list.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-generic.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-cred.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-zlib.o
-$(MODULE)-objs += @top_srcdir@/module/splat/splat-linux.o
+$(MODULE)-objs += splat-ctl.o
+$(MODULE)-objs += splat-kmem.o
+$(MODULE)-objs += splat-taskq.o
+$(MODULE)-objs += splat-random.o
+$(MODULE)-objs += splat-mutex.o
+$(MODULE)-objs += splat-condvar.o
+$(MODULE)-objs += splat-thread.o
+$(MODULE)-objs += splat-rwlock.o
+$(MODULE)-objs += splat-time.o
+$(MODULE)-objs += splat-vnode.o
+$(MODULE)-objs += splat-kobj.o
+$(MODULE)-objs += splat-atomic.o
+$(MODULE)-objs += splat-list.o
+$(MODULE)-objs += splat-generic.o
+$(MODULE)-objs += splat-cred.o
+$(MODULE)-objs += splat-zlib.o
+$(MODULE)-objs += splat-linux.o

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,4 +1,4 @@
 EXTRA_DIST = check.sh dkms.mkconf dkms.postinst kmodtool
 
 check:
-	$(top_srcdir)/scripts/check.sh
+	scripts/check.sh


### PR DESCRIPTION
Add VPATH to make sure it's possible in a different directory and not
clutter the source with build results (such as Makefiles, *.o and *.a
files etc).

Seehttps://github.com/zfsonlinux/zfs/pull/2378 for ZFS part of the fix.

Closes: zfsonlinux/zfs#1082