### PR TITLE
Fix CPU hotplug

### DIFF
--- a/include/sys/kmem_cache.h
+++ b/include/sys/kmem_cache.h
@@ -170,7 +170,7 @@ typedef struct spl_kmem_cache {
 	uint32_t		skc_magic;	/* Sanity magic */
 	uint32_t		skc_name_size;	/* Name length */
 	char			*skc_name;	/* Name string */
-	spl_kmem_magazine_t	*skc_mag[NR_CPUS]; /* Per-CPU warm cache */
+	spl_kmem_magazine_t	**skc_mag;	/* Per-CPU warm cache */
 	uint32_t		skc_mag_size;	/* Magazine size */
 	uint32_t		skc_mag_refill;	/* Magazine refill count */
 	spl_kmem_ctor_t		skc_ctor;	/* Constructor */


### PR DESCRIPTION
Allocate a kmem cache magazine for every possible CPU which might
be added to the system.  This ensures that when one of these CPUs
is enabled it can be safely used immediately.

For many systems the number of online CPUs is identical to the
number of present CPUs so this does imply an increased memory
footprint.  In fact, dynamically allocating the array of magazine
pointers instead of using the worst case NR_CPUS can end up
decreasing our memory footprint.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>