### PR TITLE
sys/sysmacros.h: Fix P2ROUNDUP_TYPED to not trigger integer overflow

### DIFF
--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -186,7 +186,7 @@ extern void spl_cleanup(void);
  */
 #define P2ALIGN(x, align)	((x) & -(align))
 #define P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
-#define P2ROUNDUP(x, align)	(-(-(x) & -(align)))
+#define P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
 #define P2PHASE(x, align)	((x) & ((align) - 1))
 #define P2NPHASE(x, align)	(-(x) & ((align) - 1))
 #define ISP2(x)			(((x) & ((x) - 1)) == 0)
@@ -213,7 +213,7 @@ extern void spl_cleanup(void);
 #define P2NPHASE_TYPED(x, align, type)  \
         (-(type)(x) & ((type)(align) - 1))
 #define P2ROUNDUP_TYPED(x, align, type) \
-        (-(-(type)(x) & -(type)(align)))
+        ((((type)(x) - 1) | ((type)(align) - 1)) + 1)
 #define P2END_TYPED(x, align, type)     \
         (-(~(type)(x) & -(type)(align)))
 #define P2PHASEUP_TYPED(x, align, phase, type)  \


### PR DESCRIPTION
The original P2ROUNDUP_TYPED macro contains a -x which triggers PaX's
integer overflow detection for unsigned integers. Replace the macro with
an equivalent version that does not trigger the overflow.

Signed-off-by: Jason Zaman <jason@perfinion.com>

Fixes issue https://github.com/zfsonlinux/zfs/issues/2505