### PR TITLE
Set spl_taskq_thread_dynamic=0 by default

### DIFF
--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -32,7 +32,7 @@ module_param(spl_taskq_thread_bind, int, 0644);
 MODULE_PARM_DESC(spl_taskq_thread_bind, "Bind taskq thread to CPU by default");
 
 
-int spl_taskq_thread_dynamic = 1;
+int spl_taskq_thread_dynamic = 0;
 module_param(spl_taskq_thread_dynamic, int, 0644);
 MODULE_PARM_DESC(spl_taskq_thread_dynamic, "Allow dynamic taskq threads");
 


### PR DESCRIPTION
Disable dynamic taskqs by default.  They have been implicated in
several lockups and disabling them typically resolves the issue.
These lockups may only occur with certain kernel CONFIG_* options
and versions but until the root cause is identified it's safest
to disable this functionality by default.  End users may opt to
re-enable them if they have not observed any problems in their
environment.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>