### PR TITLE
Invert minclsyspri and maxclsyspri

### DIFF
--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -93,8 +93,8 @@
  *
  * Treat shim tasks as SCHED_NORMAL tasks
  */
-#define minclsyspri			(MAX_RT_PRIO)
-#define maxclsyspri			(MAX_PRIO-1)
+#define minclsyspri			(MAX_PRIO-1)
+#define maxclsyspri			(MAX_RT_PRIO)
 #define defclsyspri			(DEFAULT_PRIO)
 
 #ifndef NICE_TO_PRIO

--- a/include/sys/taskq.h
+++ b/include/sys/taskq.h
@@ -129,7 +129,7 @@ extern int taskq_member(taskq_t *, void *);
 #define taskq_create_proc(name, nthreads, pri, min, max, proc, flags) \
     taskq_create(name, nthreads, pri, min, max, flags)
 #define taskq_create_sysdc(name, nthreads, min, max, proc, dc, flags) \
-    taskq_create(name, nthreads, defclsyspri, min, max, flags)
+    taskq_create(name, nthreads, maxclsyspri, min, max, flags)
 
 int spl_taskq_init(void);
 void spl_taskq_fini(void);

--- a/module/spl/spl-kmem-cache.c
+++ b/module/spl/spl-kmem-cache.c
@@ -1725,7 +1725,7 @@ spl_kmem_cache_init(void)
 	init_rwsem(&spl_kmem_cache_sem);
 	INIT_LIST_HEAD(&spl_kmem_cache_list);
 	spl_kmem_cache_taskq = taskq_create("spl_kmem_cache",
-	    spl_kmem_cache_kmem_threads, defclsyspri,
+	    spl_kmem_cache_kmem_threads, maxclsyspri,
 	    spl_kmem_cache_kmem_threads * 8, INT_MAX,
 	    TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 	spl_register_shrinker(&spl_kmem_cache_shrinker);

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -1077,12 +1077,12 @@ int
 spl_taskq_init(void)
 {
 	system_taskq = taskq_create("spl_system_taskq", MAX(boot_ncpus, 64),
-	    defclsyspri, boot_ncpus, INT_MAX, TASKQ_PREPOPULATE|TASKQ_DYNAMIC);
+	    maxclsyspri, boot_ncpus, INT_MAX, TASKQ_PREPOPULATE|TASKQ_DYNAMIC);
 	if (system_taskq == NULL)
 		return (1);
 
 	dynamic_taskq = taskq_create("spl_dynamic_taskq", 1,
-	    defclsyspri, boot_ncpus, INT_MAX, TASKQ_PREPOPULATE);
+	    maxclsyspri, boot_ncpus, INT_MAX, TASKQ_PREPOPULATE);
 	if (dynamic_taskq == NULL) {
 		taskq_destroy(system_taskq);
 		return (1);


### PR DESCRIPTION
On Linux the meaning of a processes priority is inverted with respect
to illumos.  High values on Linux indicate a _low_ priority while high
value on illumos indicate a _high_ priority.

In order to preserve the logical meaning of the minclsyspri and
maxclsyspri macros when they are used by the illumos wrapper functions
their values have been inverted.  This way when changes are merged
from upstream illumos we won't need to remember to invert the macro.
It could also lead to confusion.

Note this change also reverts some of the priorities changes in prior
commit 62aa81a.  The rational is as follows:

spl_kmem_cache    - High priority may result in blocked memory allocs
spl_system_taskq  - May perform I/O for file backed VDEVs
spl_dynamic_taskq - New taskq threads should be spawned promptly

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>