### PR TITLE
Don't call kmem_cache_shrink from shrinker

### DIFF
--- a/module/spl/spl-kmem-cache.c
+++ b/module/spl/spl-kmem-cache.c
@@ -1634,16 +1634,11 @@ spl_kmem_cache_reap_now(spl_kmem_cache_t *skc, int count)
 	atomic_inc(&skc->skc_ref);
 
 	/*
-	 * Execute the registered reclaim callback if it exists.  The
-	 * per-cpu caches will be drained when is set KMC_EXPIRE_MEM.
+	 * Execute the registered reclaim callback if it exists.
 	 */
 	if (skc->skc_flags & KMC_SLAB) {
 		if (skc->skc_reclaim)
 			skc->skc_reclaim(skc->skc_private);
-
-		if (spl_kmem_cache_expire & KMC_EXPIRE_MEM)
-			kmem_cache_shrink(skc->skc_linux_cache);
-
 		goto out;
 	}
 


### PR DESCRIPTION
Linux slab will automatically free empty slab when number of partial slab is
over min_partial, so we don't need to explicitly shrink it. In fact, calling
kmem_cache_shrink from shrinker will cause heavy contention on
kmem_cache_node->list_lock, to the point that it might cause __slab_free to
livelock (see zfsonlinux/zfs#3936)

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>