### PR TITLE
Taskq dynamic

### DIFF
--- a/include/sys/taskq.h
+++ b/include/sys/taskq.h
@@ -40,6 +40,7 @@
 #define TASKQ_DYNAMIC		0x00000004
 #define TASKQ_THREADS_CPU_PCT	0x00000008
 #define TASKQ_DC_BATCH		0x00000010
+#define TASKQ_ACTIVE		0x80000000
 
 /*
  * Flags for taskq_dispatch. TQ_SLEEP/TQ_NOSLEEP should be same as
@@ -53,7 +54,6 @@
 #define TQ_NOALLOC		0x02000000
 #define TQ_NEW			0x04000000
 #define TQ_FRONT		0x08000000
-#define TQ_ACTIVE		0x80000000
 
 typedef unsigned long taskqid_t;
 typedef void (task_func_t)(void *);
@@ -61,11 +61,13 @@ typedef void (task_func_t)(void *);
 typedef struct taskq {
 	spinlock_t		tq_lock;       /* protects taskq_t */
 	unsigned long		tq_lock_flags; /* interrupt state */
-	const char		*tq_name;      /* taskq name */
+	char			*tq_name;      /* taskq name */
 	struct list_head	tq_thread_list;/* list of all threads */
 	struct list_head	tq_active_list;/* list of active threads */
 	int			tq_nactive;    /* # of active threads */
-	int			tq_nthreads;   /* # of total threads */
+	int			tq_nthreads;   /* # of existing threads */
+	int			tq_nspawn;     /* # of threads being spawned */
+	int			tq_maxthreads; /* # of threads maximum */
 	int			tq_pri;        /* priority */
 	int			tq_minalloc;   /* min task_t pool size */
 	int			tq_maxalloc;   /* max task_t pool size */

--- a/man/man5/spl-module-parameters.5
+++ b/man/man5/spl-module-parameters.5
@@ -249,3 +249,37 @@ where a thread should run.
 .sp
 Default value: \fB0\fR
 .RE
+
+.sp
+.ne 2
+.na
+\fBspl_taskq_thread_dynamic\fR (int)
+.ad
+.RS 12n
+Allow dynamic taskqs.  When enabled taskqs which set the TASKQ_DYNAMIC flag
+will by default create only a single thread.  New threads will be created on
+demand up to a maximum allowed number to facilitate the completion of
+outstanding tasks.  Threads which are no longer needed will be promptly
+destroyed.  By default this behavior is enabled but it can be disabled to
+aid performance analysis or troubleshooting.
+.sp
+Default value: \fB1\fR
+.RE
+
+.sp
+.ne 2
+.na
+\fBspl_taskq_thread_sequential\fR (int)
+.ad
+.RS 12n
+The number of items a taskq worker thread must handle without interruption
+before requesting a new worker thread be spawned.  This is used to control
+how quickly taskqs ramp up the number of threads processing the queue.
+Because Linux thread creation and destruction are relatively inexpensive a
+small default value has been selected.  This means that normally threads will
+be created aggressively which is desirable.  Increasing this value will
+result in a slower thread creation rate which may be preferable for some
+configurations.
+.sp
+Default value: \fB4\fR
+.RE

--- a/module/spl/spl-kmem-cache.c
+++ b/module/spl/spl-kmem-cache.c
@@ -1725,7 +1725,9 @@ spl_kmem_cache_init(void)
 	init_rwsem(&spl_kmem_cache_sem);
 	INIT_LIST_HEAD(&spl_kmem_cache_list);
 	spl_kmem_cache_taskq = taskq_create("spl_kmem_cache",
-	    spl_kmem_cache_kmem_threads, maxclsyspri, 1, 32, TASKQ_PREPOPULATE);
+	    spl_kmem_cache_kmem_threads, maxclsyspri,
+	    spl_kmem_cache_kmem_threads * 8, INT_MAX,
+	    TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 	spl_register_shrinker(&spl_kmem_cache_shrinker);
 
 	return (0);

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -1069,10 +1069,8 @@ EXPORT_SYMBOL(taskq_destroy);
 int
 spl_taskq_init(void)
 {
-	/* Solaris creates a dynamic taskq of up to 64 threads, however in
-	 * a Linux environment 1 thread per-core is usually about right */
-	system_taskq = taskq_create("spl_system_taskq", num_online_cpus(),
-				    minclsyspri, 4, 512, TASKQ_PREPOPULATE);
+	system_taskq = taskq_create("spl_system_taskq", MAX(boot_ncpus, 64),
+	    minclsyspri, boot_ncpus, INT_MAX, TASKQ_PREPOPULATE|TASKQ_DYNAMIC);
 	if (system_taskq == NULL)
 		return (1);
 

--- a/module/splat/splat-taskq.c
+++ b/module/splat/splat-taskq.c
@@ -28,6 +28,7 @@
 #include <sys/vmem.h>
 #include <sys/random.h>
 #include <sys/taskq.h>
+#include <sys/time.h>
 #include <sys/timer.h>
 #include <linux/delay.h>
 #include "splat-internal.h"
@@ -74,6 +75,10 @@
 #define SPLAT_TASKQ_TEST10_ID		0x020a
 #define SPLAT_TASKQ_TEST10_NAME		"cancel"
 #define SPLAT_TASKQ_TEST10_DESC		"Cancel task execution"
+
+#define SPLAT_TASKQ_TEST11_ID		0x020b
+#define SPLAT_TASKQ_TEST11_NAME		"dynamic"
+#define SPLAT_TASKQ_TEST11_DESC		"Dynamic task queue thread creation"
 
 #define SPLAT_TASKQ_ORDER_MAX		8
 #define SPLAT_TASKQ_DEPTH_MAX		16
@@ -1052,11 +1057,104 @@ splat_taskq_test7(struct file *file, void *arg)
 
 	rc = splat_taskq_test7_impl(file, arg, B_FALSE);
 	if (rc)
-		return rc;
+		return (rc);
 
 	rc = splat_taskq_test7_impl(file, arg, B_TRUE);
 
-	return rc;
+	return (rc);
+}
+
+static void
+splat_taskq_throughput_func(void *arg)
+{
+	splat_taskq_arg_t *tq_arg = (splat_taskq_arg_t *)arg;
+	ASSERT(tq_arg);
+
+	atomic_inc(tq_arg->count);
+}
+
+static int
+splat_taskq_throughput(struct file *file, void *arg, const char *name,
+    int nthreads, int minalloc, int maxalloc, int flags, int tasks,
+    struct timespec *delta)
+{
+	taskq_t *tq;
+	taskqid_t id;
+	splat_taskq_arg_t tq_arg;
+	taskq_ent_t **tqes;
+	atomic_t count;
+	struct timespec start, stop;
+	int i, j, rc = 0;
+
+	tqes = vmalloc(sizeof (*tqes) * tasks);
+	if (tqes == NULL)
+		return (-ENOMEM);
+
+	memset(tqes, 0, sizeof (*tqes) * tasks);
+
+	splat_vprint(file, name, "Taskq '%s' creating (%d/%d/%d/%d)\n",
+	    name, nthreads, minalloc, maxalloc, tasks);
+	if ((tq = taskq_create(name, nthreads, maxclsyspri,
+	    minalloc, maxalloc, flags)) == NULL) {
+		splat_vprint(file, name, "Taskq '%s' create failed\n", name);
+		rc = -EINVAL;
+		goto out_free;
+	}
+
+	tq_arg.file = file;
+	tq_arg.name = name;
+	tq_arg.count = &count;
+	atomic_set(tq_arg.count, 0);
+
+	getnstimeofday(&start);
+
+	for (i = 0; i < tasks; i++) {
+		tqes[i] = kmalloc(sizeof (taskq_ent_t), GFP_KERNEL);
+		if (tqes[i] == NULL) {
+			rc = -ENOMEM;
+			goto out;
+		}
+
+		taskq_init_ent(tqes[i]);
+		taskq_dispatch_ent(tq, splat_taskq_throughput_func,
+		    &tq_arg, TQ_SLEEP, tqes[i]);
+		id = tqes[i]->tqent_id;
+
+		if (id == 0) {
+			splat_vprint(file, name, "Taskq '%s' function '%s' "
+			    "dispatch %d failed\n", tq_arg.name,
+			    sym2str(splat_taskq_throughput_func), i);
+			rc = -EINVAL;
+			goto out;
+		}
+	}
+
+	splat_vprint(file, name, "Taskq '%s' waiting for %d dispatches\n",
+	    tq_arg.name, tasks);
+
+	taskq_wait(tq);
+
+	if (delta != NULL) {
+		getnstimeofday(&stop);
+		*delta = timespec_sub(stop, start);
+	}
+
+	splat_vprint(file, name, "Taskq '%s' %d/%d dispatches finished\n",
+	    tq_arg.name, atomic_read(tq_arg.count), tasks);
+
+	if (atomic_read(tq_arg.count) != tasks)
+		rc = -ERANGE;
+
+out:
+	splat_vprint(file, name, "Taskq '%s' destroying\n", tq_arg.name);
+	taskq_destroy(tq);
+out_free:
+	for (j = 0; j < tasks && tqes[j] != NULL; j++)
+		kfree(tqes[j]);
+
+	vfree(tqes);
+
+	return (rc);
 }
 
 /*
@@ -1065,107 +1163,15 @@ splat_taskq_test7(struct file *file, void *arg)
  * pass.  The purpose is to provide a benchmark for measuring the
  * effectiveness of taskq optimizations.
  */
-static void
-splat_taskq_test8_func(void *arg)
-{
-	splat_taskq_arg_t *tq_arg = (splat_taskq_arg_t *)arg;
-	ASSERT(tq_arg);
-
-	atomic_inc(tq_arg->count);
-}
-
-#define TEST8_NUM_TASKS			0x20000
-#define TEST8_THREADS_PER_TASKQ		100
-
-static int
-splat_taskq_test8_common(struct file *file, void *arg, int minalloc,
-                         int maxalloc)
-{
-	taskq_t *tq;
-	taskqid_t id;
-	splat_taskq_arg_t tq_arg;
-	taskq_ent_t **tqes;
-	atomic_t count;
-	int i, j, rc = 0;
-
-	tqes = vmalloc(sizeof(*tqes) * TEST8_NUM_TASKS);
-	if (tqes == NULL)
-		return -ENOMEM;
-	memset(tqes, 0, sizeof(*tqes) * TEST8_NUM_TASKS);
-
-	splat_vprint(file, SPLAT_TASKQ_TEST8_NAME,
-		     "Taskq '%s' creating (%d/%d/%d)\n",
-		     SPLAT_TASKQ_TEST8_NAME,
-		     minalloc, maxalloc, TEST8_NUM_TASKS);
-	if ((tq = taskq_create(SPLAT_TASKQ_TEST8_NAME, TEST8_THREADS_PER_TASKQ,
-			       maxclsyspri, minalloc, maxalloc,
-			       TASKQ_PREPOPULATE)) == NULL) {
-		splat_vprint(file, SPLAT_TASKQ_TEST8_NAME,
-		             "Taskq '%s' create failed\n",
-		             SPLAT_TASKQ_TEST8_NAME);
-		rc = -EINVAL;
-		goto out_free;
-	}
-
-	tq_arg.file = file;
-	tq_arg.name = SPLAT_TASKQ_TEST8_NAME;
-	tq_arg.count = &count;
-	atomic_set(tq_arg.count, 0);
-
-	for (i = 0; i < TEST8_NUM_TASKS; i++) {
-		tqes[i] = kmalloc(sizeof(taskq_ent_t), GFP_KERNEL);
-		if (tqes[i] == NULL) {
-			rc = -ENOMEM;
-			goto out;
-		}
-		taskq_init_ent(tqes[i]);
-
-		taskq_dispatch_ent(tq, splat_taskq_test8_func,
-				   &tq_arg, TQ_SLEEP, tqes[i]);
-
-		id = tqes[i]->tqent_id;
-
-		if (id == 0) {
-			splat_vprint(file, SPLAT_TASKQ_TEST8_NAME,
-			        "Taskq '%s' function '%s' dispatch "
-				"%d failed\n", tq_arg.name,
-				sym2str(splat_taskq_test8_func), i);
-				rc = -EINVAL;
-				goto out;
-		}
-	}
-
-	splat_vprint(file, SPLAT_TASKQ_TEST8_NAME, "Taskq '%s' "
-		     "waiting for %d dispatches\n", tq_arg.name,
-		     TEST8_NUM_TASKS);
-	taskq_wait(tq);
-	splat_vprint(file, SPLAT_TASKQ_TEST8_NAME, "Taskq '%s' "
-		     "%d/%d dispatches finished\n", tq_arg.name,
-		     atomic_read(tq_arg.count), TEST8_NUM_TASKS);
-
-	if (atomic_read(tq_arg.count) != TEST8_NUM_TASKS)
-		rc = -ERANGE;
-
-out:
-	splat_vprint(file, SPLAT_TASKQ_TEST8_NAME, "Taskq '%s' destroying\n",
-	           tq_arg.name);
-	taskq_destroy(tq);
-out_free:
-	for (j = 0; j < TEST8_NUM_TASKS && tqes[j] != NULL; j++)
-		kfree(tqes[j]);
-	vfree(tqes);
-
-	return rc;
-}
+#define	TEST8_NUM_TASKS			0x20000
+#define	TEST8_THREADS_PER_TASKQ		100
 
 static int
 splat_taskq_test8(struct file *file, void *arg)
 {
-	int rc;
-
-	rc = splat_taskq_test8_common(file, arg, 1, 100);
-
-	return rc;
+	return (splat_taskq_throughput(file, arg,
+	    SPLAT_TASKQ_TEST8_NAME, TEST8_THREADS_PER_TASKQ,
+	    1, INT_MAX, TASKQ_PREPOPULATE, TEST8_NUM_TASKS, NULL));
 }
 
 /*
@@ -1433,6 +1439,46 @@ out_free:
 	return rc;
 }
 
+/*
+ * Create a dynamic taskq with 100 threads and dispatch a huge number of
+ * trivial tasks.  This will cause the taskq to grow quickly to its max
+ * thread count.  This test should always pass.  The purpose is to provide
+ * a benchmark for measuring the performance of dynamic taskqs.
+ */
+#define	TEST11_NUM_TASKS			100000
+#define	TEST11_THREADS_PER_TASKQ		100
+
+static int
+splat_taskq_test11(struct file *file, void *arg)
+{
+	struct timespec normal, dynamic;
+	int error;
+
+	error = splat_taskq_throughput(file, arg, SPLAT_TASKQ_TEST11_NAME,
+	    TEST11_THREADS_PER_TASKQ, 1, INT_MAX,
+	    TASKQ_PREPOPULATE, TEST11_NUM_TASKS, &normal);
+	if (error)
+		return (error);
+
+	error = splat_taskq_throughput(file, arg, SPLAT_TASKQ_TEST11_NAME,
+	    TEST11_THREADS_PER_TASKQ, 1, INT_MAX,
+	    TASKQ_PREPOPULATE | TASKQ_DYNAMIC, TEST11_NUM_TASKS, &dynamic);
+	if (error)
+		return (error);
+
+	splat_vprint(file, SPLAT_TASKQ_TEST11_NAME,
+	    "Timing taskq_wait(): normal=%ld.%09lds, dynamic=%ld.%09lds\n",
+	    normal.tv_sec, normal.tv_nsec,
+	    dynamic.tv_sec, dynamic.tv_nsec);
+
+	/* A 1% increase in runtime is a */
+	if ((dynamic.tv_sec * NANOSEC + dynamic.tv_nsec) >
+	    ((normal.tv_sec * NANOSEC + normal.tv_nsec) * 101 / 100))
+		error = -ETIME;
+
+	return (error);
+}
+
 splat_subsystem_t *
 splat_taskq_init(void)
 {
@@ -1470,6 +1516,8 @@ splat_taskq_init(void)
 	              SPLAT_TASKQ_TEST9_ID, splat_taskq_test9);
 	SPLAT_TEST_INIT(sub, SPLAT_TASKQ_TEST10_NAME, SPLAT_TASKQ_TEST10_DESC,
 	              SPLAT_TASKQ_TEST10_ID, splat_taskq_test10);
+	SPLAT_TEST_INIT(sub, SPLAT_TASKQ_TEST11_NAME, SPLAT_TASKQ_TEST11_DESC,
+	              SPLAT_TASKQ_TEST11_ID, splat_taskq_test11);
 
         return sub;
 }
@@ -1478,6 +1526,7 @@ void
 splat_taskq_fini(splat_subsystem_t *sub)
 {
         ASSERT(sub);
+	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST11_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST10_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST9_ID);
 	SPLAT_TEST_FINI(sub, SPLAT_TASKQ_TEST8_ID);


### PR DESCRIPTION
Add support for the TASKQ_DYNAMIC flag.  This allows taskqs to create and destroy worker threads on demand to efficiently handle outstanding tasks.