### PR TITLE
Rename cv_wait_interruptible() to cv_wait_sig()

### DIFF
--- a/include/sys/condvar.h
+++ b/include/sys/condvar.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,10 +20,10 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CONDVAR_H
-#define _SPL_CONDVAR_H
+#define	_SPL_CONDVAR_H
 
 #include <linux/module.h>
 #include <linux/wait.h>
@@ -36,8 +36,8 @@
  * The kcondvar_t struct is protected by mutex taken externally before
  * calling any of the wait/signal funs, and passed into the wait funs.
  */
-#define CV_MAGIC			0x346545f4
-#define CV_DESTROY			0x346545f5
+#define	CV_MAGIC			0x346545f4
+#define	CV_DESTROY			0x346545f5
 
 typedef struct {
 	int cv_magic;
@@ -48,30 +48,30 @@ typedef struct {
 	kmutex_t *cv_mutex;
 } kcondvar_t;
 
-typedef enum { CV_DEFAULT=0, CV_DRIVER } kcv_type_t;
+typedef enum { CV_DEFAULT = 0, CV_DRIVER } kcv_type_t;
 
-extern void __cv_init(kcondvar_t *cvp, char *name, kcv_type_t type, void *arg);
-extern void __cv_destroy(kcondvar_t *cvp);
-extern void __cv_wait(kcondvar_t *cvp, kmutex_t *mp);
-extern void __cv_wait_io(kcondvar_t *cvp, kmutex_t *mp);
-extern void __cv_wait_interruptible(kcondvar_t *cvp, kmutex_t *mp);
-extern clock_t __cv_timedwait(kcondvar_t *cvp, kmutex_t *mp, clock_t exp_time);
-extern clock_t __cv_timedwait_interruptible(kcondvar_t *cvp, kmutex_t *mp,
-	clock_t exp_time);
-extern	clock_t	cv_timedwait_hires(kcondvar_t *cvp, kmutex_t *mp,
-	hrtime_t tim, hrtime_t res, int flag);
-extern void __cv_signal(kcondvar_t *cvp);
-extern void __cv_broadcast(kcondvar_t *cvp);
+extern void __cv_init(kcondvar_t *, char *, kcv_type_t, void *);
+extern void __cv_destroy(kcondvar_t *);
+extern void __cv_wait(kcondvar_t *, kmutex_t *);
+extern void __cv_wait_io(kcondvar_t *, kmutex_t *);
+extern void __cv_wait_sig(kcondvar_t *, kmutex_t *);
+extern clock_t __cv_timedwait(kcondvar_t *, kmutex_t *, clock_t);
+extern clock_t __cv_timedwait_sig(kcondvar_t *, kmutex_t *, clock_t);
+extern clock_t cv_timedwait_hires(kcondvar_t *, kmutex_t *, hrtime_t,
+    hrtime_t res, int flag);
+extern void __cv_signal(kcondvar_t *);
+extern void __cv_broadcast(kcondvar_t *c);
 
-#define cv_init(cvp, name, type, arg)		__cv_init(cvp, name, type, arg)
-#define cv_destroy(cvp)				__cv_destroy(cvp)
-#define cv_wait(cvp, mp)			__cv_wait(cvp, mp)
-#define cv_wait_io(cvp, mp)			__cv_wait_io(cvp, mp)
-#define cv_wait_interruptible(cvp, mp)		__cv_wait_interruptible(cvp,mp)
-#define cv_timedwait(cvp, mp, t)		__cv_timedwait(cvp, mp, t)
-#define cv_timedwait_interruptible(cvp, mp, t)                                \
-	__cv_timedwait_interruptible(cvp, mp, t)
-#define cv_signal(cvp)				__cv_signal(cvp)
-#define cv_broadcast(cvp)			__cv_broadcast(cvp)
+#define	cv_init(cvp, name, type, arg)		__cv_init(cvp, name, type, arg)
+#define	cv_destroy(cvp)				__cv_destroy(cvp)
+#define	cv_wait(cvp, mp)			__cv_wait(cvp, mp)
+#define	cv_wait_io(cvp, mp)			__cv_wait_io(cvp, mp)
+#define	cv_wait_sig(cvp, mp)			__cv_wait_sig(cvp, mp)
+#define	cv_wait_interruptible(cvp, mp)		cv_wait_sig(cvp, mp)
+#define	cv_timedwait(cvp, mp, t)		__cv_timedwait(cvp, mp, t)
+#define	cv_timedwait_sig(cvp, mp, t)		__cv_timedwait_sig(cvp, mp, t)
+#define	cv_timedwait_interruptible(cvp, mp, t)	cv_timedwait_sig(cvp, mp, t)
+#define	cv_signal(cvp)				__cv_signal(cvp)
+#define	cv_broadcast(cvp)			__cv_broadcast(cvp)
 
 #endif /* _SPL_CONDVAR_H */


### PR DESCRIPTION
Commit f752b46e added the cv_wait_interruptible() function to allow
condition variables to be woken by signals.  This function and its
timed wait counterpart should have been named cv_wait_sig() to match
the illumos interface which provides the same functionality.

This patch renames the symbol but leaves a #define compatibility
wrapper in place until the ZFS code can be moved to the correct
name.

This patch also makes a small number of cosmetic changes to make
the condvar source and header cstyle clean.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>