### PR TITLE
Add support for signing kernel modules

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -242,6 +242,8 @@ dnl #
 AC_DEFUN([SPL_AC_RPM], [
 	RPM=rpm
 	RPMBUILD=rpmbuild
+	RPMKEYDIR=$(printf "%s/module" $(pwd))
+	AC_SUBST(RPMKEYDIR)
 
 	AC_MSG_CHECKING([whether $RPM is available])
 	AS_IF([tmp=$($RPM --version 2>/dev/null)], [
@@ -265,7 +267,7 @@ AC_DEFUN([SPL_AC_RPM], [
 
 	RPM_DEFINE_COMMON='--define "$(DEBUG_SPL) 1" --define "$(DEBUG_LOG) 1" --define "$(DEBUG_KMEM) 1" --define "$(DEBUG_KMEM_TRACKING) 1"'
 	RPM_DEFINE_UTIL=
-	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)"'
+	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)" --define "seckey $(RPMKEYDIR)/signing_key.priv" --define "pubkey $(RPMKEYDIR)/signing_key.x509"'
 	RPM_DEFINE_DKMS=
 
 	SRPM_DEFINE_COMMON='--define "build_src_rpm 1"'

--- a/module/.gitignore
+++ b/module/.gitignore
@@ -9,3 +9,5 @@ modules.order
 /.tmp_versions
 /Module.markers
 /Module.symvers
+/signing_key.priv
+/signing_key.x509

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -7,6 +7,12 @@ SPL_MODULE_CFLAGS  = -I@abs_top_srcdir@/include
 SPL_MODULE_CFLAGS += -include @abs_top_builddir@/spl_config.h
 export SPL_MODULE_CFLAGS
 
+SECKEY ?= ./signing_key.priv
+PUBKEY ?= ./signing_key.x509
+SIGNHASH ?= sha256
+SIGNFILE ?= @LINUX_OBJ@/scripts/sign-file
+SIGNCMD = $(SIGNFILE) $(SIGNHASH) $(SECKEY) $(PUBKEY)
+
 modules:
 	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ CONFIG_SPL=m $@
 
@@ -17,6 +23,12 @@ clean:
 
 	if [ -f @LINUX_SYMBOLS@ ]; then $(RM) @LINUX_SYMBOLS@; fi
 	if [ -f Module.markers ]; then $(RM) Module.markers; fi
+
+modules_sign:
+	@# Sign the modules if the required signing keys are available.
+	if [ -f $(SECKEY) ] && [ -f $(PUBKEY) ] && [ -x $(SIGNFILE) ]; then \
+		find . -name '*.ko' -exec $(SIGNCMD) {} \;; \
+	fi
 
 modules_install:
 	@# Install the kernel modules
@@ -49,5 +61,5 @@ distdir:
 distclean maintainer-clean: clean
 install: modules_install
 uninstall: modules_uninstall
-all: modules
+all: modules modules_sign
 check:

--- a/rpm/generic/spl-kmod.spec.in
+++ b/rpm/generic/spl-kmod.spec.in
@@ -13,6 +13,13 @@
 %bcond_with     debug_kmem_tracking
 %bcond_with     atomic_spinlocks
 
+%if %{defined seckey}
+%define _seckey SECKEY=%{seckey}
+%endif
+
+%if %{defined pubkey}
+%define _pubkey PUBKEY=%{pubkey}
+%endif
 
 Name:           %{module}-kmod
 
@@ -135,7 +142,7 @@ for kernel_version in %{?kernel_versions}; do
         %{debug_kmem} \
         %{debug_kmem_tracking} \
         %{atomic_spinlocks}
-    make %{?_smp_mflags}
+    make %{?_smp_mflags} %{?_seckey} %{?_pubkey}
     cd ..
 done
 


### PR DESCRIPTION
Linux kernels which are built with CONFIG_MODULE_SIG support the
cryptographic signing of modules.  When in "permissive" mode
unsigned modules or signed modules with an unknown key will by
allowed to load but will mark the kernel as tainted.  When in
"restrictive" mode only modules signed with a known key will be
allowed to load.

This patch updates the build system so that it will automatically
sign modules if the required public and private keys are available.
These keys are generated as part of the kernel build process and
are named "signing_key.priv" and "signing_key.x509".  Placing a
copy of these keys in the ./modules/ directory will cause the
modules to be signed as part of the build process.  Alternately,
the SECKEY and PUBKEY variables may be set to specify a different
location.

make SECKEY=~/signing_key.priv PUBKEY=~/signing_key.x509

For additional information about signed kernel modules refer to
the documentation privided in the Linux kernel documentation.

https://www.kernel.org/doc/Documentation/module-signing.txt

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>