### PR TITLE
Fix GFP_KERNEL allocations flags

### DIFF
--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -80,7 +80,7 @@ kmem_vasprintf(const char *fmt, va_list ap)
 
 	do {
 		va_copy(aq, ap);
-		ptr = kvasprintf(GFP_KERNEL, fmt, aq);
+		ptr = kvasprintf(kmem_flags_convert(KM_SLEEP), fmt, aq);
 		va_end(aq);
 	} while (ptr == NULL);
 
@@ -96,7 +96,7 @@ kmem_asprintf(const char *fmt, ...)
 
 	do {
 		va_start(ap, fmt);
-		ptr = kvasprintf(GFP_KERNEL, fmt, ap);
+		ptr = kvasprintf(kmem_flags_convert(KM_SLEEP), fmt, ap);
 		va_end(ap);
 	} while (ptr == NULL);
 

--- a/module/spl/spl-kobj.c
+++ b/module/spl/spl-kobj.c
@@ -33,7 +33,7 @@ kobj_open_file(const char *name)
 	vnode_t *vp;
 	int rc;
 
-	file = kmalloc(sizeof(_buf_t), GFP_KERNEL);
+	file = kmalloc(sizeof(_buf_t), kmem_flags_convert(KM_SLEEP));
 	if (file == NULL)
 		return ((_buf_t *)-1UL);
 

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -196,7 +196,7 @@ vn_openat(const char *path, uio_seg_t seg, int flags, int mode,
 	ASSERT(vp == rootdir);
 
 	len = strlen(path) + 2;
-	realpath = kmalloc(len, GFP_KERNEL);
+	realpath = kmalloc(len, kmem_flags_convert(KM_SLEEP));
 	if (!realpath)
 		return (ENOMEM);
 


### PR DESCRIPTION
The kmem_vasprintf(), kmem_vsprintf(), kobj_open_file(), and vn_openat()
functions should all use the kmem_flags_convert() function to generate
the GFP_* flags.  This ensures that they can be safely caller in any
context and the current flags will be used.
