### PR TITLE
Fix memory leak in spl utility

### DIFF
--- a/cmd/spl.c
+++ b/cmd/spl.c
@@ -169,6 +169,7 @@ parse_buffer(FILE *in, FILE *out)
                 line->text = p;
 
                 if (!add_rec(line, &linev, &linev_len, kept)) {
+                        free(line);
                         fprintf(stderr, "malloc failed; printing accumulated "
                                 "records and exiting.\n");
                         break;


### PR DESCRIPTION
Detected by the clang static analyzer, a memory leak was possible
in the case when a realloc(3) failed.  In practice this very unlikely
to happen and even if it did the utility is short lived so it wouldn't
be a problem.  Nevertheless this analysis is correct as this patch
resolves the leak.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
Issue #400
