### PR TITLE
vn_getf should return NULL on negative file descriptors

### DIFF
--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -648,6 +648,16 @@ vn_getf(int fd)
 	vnode_t *vp;
 	int rc = 0;
 
+	/*
+	 * Negative file descriptors passed to fget() will be implicitly
+	 * converted into positive file descriptors by C's type coercion rules
+	 * such that the value becomes fd + UINT_MAX + 1. That is wrong, so we
+	 * fail early on negative file descriptors.
+	 */
+	if (fd < 0) {
+		return (NULL);
+	}
+
 	/* Already open just take an extra reference */
 	spin_lock(&vn_file_lock);
 


### PR DESCRIPTION
C type coercion rules require that negative numbers be converted into
positive numbers via wraparound such that a negative -1 becomes a
positive 1. This causes vn_getf to return a file handle when it should
return NULL whenever a positive file descriptor existed with the same
value. We should check for a negative file descriptor and return NULL
instead.

This was caught by ClusterHQ's unit testing.

Reference:
http://stackoverflow.com/questions/50605/signed-to-unsigned-conversion-in-c-is-it-always-safe

Signed-off-by: Richard Yao <ryao@gentoo.org>
Signed-off-by: Andriy Gapon <avg@FreeBSD.org>