### PR TITLE
Replace P2ROUNDUP* macro implementations by Linux kernel variants.

### DIFF
--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -184,7 +184,7 @@ extern void spl_cleanup(void);
  */
 #define P2ALIGN(x, align)	((x) & -(align))
 #define P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
-#define P2ROUNDUP(x, align)	(-(-(x) & -(align)))
+#define P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
 #define P2PHASE(x, align)	((x) & ((align) - 1))
 #define P2NPHASE(x, align)	(-(x) & ((align) - 1))
 #define ISP2(x)			(((x) & ((x) - 1)) == 0)
@@ -211,7 +211,7 @@ extern void spl_cleanup(void);
 #define P2NPHASE_TYPED(x, align, type)  \
         (-(type)(x) & ((type)(align) - 1))
 #define P2ROUNDUP_TYPED(x, align, type) \
-        (-(-(type)(x) & -(type)(align)))
+        ((((x) - 1) | ((type)((align) - 1))) + 1)
 #define P2END_TYPED(x, align, type)     \
         (-(~(type)(x) & -(type)(align)))
 #define P2PHASEUP_TYPED(x, align, phase, type)  \


### PR DESCRIPTION
This replaces the implementation of P2ROUNDUP* by the implementation used in Linux's `round_up()` macro: http://lxr.free-electrons.com/source/include/linux/kernel.h?v=3.2#L53. This implementation does not trigger PaX' overflow detection erroneously and thus would fix [issue 2505](https://github.com/zfsonlinux/zfs/issues/2505). It was tested by @perfinion and found to be indeed fixing the issue, but a more detailed review is understandable and probably desirable.