### PR TITLE
Provide kstat for taskqs in /proc/spl/taskqs

### DIFF
--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -29,6 +29,7 @@
 #include <sys/kmem.h>
 #include <sys/kmem_cache.h>
 #include <sys/vmem.h>
+#include <sys/taskq.h>
 #include <linux/ctype.h>
 #include <linux/kmod.h>
 #include <linux/seq_file.h>
@@ -49,6 +50,8 @@ static struct ctl_table_header *spl_header = NULL;
 static struct proc_dir_entry *proc_spl = NULL;
 static struct proc_dir_entry *proc_spl_kmem = NULL;
 static struct proc_dir_entry *proc_spl_kmem_slab = NULL;
+static struct proc_dir_entry *proc_spl_taskq_all = NULL;
+static struct proc_dir_entry *proc_spl_taskq = NULL;
 struct proc_dir_entry *proc_spl_kstat = NULL;
 
 static int
@@ -216,6 +219,176 @@ proc_dohostid(struct ctl_table *table, int write,
 }
 
 static void
+taskq_seq_show_headers(struct seq_file *f)
+{
+	seq_printf(f, "%-25s %5s %5s %5s %5s %5s %5s %12s %5s %10s\n",
+	    "taskq", "act", "nthr", "spwn", "maxt", "pri",
+	    "mina", "maxa", "cura", "flags");
+}
+
+/* indices into the lheads array below */
+#define	LHEAD_PEND	0
+#define LHEAD_PRIO	1
+#define LHEAD_DELAY	2
+#define LHEAD_WAIT	3
+#define LHEAD_ACTIVE	4
+#define LHEAD_SIZE	5
+
+static int
+taskq_seq_show_impl(struct seq_file *f, void *p, boolean_t allflag)
+{
+	taskq_t *tq = p;
+	taskq_thread_t *tqt;
+	wait_queue_t *wq;
+	struct task_struct *tsk;
+	taskq_ent_t *tqe;
+	char name[100];
+	struct list_head *lheads[LHEAD_SIZE], *lh;
+	static char *list_names[LHEAD_SIZE] =
+	    {"pend", "prio", "delay", "wait", "active" };
+	int i, j, have_lheads = 0;
+	unsigned long wflags, flags;
+
+	spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
+	spin_lock_irqsave(&tq->tq_wait_waitq.lock, wflags);
+
+	/* get the various lists and check whether they're empty */
+	lheads[LHEAD_PEND] = &tq->tq_pend_list;
+	lheads[LHEAD_PRIO] = &tq->tq_prio_list;
+	lheads[LHEAD_DELAY] = &tq->tq_delay_list;
+	lheads[LHEAD_WAIT] = &tq->tq_wait_waitq.task_list;
+	lheads[LHEAD_ACTIVE] = &tq->tq_active_list;
+
+	for (i = 0; i < LHEAD_SIZE; ++i) {
+		if (list_empty(lheads[i]))
+			lheads[i] = NULL;
+		else
+			++have_lheads;
+	}
+
+	/* early return in non-"all" mode if lists are all empty */
+	if (!allflag && !have_lheads) {
+		spin_unlock_irqrestore(&tq->tq_wait_waitq.lock, wflags);
+		spin_unlock_irqrestore(&tq->tq_lock, flags);
+		return (0);
+	}
+
+	/* unlock the waitq quickly */
+	if (!lheads[LHEAD_WAIT])
+		spin_unlock_irqrestore(&tq->tq_wait_waitq.lock, wflags);
+
+	/* show the base taskq contents */
+	snprintf(name, sizeof(name), "%s/%d", tq->tq_name, tq->tq_instance);
+	seq_printf(f, "%-25s ", name);
+	seq_printf(f, "%5d %5d %5d %5d %5d %5d %12d %5d %10x\n",
+	    tq->tq_nactive, tq->tq_nthreads, tq->tq_nspawn,
+	    tq->tq_maxthreads, tq->tq_pri, tq->tq_minalloc, tq->tq_maxalloc,
+	    tq->tq_nalloc, tq->tq_flags);
+
+	/* show the active list */
+	if (lheads[LHEAD_ACTIVE]) {
+		j = 0;
+		list_for_each_entry(tqt, &tq->tq_active_list, tqt_active_list) {
+			if (j == 0)
+				seq_printf(f, "\t%s:", list_names[LHEAD_ACTIVE]);
+			else if (j == 2) {
+				seq_printf(f, "\n\t       ");
+				j = 0;
+			}
+			seq_printf(f, " [%d]%pf(%ps)",
+			    tqt->tqt_thread->pid,
+			    tqt->tqt_task->tqent_func,
+			    tqt->tqt_task->tqent_arg);
+			++j;
+		}
+		seq_printf(f, "\n");
+	}
+
+	for (i = LHEAD_PEND; i <= LHEAD_WAIT; ++i)
+		if (lheads[i]) {
+			j = 0;
+			list_for_each(lh, lheads[i]) {
+				/* show the wait waitq list */
+				if (i == LHEAD_WAIT) {
+					wq = list_entry(lh, wait_queue_t, task_list);
+					if (j == 0)
+						seq_printf(f, "\t%s:",
+						    list_names[i]);
+					else if (j == 12) {
+						seq_printf(f, "\n\t     ");
+						j = 0;
+					}
+					tsk = wq->private;
+					seq_printf(f, " %d", tsk->pid);
+				/* pend, prio and delay lists */
+				} else {
+					tqe = list_entry(lh, taskq_ent_t,
+					    tqent_list);
+					if (j == 0)
+						seq_printf(f, "\t%s:",
+						    list_names[i]);
+					else if (j == 2) {
+						seq_printf(f, "\n\t     ");
+						j = 0;
+					}
+					seq_printf(f, " %pf(%ps)",
+					    tqe->tqent_func,
+					    tqe->tqent_arg);
+				}
+				++j;
+			}
+			seq_printf(f, "\n");
+		}
+	if (lheads[LHEAD_WAIT])
+		spin_unlock_irqrestore(&tq->tq_wait_waitq.lock, wflags);
+	spin_unlock_irqrestore(&tq->tq_lock, flags);
+
+	return (0);
+}
+
+static int
+taskq_all_seq_show(struct seq_file *f, void *p)
+{
+	return (taskq_seq_show_impl(f, p, B_TRUE));
+}
+
+static int
+taskq_seq_show(struct seq_file *f, void *p)
+{
+	return (taskq_seq_show_impl(f, p, B_FALSE));
+}
+
+static void *
+taskq_seq_start(struct seq_file *f, loff_t *pos)
+{
+	struct list_head *p;
+	loff_t n = *pos;
+
+	down_read(&tq_list_sem);
+	if (!n)
+		taskq_seq_show_headers(f);
+
+	p = tq_list.next;
+	while (n--) {
+		p = p->next;
+		if (p == &tq_list)
+		return (NULL);
+	}
+
+	return (list_entry(p, taskq_t, tq_taskqs));
+}
+
+static void *
+taskq_seq_next(struct seq_file *f, void *p, loff_t *pos)
+{
+	taskq_t *tq = p;
+
+	++*pos;
+	return ((tq->tq_taskqs.next == &tq_list) ?
+	       NULL : list_entry(tq->tq_taskqs.next, taskq_t, tq_taskqs));
+}
+
+static void
 slab_seq_show_headers(struct seq_file *f)
 {
         seq_printf(f,
@@ -323,6 +496,52 @@ static struct file_operations proc_slab_operations = {
         .read           = seq_read,
         .llseek         = seq_lseek,
         .release        = seq_release,
+};
+
+static void
+taskq_seq_stop(struct seq_file *f, void *v)
+{
+	up_read(&tq_list_sem);
+}
+
+static struct seq_operations taskq_all_seq_ops = {
+	.show  = taskq_all_seq_show,
+	.start = taskq_seq_start,
+	.next  = taskq_seq_next,
+	.stop  = taskq_seq_stop,
+};
+
+static struct seq_operations taskq_seq_ops = {
+	.show  = taskq_seq_show,
+	.start = taskq_seq_start,
+	.next  = taskq_seq_next,
+	.stop  = taskq_seq_stop,
+};
+
+static int
+proc_taskq_all_open(struct inode *inode, struct file *filp)
+{
+	return seq_open(filp, &taskq_all_seq_ops);
+}
+
+static int
+proc_taskq_open(struct inode *inode, struct file *filp)
+{
+	return seq_open(filp, &taskq_seq_ops);
+}
+
+static struct file_operations proc_taskq_all_operations = {
+	.open           = proc_taskq_all_open,
+	.read           = seq_read,
+	.llseek         = seq_lseek,
+	.release        = seq_release,
+};
+
+static struct file_operations proc_taskq_operations = {
+	.open           = proc_taskq_open,
+	.read           = seq_read,
+	.llseek         = seq_lseek,
+	.release        = seq_release,
 };
 
 static struct ctl_table spl_kmem_table[] = {
@@ -476,6 +695,20 @@ spl_proc_init(void)
 		goto out;
 	}
 
+	proc_spl_taskq_all = proc_create_data("taskq-all", 0444,
+		proc_spl, &proc_taskq_all_operations, NULL);
+	if (proc_spl_taskq_all == NULL) {
+		rc = -EUNATCH;
+		goto out;
+	}
+
+	proc_spl_taskq = proc_create_data("taskq", 0444,
+		proc_spl, &proc_taskq_operations, NULL);
+	if (proc_spl_taskq == NULL) {
+		rc = -EUNATCH;
+		goto out;
+	}
+
         proc_spl_kmem = proc_mkdir("kmem", proc_spl);
         if (proc_spl_kmem == NULL) {
                 rc = -EUNATCH;
@@ -499,6 +732,8 @@ out:
 		remove_proc_entry("kstat", proc_spl);
 	        remove_proc_entry("slab", proc_spl_kmem);
 		remove_proc_entry("kmem", proc_spl);
+		remove_proc_entry("taskq-all", proc_spl);
+		remove_proc_entry("taskq", proc_spl);
 		remove_proc_entry("spl", NULL);
 	        unregister_sysctl_table(spl_header);
 	}
@@ -512,6 +747,8 @@ spl_proc_fini(void)
 	remove_proc_entry("kstat", proc_spl);
         remove_proc_entry("slab", proc_spl_kmem);
 	remove_proc_entry("kmem", proc_spl);
+	remove_proc_entry("taskq-all", proc_spl);
+	remove_proc_entry("taskq", proc_spl);
 	remove_proc_entry("spl", NULL);
 
         ASSERT(spl_header != NULL);

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -54,6 +54,10 @@ EXPORT_SYMBOL(system_taskq);
 static taskq_t *dynamic_taskq;
 static taskq_thread_t *taskq_thread_create(taskq_t *);
 
+/* List of all taskqs */
+LIST_HEAD(tq_list);
+DECLARE_RWSEM(tq_list_sem);
+
 static int
 task_km_flags(uint_t flags)
 {
@@ -64,6 +68,23 @@ task_km_flags(uint_t flags)
 		return (KM_PUSHPAGE);
 
 	return (KM_SLEEP);
+}
+
+/*
+ * taskq_find_by_name - Find the largest instance number of a named taskq.
+ */
+static int
+taskq_find_by_name(const char *name)
+{
+	struct list_head *tql;
+	taskq_t *tq;
+
+	list_for_each_prev(tql, &tq_list) {
+		tq = list_entry(tql, taskq_t, tq_taskqs);
+		if (strcmp(name, tq->tq_name) == 0)
+			return tq->tq_instance;
+	}
+	return (-1);
 }
 
 /*
@@ -1024,6 +1045,7 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	init_waitqueue_head(&tq->tq_work_waitq);
 	init_waitqueue_head(&tq->tq_wait_waitq);
 	tq->tq_lock_class = TQ_LOCK_GENERAL;
+	INIT_LIST_HEAD(&tq->tq_taskqs);
 
 	if (flags & TASKQ_PREPOPULATE) {
 		spin_lock_irqsave_nested(&tq->tq_lock, irqflags,
@@ -1053,6 +1075,11 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	if (rc) {
 		taskq_destroy(tq);
 		tq = NULL;
+	} else {
+		down_write(&tq_list_sem);
+		tq->tq_instance = taskq_find_by_name(name) + 1;
+		list_add_tail(&tq->tq_taskqs, &tq_list);
+		up_write(&tq_list_sem);
 	}
 
 	return (tq);
@@ -1080,6 +1107,11 @@ taskq_destroy(taskq_t *tq)
 		taskq_wait_outstanding(dynamic_taskq, 0);
 
 	taskq_wait(tq);
+
+	/* remove taskq from global list used by the kstats */
+	down_write(&tq_list_sem);
+	list_del(&tq->tq_taskqs);
+	up_write(&tq_list_sem);
 
 	spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
 


### PR DESCRIPTION
I'm posting this as a WIP for further commentary and feedback.  I think the output is potentially useful as it stands but there's plenty that could be changed, added or deleted..  The main goal at the moment is to provide a way to help track down issues regarding dynamic taskqs but the information provided could certainly be useful in other contexts.

Among other things, I've thought about adding a nicer header line and grouping the columns, for example, into a "tqent" section, and others.  There are also likely some non-useful columns at the moment and maybe some others which ought to be added.

On a smaller test system running a bunch of ```zfs send``` and other miscellaneous things running current master code with dynamic taskqs enabled, here's a sample of the output:
```
taskq                       act  nthr  spwn  maxt   pri  mina         maxa  cura      flags
spl_kmem_cache/0              0     1     0     4   100    32   2147483647    32   80000005
spl_system_taskq/0            1     1     0    64   100     8   2147483647     8   80000005
	traverse_prefetch_thread [zfs](0xffff8800c690e420)
spl_dynamic_taskq/0           0     1     0     1   100     8   2147483647     8   80000001
dbu_evict/0                   0     1     0     1   120     0            0     0   80000000
arc_prune/0                   0     1     0     8   120     8   2147483647     8   80000005
z_unmount/0                   0     1     0     1   120     1            8     1   80000001
z_null_iss/0                  0     1     0     1   100    50   2147483647     0   80000004
z_null_int/0                  0     1     0     1   100    50   2147483647     0   80000004
z_rd_iss/0                    0     1     0     8   100    50   2147483647     0   80000004
z_rd_int_0/0                  0     1     0    12   100    50   2147483647     0   80000004
z_rd_int_1/0                  0     1     0    12   100    50   2147483647     0   80000004
...
z_rd_int_1/1                  0     1     0    12   100    50   2147483647     0   80000004
z_rd_int_2/1                  0     1     0    12   100    50   2147483647     0   80000004
z_rd_int_3/1                  0     1     0    12   100    50   2147483647     0   80000004
z_rd_int_4/1                  1     1     0    12   100    50   2147483647     0   80000004
	zio_execute [zfs](0xffff8802256fc1a0)
z_rd_int_5/1                  0     1     0    12   100    50   2147483647     0   80000004
z_rd_int_6/1                  0     1     0    12   100    50   2147483647     0   80000004
z_rd_int_7/1                  0     1     0    12   100    50   2147483647     0   80000004
z_wr_iss/1                    0     1     0     6   101    50   2147483647     0   8000000c
z_wr_iss_h/1                  0     1     0     5   100    50   2147483647     0   80000004
...
metaslab_group_taskq/1        0     1     0     4   100    10   2147483647     0   8000000c
metaslab_group_taskq/2        0     1     0     4   100    10   2147483647     0   8000000c
z_iput/1                      0     1     0     8   120    64   2147483647    64   80000005
```
The "/X" in the name of the taskq is what I'm calling the "instance number".  It's a monotonically increasing integer to help distinguish otherwise identically-named taskqs.