### PR TITLE
Remove needfree, desfree, lotsfree #defines

### DIFF
--- a/include/sys/vmsystm.h
+++ b/include/sys/vmsystm.h
@@ -36,9 +36,6 @@
 #define	membar_producer()		smp_wmb()
 #define	physmem				totalram_pages
 #define	freemem				nr_free_pages()
-#define	needfree			0
-#define	desfree				0
-#define	lotsfree			0
 
 #define	xcopyin(from, to, size)		copy_from_user(to, from, size)
 #define	xcopyout(from, to, size)	copy_to_user(to, from, size)


### PR DESCRIPTION
This patch reverts 77ab5dd.  This is now possible because upstream has
refactored the ARC is such a way that these values are only used in a
few key places.  Those places have subsequently been updated to use
the default illumos setting but also exposed as module option to
allow tuning if required.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue zfsonlinux/zfs#3637