### PR TITLE
Rate limit debugging stack traces

### DIFF
--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -725,7 +725,7 @@ kmem_alloc_debug(size_t size, int flags, const char *func, int line,
 		    "large kmem_alloc(%llu, 0x%x) at %s:%d (%lld/%llu)\n",
 		    (unsigned long long) size, flags, func, line,
 		    kmem_alloc_used_read(), kmem_alloc_max);
-		dump_stack();
+		spl_debug_dumpstack(NULL);
 	}
 
 	/* Use the correct allocator */


### PR DESCRIPTION
There have been issues in the past where excessive debug logging
to the console has resulted in significant performance impacts.
In the vast majority of these cases only a few stack traces are
required to diagnose the issue.  Therefore, stack traces dumped to
the console will now we limited to 5 every 60s.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #374
