### PR TITLE
Remove compat includes from sys/types.h

### DIFF
--- a/include/linux/wait_compat.h
+++ b/include/linux/wait_compat.h
@@ -25,6 +25,7 @@
 #ifndef _SPL_WAIT_COMPAT_H
 #define _SPL_WAIT_COMPAT_H
 
+#include <linux/sched.h>
 
 #ifndef HAVE_WAIT_ON_BIT_ACTION
 #  define spl_wait_on_bit(word, bit, mode) wait_on_bit(word, bit, mode)

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -28,18 +28,6 @@
 #include <linux/types.h>
 #include <sys/sysmacros.h>
 
-#include <linux/file_compat.h>
-#include <linux/list_compat.h>
-#include <linux/bitops_compat.h>
-#include <linux/module_compat.h>
-#include <linux/proc_compat.h>
-#include <linux/math64_compat.h>
-#include <linux/zlib_compat.h>
-#include <linux/mm_compat.h>
-#include <linux/delay.h>
-#include <linux/wait_compat.h>
-#include <linux/uaccess.h>
-
 #ifndef ULLONG_MAX
 #define ULLONG_MAX			(~0ULL)
 #endif

--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -39,6 +39,7 @@
 #include <sys/kstat.h>
 #include <sys/file.h>
 #include <linux/kmod.h>
+#include <linux/math64_compat.h>
 #include <linux/proc_compat.h>
 #include <spl-debug.h>
 

--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -26,6 +26,8 @@
 
 #include <sys/kmem.h>
 #include <spl-debug.h>
+#include <linux/mm_compat.h>
+#include <linux/wait_compat.h>
 
 #ifdef SS_DEBUG_SUBSYS
 #undef SS_DEBUG_SUBSYS

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -27,6 +27,7 @@
 #include <sys/cred.h>
 #include <sys/vnode.h>
 #include <linux/falloc.h>
+#include <linux/file_compat.h>
 #include <spl-debug.h>
 
 #ifdef SS_DEBUG_SUBSYS

--- a/module/spl/spl-zlib.c
+++ b/module/spl/spl-zlib.c
@@ -55,6 +55,7 @@
 
 #include <sys/kmem.h>
 #include <sys/zmod.h>
+#include <linux/zlib_compat.h>
 #include <spl-debug.h>
 
 #ifdef DEBUG_SUBSYSTEM

--- a/module/splat/splat-atomic.c
+++ b/module/splat/splat-atomic.c
@@ -27,6 +27,7 @@
 #include <sys/atomic.h>
 #include <sys/thread.h>
 #include <sys/mutex.h>
+#include <linux/mm_compat.h>
 #include <linux/slab.h>
 #include "splat-internal.h"
 

--- a/module/splat/splat-ctl.c
+++ b/module/splat/splat-ctl.c
@@ -43,16 +43,17 @@
  *  of regression tests or particular tests.
 \*****************************************************************************/
 
-#include <linux/module.h>
-#include <linux/slab.h>
-#include <linux/vmalloc.h>
-#include <linux/cdev.h>
-#include <linux/fs.h>
-#include <linux/uaccess.h>
-#include <linux/miscdevice.h>
-#include <sys/types.h>
 #include <sys/debug.h>
 #include <sys/mutex.h>
+#include <sys/types.h>
+#include <linux/cdev.h>
+#include <linux/fs.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/module_compat.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/vmalloc.h>
 #include "splat-internal.h"
 
 static struct list_head splat_module_list;

--- a/module/splat/splat-generic.c
+++ b/module/splat/splat-generic.c
@@ -25,6 +25,7 @@
 \*****************************************************************************/
 
 #include <sys/sunddi.h>
+#include <linux/math64_compat.h>
 #include "splat-internal.h"
 
 #define SPLAT_GENERIC_NAME		"generic"

--- a/module/splat/splat-linux.c
+++ b/module/splat/splat-linux.c
@@ -24,6 +24,7 @@
 \*****************************************************************************/
 
 #include <sys/kmem.h>
+#include <linux/mm_compat.h>
 #include "splat-internal.h"
 
 #define SPLAT_LINUX_NAME		"linux"

--- a/module/splat/splat-mutex.c
+++ b/module/splat/splat-mutex.c
@@ -26,6 +26,8 @@
 
 #include <sys/mutex.h>
 #include <sys/taskq.h>
+#include <linux/delay.h>
+#include <linux/mm_compat.h>
 #include "splat-internal.h"
 
 #define SPLAT_MUTEX_NAME                "mutex"

--- a/module/splat/splat-rwlock.c
+++ b/module/splat/splat-rwlock.c
@@ -24,9 +24,11 @@
  *  Solaris Porting LAyer Tests (SPLAT) Read/Writer Lock Tests.
 \*****************************************************************************/
 
+#include <sys/random.h>
 #include <sys/rwlock.h>
 #include <sys/taskq.h>
-#include <sys/random.h>
+#include <linux/delay.h>
+#include <linux/mm_compat.h>
 #include "splat-internal.h"
 
 #define SPLAT_RWLOCK_NAME		"rwlock"

--- a/module/splat/splat-taskq.c
+++ b/module/splat/splat-taskq.c
@@ -24,9 +24,10 @@
  *  Solaris Porting LAyer Tests (SPLAT) Task Queue Tests.
 \*****************************************************************************/
 
-#include <sys/taskq.h>
-#include <sys/random.h>
 #include <sys/kmem.h>
+#include <sys/random.h>
+#include <sys/taskq.h>
+#include <linux/delay.h>
 #include "splat-internal.h"
 
 #define SPLAT_TASKQ_NAME		"taskq"

--- a/module/splat/splat-thread.c
+++ b/module/splat/splat-thread.c
@@ -26,6 +26,8 @@
 
 #include <sys/thread.h>
 #include <sys/random.h>
+#include <linux/delay.h>
+#include <linux/mm_compat.h>
 #include <linux/slab.h>
 #include "splat-internal.h"
 

--- a/module/splat/splat-time.c
+++ b/module/splat/splat-time.c
@@ -25,6 +25,7 @@
 \*****************************************************************************/
 
 #include <sys/time.h>
+#include <linux/mm_compat.h>
 #include <linux/slab.h>
 #include "splat-internal.h"
 


### PR DESCRIPTION
Don't include the compatibility code in linux/*_compat.h in the public
header sys/types.h. This causes problems when an external code base
includes the ZFS headers and has its own conflicting compatibility code.
Lustre, in particular, defined SHRINK_STOP for compatibility with
pre-3.12 kernels in a way that conflicted with the SPL's definition.
Because Lustre ZFS OSD includes ZFS headers it fails to build due to a
'"SHRINK_STOP" redefined' compiler warning.  To avoid such conflicts
only include the compat headers from .c files or private headers.

Also, for consistency, include sys/_.h before linux/_.h then sort by
header name.

Signed-off-by: Ned Bass bass6@llnl.gov
