### PR TITLE
Set HAVE_FS_STRUCT_SPINLOCK correctly when CONFIG_FRAME_WARN==1024

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -1033,7 +1033,7 @@ AC_DEFUN([SPL_AC_FS_STRUCT_SPINLOCK], [
 		#include <linux/sched.h>
 		#include <linux/fs_struct.h>
 	],[
-		struct fs_struct fs;
+		static struct fs_struct fs;
 		spin_lock_init(&fs.lock);
 	],[
 		AC_MSG_RESULT(yes)


### PR DESCRIPTION
If kernel lock debugging is enabled, the fs_struct structure exceeds the
typical 1024 byte limit of CONFIG_FRAME_WARN and isn't enabled when it
otherwise should be.