### PR TITLE
Add hooks to memory allocate function for direct reclaim debugging 

### DIFF
--- a/include/sys/kmem_cache.h
+++ b/include/sys/kmem_cache.h
@@ -225,7 +225,11 @@ extern void spl_kmem_reap(void);
     spl_kmem_cache_create(name, size, align, ctor, dtor, rclm, priv, vmp, fl)
 #define	kmem_cache_set_move(skc, move)	spl_kmem_cache_set_move(skc, move)
 #define	kmem_cache_destroy(skc)		spl_kmem_cache_destroy(skc)
-#define	kmem_cache_alloc(skc, flags)	spl_kmem_cache_alloc(skc, flags)
+#define	kmem_cache_alloc(skc, flags)			\
+({							\
+	spl_kmem_debug_direct_reclaim_stub(flags);	\
+	spl_kmem_cache_alloc(skc, flags);		\
+})
 #define	kmem_cache_free(skc, obj)	spl_kmem_cache_free(skc, obj)
 #define	kmem_cache_reap_now(skc)	\
     spl_kmem_cache_reap_now(skc, skc->skc_reap)

--- a/include/sys/vmem.h
+++ b/include/sys/vmem.h
@@ -95,8 +95,16 @@ extern void *spl_vmalloc(unsigned long size, gfp_t lflags, pgprot_t prot);
  * to them.
  */
 
-#define	vmem_alloc(sz, fl)	spl_vmem_alloc((sz), (fl), __func__, __LINE__)
-#define	vmem_zalloc(sz, fl)	spl_vmem_zalloc((sz), (fl), __func__, __LINE__)
+#define	vmem_alloc(sz, fl)				\
+({							\
+	spl_kmem_debug_direct_reclaim_stub(fl);		\
+	spl_vmem_alloc((sz), (fl), __func__, __LINE__);	\
+})
+#define	vmem_zalloc(sz, fl)				\
+({							\
+	spl_kmem_debug_direct_reclaim_stub(fl);		\
+	spl_vmem_zalloc((sz), (fl), __func__, __LINE__);\
+})
 #define	vmem_free(ptr, sz)	spl_vmem_free((ptr), (sz))
 
 extern void *spl_vmem_alloc(size_t sz, int fl, const char *func, int line);

--- a/module/spl/Makefile.in
+++ b/module/spl/Makefile.in
@@ -9,6 +9,7 @@ obj-$(CONFIG_SPL) := $(MODULE).o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-proc.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-kmem.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-kmem-cache.o
+$(MODULE)-objs += @top_srcdir@/module/spl/spl-kmem-direct.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-vmem.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-thread.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-taskq.o

--- a/module/spl/spl-kmem-direct.c
+++ b/module/spl/spl-kmem-direct.c
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef KMEM_DEBUG_DIRECT_RECLAIM
+
+#include <sys/kmem.h>
+#include <linux/atomic.h>
+
+static spl_kmem_debug_direct_t debug_reclaim_func = NULL;
+static atomic_t rcount = ATOMIC_INIT(0);
+
+void spl_kmem_debug_direct_reclaim_register(spl_kmem_debug_direct_t f)
+{
+	debug_reclaim_func = f;
+}
+EXPORT_SYMBOL(spl_kmem_debug_direct_reclaim_register);
+
+void spl_kmem_debug_direct_reclaim_unregister(void)
+{
+	debug_reclaim_func = NULL;
+	smp_mb();
+
+	/* wait until the last user exits */
+	while (atomic_read(&rcount))
+		schedule_timeout(1);
+}
+EXPORT_SYMBOL(spl_kmem_debug_direct_reclaim_unregister);
+
+void spl_kmem_debug_direct_reclaim(int flags, unsigned long *t, const char *c)
+{
+	spl_kmem_debug_direct_t f;
+
+	/* not allowed to do direct reclaim */
+	if (flags & KM_NOSLEEP || current->flags & (PF_FSTRANS|PF_MEMALLOC))
+		return;
+	/* not yet registered or unregistered */
+	if (!debug_reclaim_func)
+		return;
+
+	atomic_inc(&rcount);
+	smp_mb();
+	/* check again in case it's being unregistered */
+	f = ACCESS_ONCE(debug_reclaim_func);
+	if (!f)
+		goto out;
+	f(flags, t, c);
+out:
+	atomic_dec(&rcount);
+}
+EXPORT_SYMBOL(spl_kmem_debug_direct_reclaim);
+#endif	/* KMEM_DEBUG_DIRECT_RECLAIM */


### PR DESCRIPTION
In order to better catch deadlocks related to direct reclaim, this patch add
hooks to kmem_alloc, kmem_cache_alloc and vmem_alloc in order to simulate
direct reclaim as we desire.

Before using it, you would need to register a callback function. The function
should in turn call to the target shrinker functions.

The whole code is covered with #ifdef KMEM_DEBUG_DIRECT_RECLAIM, so you need
to add it to spl_config.h to enable it.

Signed-off-by: Chunwei Chen <tuxoko@gmail.com>