### PR TITLE
Prevent rm modules.* when make install

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -26,7 +26,7 @@ modules_install:
 		KERNELRELEASE=@LINUX_VERSION@
 	@# Remove extraneous build products when packaging
 	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@; \
-	if [ -n $$kmoddir ]; then \
+	if [ -n "$(DESTDIR)" ]; then \
 		find $$kmoddir -name 'modules.*' | xargs $(RM); \
 	fi
 	sysmap=$(DESTDIR)$(INSTALL_MOD_PATH)/boot/System.map-@LINUX_VERSION@; \


### PR DESCRIPTION
This was originally in e80cd06b8e0428f3ca2c62e4cb0e4ec54fda1d5c, but somehow
was changed and not working anymore. And it will cause the following error:

```
# modprobe zfs
modprobe: ERROR: ../libkmod/libkmod.c:506 lookup_builtin_file() could not open builtin file '/lib/modules/4.2.0-18-generic/modules.builtin.bin'
```

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>