### PR TITLE
Use current_kernel_time() in the time compatibility wrappers

### DIFF
--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -54,17 +54,14 @@
 static inline void
 gethrestime(timestruc_t *now)
 {
-	struct timespec ts;
-	getnstimeofday(&ts);
-	now->tv_sec = ts.tv_sec;
-	now->tv_nsec = ts.tv_nsec;
+	*now = current_kernel_time();
 }
 
 static inline time_t
 gethrestime_sec(void)
 {
 	struct timespec ts;
-	getnstimeofday(&ts);
+	ts = current_kernel_time();
 	return (ts.tv_sec);
 }
 


### PR DESCRIPTION
Since the Linux kernel's utimens family of functions uses
current_kernel_time(), we need to do the same in the context of ZFS
or else there can be discrepencies in timestamps (they go backward)
if userland code does:

	fd = creat(FNAME, 0600);
	(void) futimens(fd, NULL);

The getnstimeofday() function generally returns a slightly lower time
value.