### PR TITLE
Add crgetzoneid() stub

### DIFF
--- a/include/sys/zone.h
+++ b/include/sys/zone.h
@@ -27,7 +27,10 @@
 
 #include <sys/byteorder.h>
 
+#define GLOBAL_ZONEID           0
+
 #define zone_dataset_visible(x, y)                      (1)
+#define crgetzoneid(x)                                  (GLOBAL_ZONEID)
 #define INGLOBALZONE(z)                                 (1)
 
 #endif /* SPL_ZONE_H */


### PR DESCRIPTION
Illumos 3897 introduces a dependency on crgetzoneid(). Stub it out until such time as zones are implemented.

References:
  https://github.com/zfsonlinux/zfs/issues/3240
