### PR TITLE
Fix race between getf() and areleasef()

### DIFF
--- a/include/sys/user.h
+++ b/include/sys/user.h
@@ -30,8 +30,8 @@
  * about the Linux task_struct. Since this is internal to our compatibility
  * layer, we make it an opaque type.
  *
- * XXX: If the descriptor changes under us, we would get an incorrect
- * reference.
+ * XXX: If the descriptor changes under us and we do not do a getf() between
+ * the change and using it, we would get an incorrect reference.
  */
 
 struct uf_info;


### PR DESCRIPTION
If a vnode is released asynchronously through areleasef(), it is
possible for the user process to reuse the file descriptor before
areleasef is called. When this happens, getf() will return a stale
reference, any operations in the kernel on that file descriptor will
fail (as it is closed) and the operations meant for that fd will
never occur from userspace's perspective.

We correct this by detecting this condition in getf(), doing a putf on the old
file handle, updating the file descriptor and proceeding as if everything was
fine. When the areleasef() is done, it will harmlessly decrement the reference
counter on the Illumos file handle.

Signed-off-by: Richard Yao <ryao@gentoo.org>