### PR TITLE
Don't allow shrinking a PF_FSTRANS context

### DIFF
--- a/module/spl/spl-kmem-cache.c
+++ b/module/spl/spl-kmem-cache.c
@@ -1574,6 +1574,12 @@ __spl_kmem_cache_generic_shrinker(struct shrinker *shrink,
 	spl_kmem_cache_t *skc;
 	int alloc = 0;
 
+	/*
+	 * No shrinking in a transaction context.  Can cause deadlocks.
+	 */
+	if (sc->nr_to_scan && spl_fstrans_check())
+		return (SHRINK_STOP);
+
 	down_read(&spl_kmem_cache_sem);
 	list_for_each_entry(skc, &spl_kmem_cache_list, skc_list) {
 		if (sc->nr_to_scan) {

--- a/module/splat/splat-atomic.c
+++ b/module/splat/splat-atomic.c
@@ -145,7 +145,7 @@ splat_atomic_test1(struct file *file, void *arg)
 
 	ap.ap_magic = SPLAT_ATOMIC_TEST_MAGIC;
 	ap.ap_file = file;
-	mutex_init(&ap.ap_lock, SPLAT_ATOMIC_TEST1_NAME, MUTEX_DEFAULT, NULL);
+	mutex_init(&ap.ap_lock, SPLAT_ATOMIC_TEST1_NAME, NULL, NULL);
 	init_waitqueue_head(&ap.ap_waitq);
 	ap.ap_atomic = SPLAT_ATOMIC_INIT_VALUE;
 	ap.ap_atomic_exited = 0;


### PR DESCRIPTION
Avoid deadlocks when entering the shrinker from a PF_FSTRANS context.

This patch also reverts commit d0d5dd714424365a4da0d887cb641cb2f0ae8844
which added MUTEX_FSTRANS.  Its use has been deprecated within ZFS as it
was an ineffective mechanism to eliminate deadlocks.  Among other things,
it introduced the need for strict ordering of mutex locking and unlocking
in order that the PF_FSTRANS flag wouldn't set incorrectly.