### PR TITLE
Rename SHRINK_STOP to SPL_SHRINK_STOP

### DIFF
--- a/include/linux/mm_compat.h
+++ b/include/linux/mm_compat.h
@@ -190,7 +190,7 @@ fn ## _scan_objects(struct shrinker *shrink, struct shrink_control *sc)	\
 	int __ret__;							\
 									\
 	__ret__ = __ ## fn(NULL, sc);					\
-	return ((__ret__ < 0) ? SHRINK_STOP : __ret__);			\
+	return ((__ret__ < 0) ? SPL_SHRINK_STOP : __ret__);		\
 }
 #else
 /*
@@ -201,9 +201,10 @@ fn ## _scan_objects(struct shrinker *shrink, struct shrink_control *sc)	\
 
 #if defined(HAVE_SPLIT_SHRINKER_CALLBACK)
 typedef unsigned long	spl_shrinker_t;
+#define	SPL_SHRINK_STOP	SHRINK_STOP
 #else
 typedef int		spl_shrinker_t;
-#define	SHRINK_STOP	(-1)
+#define	SPL_SHRINK_STOP	(-1)
 #endif
 
 #endif /* SPL_MM_COMPAT_H */

--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -2095,7 +2095,7 @@ __spl_kmem_cache_generic_shrinker(struct shrinker *shrink,
 	 * system to thrash.
 	 */
 	if ((spl_kmem_cache_reclaim & KMC_RECLAIM_ONCE) && sc->nr_to_scan)
-		return (SHRINK_STOP);
+		return (SPL_SHRINK_STOP);
 
 	return (MAX(alloc, 0));
 }

--- a/module/splat/splat-linux.c
+++ b/module/splat/splat-linux.c
@@ -87,7 +87,7 @@ __splat_linux_shrinker_fn(struct shrinker *shrink, struct shrink_control *sc)
 		splat_vprint(splat_linux_shrinker_file, SPLAT_LINUX_TEST1_NAME,
 		    "Far more calls than expected (%d), size now %lu\n",
 		   failsafe, splat_linux_shrinker_size);
-		return (SHRINK_STOP);
+		return (SPL_SHRINK_STOP);
 	} else {
 		/*
 		 * We only increment failsafe if it doesn't trigger.  This


### PR DESCRIPTION
Rename SHRINK_STOP to SPL_SHRINK_STOP to avoid namespace conflicts with
Lustre. On older kernels, SPL defines SHRINK_STOP to -1 for backward
compatbility with the return value of the shrinker implementation
predating the Linux 3.12 shrinker API changes. The conflict arises
because Lustre's 3.12 compatbility code defines SHRINK_STOP to 0 for
older kernels (which is consistent with the Linux value), and their
osd-zfs module (indirectly) includes SPL's linux/mm_compat.h header.
This leads to a 'SHRINK_STOP redefined' build error. Add a SPL_ prefix
to resolve the conflict.

Signed-off-by: Ned Bass bass6@llnl.gov
