### PR TITLE
Kernel header installation should respect --prefix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,10 +12,10 @@ endif
 if CONFIG_KERNEL
 SUBDIRS += module
 
-extradir = /usr/src/spl-$(VERSION)
+extradir = @prefix@/src/spl-$(VERSION)
 extra_HEADERS = spl.release.in spl_config.h.in
 
-kerneldir = /usr/src/spl-$(VERSION)/$(LINUX_VERSION)
+kerneldir = @prefix@/src/spl-$(VERSION)/$(LINUX_VERSION)
 nodist_kernel_HEADERS = spl.release spl_config.h module/$(LINUX_SYMBOLS)
 endif
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -16,6 +16,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include
+kerneldir = @prefix@/src/spl-$(VERSION)/include
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/fs/Makefile.am
+++ b/include/fs/Makefile.am
@@ -8,6 +8,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/fs
+kerneldir = @prefix@/src/spl-$(VERSION)/include/fs
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/linux/Makefile.am
+++ b/include/linux/Makefile.am
@@ -24,6 +24,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/linux
+kerneldir = @prefix@/src/spl-$(VERSION)/include/linux
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/rpc/Makefile.am
+++ b/include/rpc/Makefile.am
@@ -9,6 +9,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/rpc
+kerneldir = @prefix@/src/spl-$(VERSION)/include/rpc
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/sharefs/Makefile.am
+++ b/include/sharefs/Makefile.am
@@ -8,6 +8,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/sharefs
+kerneldir = @prefix@/src/spl-$(VERSION)/include/sharefs
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -105,7 +105,7 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/sys
+kerneldir = @prefix@/src/spl-$(VERSION)/include/sys
 kernel_HEADERS = $(KERNEL_H)
 endif
 

--- a/include/sys/fm/Makefile.am
+++ b/include/sys/fm/Makefile.am
@@ -9,6 +9,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/sys/fm
+kerneldir = @prefix@/src/spl-$(VERSION)/include/sys/fm
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/sys/fs/Makefile.am
+++ b/include/sys/fs/Makefile.am
@@ -8,6 +8,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/sys/fs
+kerneldir = @prefix@/src/spl-$(VERSION)/include/sys/fs
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/sys/sysevent/Makefile.am
+++ b/include/sys/sysevent/Makefile.am
@@ -8,6 +8,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/sys/sysevent
+kerneldir = @prefix@/src/spl-$(VERSION)/include/sys/sysevent
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/util/Makefile.am
+++ b/include/util/Makefile.am
@@ -9,6 +9,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/util
+kerneldir = @prefix@/src/spl-$(VERSION)/include/util
 kernel_HEADERS = $(KERNEL_H)
 endif

--- a/include/vm/Makefile.am
+++ b/include/vm/Makefile.am
@@ -10,6 +10,6 @@ USER_H =
 EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
 
 if CONFIG_KERNEL
-kerneldir = /usr/src/spl-$(VERSION)/include/vm
+kerneldir = @prefix@/src/spl-$(VERSION)/include/vm
 kernel_HEADERS = $(KERNEL_H)
 endif


### PR DESCRIPTION
This is the upstream component of work that enables preliminary support
for building Gentoo's ZFS packaging on other Linux systems via Gentoo
Prefix.

Signed-off-by: Richard Yao richard.yao@clusterhq.com
