### PR TITLE
Retire rwsem_is_locked() compat

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -33,7 +33,6 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_FS_STRUCT_SPINLOCK
 	SPL_AC_KUIDGID_T
 	SPL_AC_PUT_TASK_STRUCT
-	SPL_AC_EXPORTED_RWSEM_IS_LOCKED
 	SPL_AC_KERNEL_FALLOCATE
 	SPL_AC_CONFIG_ZLIB_INFLATE
 	SPL_AC_CONFIG_ZLIB_DEFLATE
@@ -1199,27 +1198,6 @@ AC_DEFUN([SPL_AC_KERNEL_FALLOCATE], [
 	SPL_AC_KERNEL_FILE_FALLOCATE
 	SPL_AC_KERNEL_INODE_FALLOCATE
 	SPL_AC_PAX_KERNEL_FILE_FALLOCATE
-])
-
-dnl #
-dnl # 2.6.33 API change. Also backported in RHEL5 as of 2.6.18-190.el5.
-dnl # Earlier versions of rwsem_is_locked() were inline and had a race
-dnl # condition.  The fixed version is exported as a symbol.  The race
-dnl # condition is fixed by acquiring sem->wait_lock, so we must not
-dnl # call that version while holding sem->wait_lock.
-dnl #
-AC_DEFUN([SPL_AC_EXPORTED_RWSEM_IS_LOCKED],
-	[AC_MSG_CHECKING([whether rwsem_is_locked() acquires sem->wait_lock])
-	SPL_LINUX_TRY_COMPILE_SYMBOL([
-		#include <linux/rwsem.h>
-		int rwsem_is_locked(struct rw_semaphore *sem) { return 0; }
-	], [], [rwsem_is_locked], [lib/rwsem-spinlock.c], [
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(RWSEM_IS_LOCKED_TAKES_WAIT_LOCK, 1,
-		          [rwsem_is_locked() acquires sem->wait_lock])
-	], [
-		AC_MSG_RESULT(no)
-	])
 ])
 
 dnl #

--- a/include/sys/rwlock.h
+++ b/include/sys/rwlock.h
@@ -83,15 +83,13 @@ rw_owner(krwlock_t *rwp)
 static inline int
 RW_READ_HELD(krwlock_t *rwp)
 {
-	return (spl_rwsem_is_locked(SEM(rwp)) &&
-		rw_owner(rwp) == NULL);
+	return (spl_rwsem_is_locked(SEM(rwp)) && rw_owner(rwp) == NULL);
 }
 
 static inline int
 RW_WRITE_HELD(krwlock_t *rwp)
 {
-	return (spl_rwsem_is_locked(SEM(rwp)) &&
-		rw_owner(rwp) == current);
+	return (spl_rwsem_is_locked(SEM(rwp)) && rw_owner(rwp) == current);
 }
 
 static inline int


### PR DESCRIPTION
Stock Linux 2.6.32 and earlier kernels contained a broken version of
rwsem_is_locked() which could return an incorrect value.  Because of
this compatibility code was added to detect the broken implementation
and replace it with our own if needed.

The fix for this issue was merged in to the mainline Linux kernel as
of 2.6.33 and the major enterprise distributions based on 2.6.32 have
all backported the fix.  Therefore there is no longer a need to carry
this code and it can be removed.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>