### PR TITLE
add spin_lock_irqsave_nolockdep and mutex type MUTEX_NOLOCKDEP

### DIFF
--- a/include/linux/file_compat.h
+++ b/include/linux/file_compat.h
@@ -76,7 +76,7 @@ spl_filp_fallocate(struct file *fp, int mode, loff_t offset, loff_t len)
 #define	spl_filp_fsync(fp, sync)	vfs_fsync(fp, (fp)->f_dentry, sync)
 #endif /* HAVE_2ARGS_VFS_FSYNC */
 
-#define	spl_inode_lock(ip)		mutex_lock(&(ip)->i_mutex)
+#define	spl_inode_lock(ip)		mutex_lock_nested(&(ip)->i_mutex, I_MUTEX_PARENT)
 #define	spl_inode_unlock(ip)		mutex_unlock(&(ip)->i_mutex)
 
 #endif /* SPL_FILE_COMPAT_H */

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -28,17 +28,22 @@
 #include <sys/types.h>
 #include <linux/mutex.h>
 #include <linux/compiler_compat.h>
+#include <linux/lockdep.h>
 
 typedef enum {
 	MUTEX_DEFAULT	= 0,
 	MUTEX_SPIN	= 1,
-	MUTEX_ADAPTIVE	= 2
+	MUTEX_ADAPTIVE	= 2,
+	MUTEX_NOLOCKDEP	= 3
 } kmutex_type_t;
 
 typedef struct {
 	struct mutex		m_mutex;
 	spinlock_t		m_lock;	/* used for serializing mutex_exit */
 	kthread_t		*m_owner;
+#ifdef CONFIG_LOCKDEP
+	kmutex_type_t		m_type;
+#endif /* CONFIG_LOCKDEP */
 } kmutex_t;
 
 #define	MUTEX(mp)		(&((mp)->m_mutex))
@@ -60,6 +65,30 @@ spl_mutex_clear_owner(kmutex_t *mp)
 #define	MUTEX_HELD(mp)		mutex_owned(mp)
 #define	MUTEX_NOT_HELD(mp)	(!MUTEX_HELD(mp))
 
+#ifdef CONFIG_LOCKDEP
+static inline void
+spl_mutex_set_type(kmutex_t *mp, kmutex_type_t type)
+{
+	mp->m_type = type;
+}
+static inline void
+spl_mutex_lockdep_off_maybe(kmutex_t *mp)			\
+{								\
+	if (mp && mp->m_type == MUTEX_NOLOCKDEP)		\
+		lockdep_off();					\
+}
+static inline void
+spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
+{								\
+	if (mp && mp->m_type == MUTEX_NOLOCKDEP)		\
+		lockdep_on();					\
+}
+#else  /* CONFIG_LOCKDEP */
+#define spl_mutex_set_type(mp, type)
+#define spl_mutex_lockdep_off_maybe(mp)
+#define spl_mutex_lockdep_on_maybe(mp)
+#endif /* CONFIG_LOCKDEP */
+
 /*
  * The following functions must be a #define and not static inline.
  * This ensures that the native linux mutex functions (lock/unlock)
@@ -70,11 +99,12 @@ spl_mutex_clear_owner(kmutex_t *mp)
 #define	mutex_init(mp, name, type, ibc)				\
 {								\
 	static struct lock_class_key __key;			\
-	ASSERT(type == MUTEX_DEFAULT);				\
+	ASSERT(type == MUTEX_DEFAULT || type == MUTEX_NOLOCKDEP); \
 								\
 	__mutex_init(MUTEX(mp), (name) ? (#name) : (#mp), &__key); \
 	spin_lock_init(&(mp)->m_lock);				\
 	spl_mutex_clear_owner(mp);				\
+	spl_mutex_set_type(mp, type);				\
 }
 
 #undef mutex_destroy
@@ -87,8 +117,10 @@ spl_mutex_clear_owner(kmutex_t *mp)
 ({								\
 	int _rc_;						\
 								\
+	spl_mutex_lockdep_off_maybe(mp);			\
 	if ((_rc_ = mutex_trylock(MUTEX(mp))) == 1)		\
 		spl_mutex_set_owner(mp);			\
+	spl_mutex_lockdep_on_maybe(mp);				\
 								\
 	_rc_;							\
 })
@@ -97,14 +129,18 @@ spl_mutex_clear_owner(kmutex_t *mp)
 #define	mutex_enter_nested(mp, subclass)			\
 {								\
 	ASSERT3P(mutex_owner(mp), !=, current);			\
+	spl_mutex_lockdep_off_maybe(mp);			\
 	mutex_lock_nested(MUTEX(mp), (subclass));		\
+	spl_mutex_lockdep_on_maybe(mp);				\
 	spl_mutex_set_owner(mp);				\
 }
 #else /* CONFIG_DEBUG_LOCK_ALLOC */
 #define	mutex_enter_nested(mp, subclass)			\
 {								\
 	ASSERT3P(mutex_owner(mp), !=, current);			\
+	spl_mutex_lockdep_off_maybe(mp);			\
 	mutex_lock(MUTEX(mp));					\
+	spl_mutex_lockdep_on_maybe(mp);				\
 	spl_mutex_set_owner(mp);				\
 }
 #endif /*  CONFIG_DEBUG_LOCK_ALLOC */
@@ -132,10 +168,12 @@ spl_mutex_clear_owner(kmutex_t *mp)
  */
 #define	mutex_exit(mp)						\
 {								\
+	spl_mutex_lockdep_off_maybe(mp);			\
 	spin_lock(&(mp)->m_lock);				\
 	spl_mutex_clear_owner(mp);				\
 	mutex_unlock(MUTEX(mp));				\
 	spin_unlock(&(mp)->m_lock);				\
+	spl_mutex_lockdep_on_maybe(mp);				\
 }
 
 int spl_mutex_init(void);

--- a/include/sys/taskq.h
+++ b/include/sys/taskq.h
@@ -55,6 +55,14 @@
 #define TQ_NEW			0x04000000
 #define TQ_FRONT		0x08000000
 
+/* spin_lock(lock) and spin_lock_nested(lock,0) are equivalent,
+ * so TQ_LOCK_DYNAMIC must not evaluate to 0
+ */
+typedef enum tq_lock_role {
+	TQ_LOCK_GENERAL =	0,
+	TQ_LOCK_DYNAMIC =	1,
+} tq_lock_role_t;
+
 typedef unsigned long taskqid_t;
 typedef void (task_func_t)(void *);
 
@@ -81,6 +89,7 @@ typedef struct taskq {
 	struct list_head	tq_delay_list; /* delayed task_t's */
 	wait_queue_head_t	tq_work_waitq; /* new work waitq */
 	wait_queue_head_t	tq_wait_waitq; /* wait waitq */
+	tq_lock_role_t		tq_lock_class; /* class used when taking tq_lock */
 } taskq_t;
 
 typedef struct taskq_ent {

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -113,7 +113,7 @@ retry:
 		 */
 		spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 		schedule_timeout(HZ / 100);
-		spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+		spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 		if (count < 100) {
 			count++;
 			goto retry;
@@ -122,7 +122,7 @@ retry:
 
 	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 	t = kmem_alloc(sizeof(taskq_ent_t), task_km_flags(flags));
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 	if (t) {
 		taskq_init_ent(t);
@@ -188,7 +188,7 @@ task_expire(unsigned long data)
 	taskq_t *tq = t->tqent_taskq;
 	struct list_head *l;
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 	if (t->tqent_flags & TQENT_FLAG_CANCEL) {
 		ASSERT(list_empty(&t->tqent_list));
@@ -379,7 +379,7 @@ taskq_wait_id_check(taskq_t *tq, taskqid_t id)
 	int active = 0;
 	int rc;
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	rc = (taskq_find(tq, id, &active) == NULL);
 	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 
@@ -402,7 +402,7 @@ taskq_wait_outstanding_check(taskq_t *tq, taskqid_t id)
 {
 	int rc;
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	rc = (id < tq->tq_lowest_id);
 	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 
@@ -429,7 +429,7 @@ taskq_wait_check(taskq_t *tq)
 {
 	int rc;
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	rc = (tq->tq_lowest_id == tq->tq_next_id);
 	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 
@@ -474,7 +474,7 @@ taskq_member(taskq_t *tq, void *t)
 {
 	int found;
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	found = taskq_member_impl(tq, t);
 	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 
@@ -497,7 +497,7 @@ taskq_cancel_id(taskq_t *tq, taskqid_t id)
 
 	ASSERT(tq);
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	t = taskq_find(tq, id, &active);
 	if (t && !active) {
 		list_del_init(&t->tqent_list);
@@ -519,7 +519,7 @@ taskq_cancel_id(taskq_t *tq, taskqid_t id)
 		if (timer_pending(&t->tqent_timer)) {
 			spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 			del_timer_sync(&t->tqent_timer);
-			spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+			spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 		}
 
 		if (!(t->tqent_flags & TQENT_FLAG_PREALLOC))
@@ -549,7 +549,7 @@ taskq_dispatch(taskq_t *tq, task_func_t func, void *arg, uint_t flags)
 	ASSERT(tq);
 	ASSERT(func);
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 	/* Taskq being destroyed and all tasks drained */
 	if (!(tq->tq_flags & TASKQ_ACTIVE))
@@ -605,7 +605,7 @@ taskq_dispatch_delay(taskq_t *tq, task_func_t func, void *arg,
 	ASSERT(tq);
 	ASSERT(func);
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 	/* Taskq being destroyed and all tasks drained */
 	if (!(tq->tq_flags & TASKQ_ACTIVE))
@@ -648,7 +648,7 @@ taskq_dispatch_ent(taskq_t *tq, task_func_t func, void *arg, uint_t flags,
 	ASSERT(tq);
 	ASSERT(func);
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 	/* Taskq being destroyed and all tasks drained */
 	if (!(tq->tq_flags & TASKQ_ACTIVE)) {
@@ -740,13 +740,13 @@ taskq_thread_spawn_task(void *arg)
 
 	(void) taskq_thread_create(tq);
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	tq->tq_nspawn--;
 	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 }
 
 /*
- * Spawn addition threads for dynamic taskqs (TASKQ_DYNMAIC) the current
+ * Spawn addition threads for dynamic taskqs (TASKQ_DYNAMIC) the current
  * number of threads is insufficient to handle the pending tasks.  These
  * new threads must be created by the dedicated dynamic_taskq to avoid
  * deadlocks between thread creation and memory reclaim.  The system_taskq
@@ -810,6 +810,7 @@ taskq_thread(void *args)
 	int seq_tasks = 0;
 
 	ASSERT(tqt);
+	ASSERT(tqt->tqt_tq);
 	tq = tqt->tqt_tq;
 	current->flags |= PF_NOFREEZE;
 
@@ -821,7 +822,7 @@ taskq_thread(void *args)
 	sigprocmask(SIG_BLOCK, &blocked, NULL);
 	flush_signals(current);
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 	/* Immediately exit if more threads than allowed were created. */
 	if (tq->tq_nthreads >= tq->tq_maxthreads)
@@ -848,7 +849,7 @@ taskq_thread(void *args)
 			schedule();
 			seq_tasks = 0;
 
-			spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+			spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 			remove_wait_queue(&tq->tq_work_waitq, &wait);
 		} else {
 			__set_current_state(TASK_RUNNING);
@@ -877,7 +878,7 @@ taskq_thread(void *args)
 			/* Perform the requested task */
 			t->tqent_func(t->tqent_arg);
 
-			spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+			spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 			tq->tq_nactive--;
 			list_del_init(&tqt->tqt_active_list);
 			tqt->tqt_task = NULL;
@@ -999,9 +1000,10 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	INIT_LIST_HEAD(&tq->tq_delay_list);
 	init_waitqueue_head(&tq->tq_work_waitq);
 	init_waitqueue_head(&tq->tq_wait_waitq);
+	tq->tq_lock_class = TQ_LOCK_GENERAL;
 
 	if (flags & TASKQ_PREPOPULATE) {
-		spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+		spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 		for (i = 0; i < minalloc; i++)
 			task_done(tq, task_alloc(tq, TQ_PUSHPAGE | TQ_NEW));
@@ -1040,7 +1042,7 @@ taskq_destroy(taskq_t *tq)
 	taskq_ent_t *t;
 
 	ASSERT(tq);
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	tq->tq_flags &= ~TASKQ_ACTIVE;
 	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
 
@@ -1053,7 +1055,7 @@ taskq_destroy(taskq_t *tq)
 
 	taskq_wait(tq);
 
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+	spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 
 	/*
 	 * Signal each thread to exit and block until it does.  Each thread
@@ -1069,7 +1071,7 @@ taskq_destroy(taskq_t *tq)
 
 		kthread_stop(thread);
 
-		spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
+		spin_lock_irqsave_nested(&tq->tq_lock, tq->tq_lock_flags, tq->tq_lock_class);
 	}
 
 	while (!list_empty(&tq->tq_free_list)) {
@@ -1112,6 +1114,12 @@ spl_taskq_init(void)
 		taskq_destroy(system_taskq);
 		return (1);
 	}
+
+	/* This is used to annotate tq_lock, so
+	 * 	taskq_dispatch -> taskq_thread_spawn -> taskq_dispatch
+	 * does not trigger a lockdep warning re: possible recursive locking
+	 */
+	dynamic_taskq->tq_lock_class = TQ_LOCK_DYNAMIC;
 
 	return (0);
 }


### PR DESCRIPTION
When running a kernel with CONFIG_LOCKDEP=y, lockdep reports possible
recursive locking in some cases and possible circular locking dependency
in others, within the SPL and ZFS modules.

When lockdep detects these conditions, it disables further lock analysis
for all locks.  This causes /proc/lock_stats not to reflect full
information about lock contention, even in locks without dependency
issues.

This commit creates new macros spin_lock_irqsave_nolockdep and
spin_unlock_irqrestore_nolockdep.  These macros use lockdep_off() and
lockdep_on() to temporarily disable lockdep when taking/releasing the
locks.

This commit also creates a new type of mutex, MUTEX_NOLOCKDEP.  This
mutex type causes subsequent attempts to take or release those locks to
be wrapped in lockdep_off() and lockdep_on().

At this time it's unknown whether this method distorts the statistics
reported by lock_stats.

This commit uses the new spin_lock macros for one such offending lock.

See also commit  "Identify locks flagged by lockdep" at https://github.com/zfsonlinux/zfs/pull/3895

Combined, these two commits mark all offending locks at this time, for
later analysis and fixes or annotation.