### PR TITLE
Linux 3.17 compat: remove wait_on_bit action function

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -94,6 +94,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_2ARGS_VFS_GETATTR
 	SPL_AC_USLEEP_RANGE
 	SPL_AC_KMEM_CACHE_ALLOCFLAGS
+	SPL_AC_WAIT_ON_BIT
 ])
 
 AC_DEFUN([SPL_AC_MODULE_SYMVERS], [
@@ -2568,5 +2569,30 @@ AC_DEFUN([SPL_AC_KMEM_CACHE_ALLOCFLAGS], [
 		],[
 			AC_MSG_RESULT(no)
 		])
+	])
+])
+
+dnl #
+dnl # 3.17 API change,
+dnl # wait_on_bit() no longer requires an action argument. The former
+dnl # "wait_on_bit" interface required an 'action' function to be provided
+dnl # which does the actual waiting. There were over 20 such functions in the
+dnl # kernel, many of them identical, though most cases can be satisfied by one
+dnl # of just two functions: one which uses io_schedule() and one which just
+dnl # uses schedule().  This API change was made to consolidate all of those
+dnl # redundant wait functions.
+dnl #
+AC_DEFUN([SPL_AC_WAIT_ON_BIT], [
+	AC_MSG_CHECKING([whether wait_on_bit() takes an action])
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/wait.h>
+	],[
+		int (*action)(void *) = NULL;
+		wait_on_bit(NULL, 0, action, 0);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_WAIT_ON_BIT_ACTION, 1, [yes])
+	],[
+		AC_MSG_RESULT(no)
 	])
 ])

--- a/include/linux/Makefile.am
+++ b/include/linux/Makefile.am
@@ -17,6 +17,7 @@ KERNEL_H = \
 	$(top_srcdir)/include/linux/sysctl_compat.h \
 	$(top_srcdir)/include/linux/time_compat.h \
 	$(top_srcdir)/include/linux/uaccess_compat.h \
+	$(top_srcdir)/include/linux/wait_compat.h \
 	$(top_srcdir)/include/linux/zlib_compat.h
 
 USER_H =

--- a/include/linux/wait_compat.h
+++ b/include/linux/wait_compat.h
@@ -1,0 +1,45 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2014 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+\*****************************************************************************/
+
+#ifndef _SPL_WAIT_COMPAT_H
+#define _SPL_WAIT_COMPAT_H
+
+
+#ifndef HAVE_WAIT_ON_BIT_ACTION
+#  define spl_wait_on_bit(word, bit, mode) wait_on_bit(word, bit, mode)
+#else
+
+static inline int
+spl_bit_wait(void *word)
+{
+        schedule();
+        return 0;
+}
+
+#define spl_wait_on_bit(word, bit, mode)			\
+	wait_on_bit(word, bit, spl_bit_wait, mode)
+
+#endif /* HAVE_WAIT_ON_BIT_ACTION */
+
+#endif /* SPL_WAIT_COMPAT_H */

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -43,6 +43,7 @@
 #include <linux/zlib_compat.h>
 #include <linux/mm_compat.h>
 #include <linux/delay.h>
+#include <linux/wait_compat.h>
 
 #ifndef HAVE_UINTPTR_T
 typedef unsigned long			uintptr_t;

--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -1900,13 +1900,6 @@ spl_cache_grow_wait(spl_kmem_cache_t *skc)
 	return !test_bit(KMC_BIT_GROWING, &skc->skc_flags);
 }
 
-static int
-spl_cache_reclaim_wait(void *word)
-{
-	schedule();
-	return 0;
-}
-
 /*
  * No available objects on any slabs, create a new slab.  Note that this
  * functionality is disabled for KMC_SLAB caches which are backed by the
@@ -1928,8 +1921,8 @@ spl_cache_grow(spl_kmem_cache_t *skc, int flags, void **obj)
 	 * then return so the local magazine can be rechecked for new objects.
 	 */
 	if (test_bit(KMC_BIT_REAPING, &skc->skc_flags)) {
-		rc = wait_on_bit(&skc->skc_flags, KMC_BIT_REAPING,
-		    spl_cache_reclaim_wait, TASK_UNINTERRUPTIBLE);
+		rc = spl_wait_on_bit(&skc->skc_flags, KMC_BIT_REAPING,
+		    TASK_UNINTERRUPTIBLE);
 		SRETURN(rc ? rc : -EAGAIN);
 	}
 


### PR DESCRIPTION
Linux kernel 3.17 removes the action function argument
from wait_on_bit().  Add autoconf test and compatibility
macro to support new interface.

References:
    torvalds/linux@7431620

Signed-off-by: Ned Bass bass6@llnl.gov

Closes zfsonlinux/spl#378
