### PR TITLE
Disable direct reclaim in taskq worker threads on Linux 3.9+

### DIFF
--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -817,6 +817,10 @@ taskq_thread(void *args)
 	tq = tqt->tqt_tq;
 	current->flags |= PF_NOFREEZE;
 
+	#if defined(PF_MEMALLOC_NOIO)
+	(void) memalloc_noio_save();
+	#endif
+
 	sigfillset(&blocked);
 	sigprocmask(SIG_BLOCK, &blocked, NULL);
 	flush_signals(current);


### PR DESCRIPTION
Illumos does not have direct reclaim and code run inside taskq worker
threads is not designed to deal with it. Allowing direct reclaim inside
a worker thread can therefore deadlock. We set PF_MEMALLOC_NOIO through
memalloc_noio_save() to indicate to the kernel's reclaim code that we
are inside a context where memory allocations cannot be allowed to block
on filesystem activity.

Signed-off-by: Richard Yao <ryao@gentoo.org>