### PR TITLE
Include other sources of freeable memory in the freemem calculation

### DIFF
--- a/include/sys/vmsystm.h
+++ b/include/sys/vmsystm.h
@@ -35,7 +35,10 @@
 
 #define	membar_producer()		smp_wmb()
 #define	physmem				totalram_pages
-#define	freemem				nr_free_pages()
+#define	freemem			(nr_free_pages() + \
+				global_page_state(NR_INACTIVE_FILE) + \
+				global_page_state(NR_INACTIVE_ANON) + \
+				global_page_state(NR_SLAB_RECLAIMABLE))
 
 #define	xcopyin(from, to, size)		copy_from_user(to, from, size)
 #define	xcopyout(from, to, size)	copy_to_user(to, from, size)


### PR DESCRIPTION
This prevents ARC collapse when non-ZFS filesystems, the block layer or
other consumers use a lot of reclaimable memory.