### PR TITLE
Make taskq_member() use ->journal_info

### DIFF
--- a/include/linux/Makefile.am
+++ b/include/linux/Makefile.am
@@ -1,6 +1,7 @@
 COMMON_H =
 
 KERNEL_H = \
+	$(top_srcdir)/include/linux/api_compat.h \
 	$(top_srcdir)/include/linux/bitops_compat.h \
 	$(top_srcdir)/include/linux/compiler_compat.h \
 	$(top_srcdir)/include/linux/delay_compat.h \

--- a/include/linux/api_compat.h
+++ b/include/linux/api_compat.h
@@ -1,23 +1,46 @@
+typedef struct {
+	struct task_struct *lac_thread;
+	void *lac_journal_info;
+} api_cookie_t;
+
+static inline api_cookie_t
+spl_api_mark(void)
+{
+	api_cookie_t cookie;
+
+	cookie.lac_thread = current;
+	cookie.lac_journal_info = current->journal_info;
+	current->journal_info = NULL;
+
+	return (cookie);
+}
+
+static inline void
+spl_api_unmark(api_cookie_t cookie)
+{
+	ASSERT3P(cookie.lac_thread, ==, current);
+	ASSERT(current->journal_info == NULL);
+
+	current->journal_info = cookie.lac_journal_info;
+}
+
 #define LINUX_API_CALL_VOID(function, ...)			\
 do {								\
-	void *__journal_info = current->journal_info;		\
-	current->journal_info = NULL;				\
+	api_cookie_t cookie = spl_api_mark();		\
 	(void) (function)(__VA_ARGS__);				\
-	current->journal_info = __journal_info;			\
+	spl_api_unmark(cookie);					\
 } while(0)
 
 #define LINUX_API_CALL_TYPED(rc, type, function, ...)		\
 do {								\
-	void *__journal_info = current->journal_info;		\
-	current->journal_info = NULL;				\
+	api_cookie_t cookie = spl_api_mark();		\
 	(rc) = (type)(function)(__VA_ARGS__);			\
-	current->journal_info = __journal_info;			\
+	spl_api_unmark(cookie);					\
 } while(0)
 
 #define LINUX_API_CALL(rc, function, ...)			\
 do {								\
-	void *__journal_info = current->journal_info;		\
-	current->journal_info = NULL;				\
+	api_cookie_t cookie = spl_api_mark();		\
 	(rc) = (function)(__VA_ARGS__);				\
-	current->journal_info = __journal_info;			\
+	spl_api_unmark(cookie);					\
 } while(0)

--- a/include/linux/api_compat.h
+++ b/include/linux/api_compat.h
@@ -1,0 +1,23 @@
+#define LINUX_API_CALL_VOID(function, ...)			\
+do {								\
+	void *__journal_info = current->journal_info;		\
+	current->journal_info = NULL;				\
+	(void) (function)(__VA_ARGS__);				\
+	current->journal_info = __journal_info;			\
+} while(0)
+
+#define LINUX_API_CALL_TYPED(rc, type, function, ...)		\
+do {								\
+	void *__journal_info = current->journal_info;		\
+	current->journal_info = NULL;				\
+	(rc) = (type)(function)(__VA_ARGS__);			\
+	current->journal_info = __journal_info;			\
+} while(0)
+
+#define LINUX_API_CALL(rc, function, ...)			\
+do {								\
+	void *__journal_info = current->journal_info;		\
+	current->journal_info = NULL;				\
+	(rc) = (function)(__VA_ARGS__);				\
+	current->journal_info = __journal_info;			\
+} while(0)

--- a/include/sys/taskq.h
+++ b/include/sys/taskq.h
@@ -124,7 +124,7 @@ extern void taskq_wait_id(taskq_t *, taskqid_t);
 extern void taskq_wait_outstanding(taskq_t *, taskqid_t);
 extern void taskq_wait(taskq_t *);
 extern int taskq_cancel_id(taskq_t *, taskqid_t);
-extern int taskq_member(taskq_t *, void *);
+#define	taskq_member(taskq, thread)	((taskq) == ((thread)->journal_info))
 
 #define taskq_create_proc(name, nthreads, pri, min, max, proc, flags) \
     taskq_create(name, nthreads, pri, min, max, flags)

--- a/module/spl/spl-kobj.c
+++ b/module/spl/spl-kobj.c
@@ -25,6 +25,7 @@
 \*****************************************************************************/
 
 #include <sys/kobj.h>
+#include <linux/api_compat.h>
 
 struct _buf *
 kobj_open_file(const char *name)
@@ -33,12 +34,12 @@ kobj_open_file(const char *name)
 	vnode_t *vp;
 	int rc;
 
-	file = kmalloc(sizeof(_buf_t), kmem_flags_convert(KM_SLEEP));
+	LINUX_API_CALL(file, kmalloc,sizeof(_buf_t), kmem_flags_convert(KM_SLEEP));
 	if (file == NULL)
 		return ((_buf_t *)-1UL);
 
 	if ((rc = vn_open(name, UIO_SYSSPACE, FREAD, 0644, &vp, 0, 0))) {
-		kfree(file);
+		LINUX_API_CALL_VOID(kfree, file);
 		return ((_buf_t *)-1UL);
 	}
 
@@ -52,7 +53,7 @@ void
 kobj_close_file(struct _buf *file)
 {
 	VOP_CLOSE(file->vp, 0, 0, 0, 0, 0);
-        kfree(file);
+	LINUX_API_CALL_VOID(kfree, file);
 } /* kobj_close_file() */
 EXPORT_SYMBOL(kobj_close_file);
 

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -448,40 +448,6 @@ taskq_wait(taskq_t *tq)
 }
 EXPORT_SYMBOL(taskq_wait);
 
-static int
-taskq_member_impl(taskq_t *tq, void *t)
-{
-	struct list_head *l;
-	taskq_thread_t *tqt;
-	int found = 0;
-
-	ASSERT(tq);
-	ASSERT(t);
-	ASSERT(spin_is_locked(&tq->tq_lock));
-
-	list_for_each(l, &tq->tq_thread_list) {
-		tqt = list_entry(l, taskq_thread_t, tqt_thread_list);
-		if (tqt->tqt_thread == (struct task_struct *)t) {
-			found = 1;
-			break;
-		}
-	}
-	return (found);
-}
-
-int
-taskq_member(taskq_t *tq, void *t)
-{
-	int found;
-
-	spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
-	found = taskq_member_impl(tq, t);
-	spin_unlock_irqrestore(&tq->tq_lock, tq->tq_lock_flags);
-
-	return (found);
-}
-EXPORT_SYMBOL(taskq_member);
-
 /*
  * Cancel an already dispatched task given the task id.  Still pending tasks
  * will be immediately canceled, and if the task is active the function will
@@ -812,6 +778,7 @@ taskq_thread(void *args)
 	ASSERT(tqt);
 	tq = tqt->tqt_tq;
 	current->flags |= PF_NOFREEZE;
+	current->journal_info = tq;
 
 	#if defined(PF_MEMALLOC_NOIO)
 	(void) memalloc_noio_save();
@@ -876,6 +843,8 @@ taskq_thread(void *args)
 
 			/* Perform the requested task */
 			t->tqent_func(t->tqent_arg);
+
+			ASSERT3P(tq, ==, current->journal_info);
 
 			spin_lock_irqsave(&tq->tq_lock, tq->tq_lock_flags);
 			tq->tq_nactive--;

--- a/module/spl/spl-thread.c
+++ b/module/spl/spl-thread.c
@@ -142,7 +142,10 @@ spl_kthread_create(int (*func)(void *), void *data, const char namefmt[], ...)
 	vsnprintf(name, sizeof(name), namefmt, args);
 	va_end(args);
 	do {
+		void *journal_info = current->journal_info;
+		current->journal_info = NULL;
 		tsk = kthread_create(func, data, "%s", name);
+		current->journal_info = journal_info;
 		if (IS_ERR(tsk)) {
 			if (signal_pending(current)) {
 				clear_thread_flag(TIF_SIGPENDING);

--- a/module/spl/spl-thread.c
+++ b/module/spl/spl-thread.c
@@ -27,6 +27,7 @@
 #include <sys/thread.h>
 #include <sys/kmem.h>
 #include <sys/tsd.h>
+#include <linux/api_compat.h>
 
 /*
  * Thread interfaces
@@ -142,10 +143,9 @@ spl_kthread_create(int (*func)(void *), void *data, const char namefmt[], ...)
 	vsnprintf(name, sizeof(name), namefmt, args);
 	va_end(args);
 	do {
-		void *journal_info = current->journal_info;
-		current->journal_info = NULL;
+		api_cookie_t cookie = spl_api_mark();
 		tsk = kthread_create(func, data, "%s", name);
-		current->journal_info = journal_info;
+		spl_api_unmark(cookie);
 		if (IS_ERR(tsk)) {
 			if (signal_pending(current)) {
 				clear_thread_flag(TIF_SIGPENDING);

--- a/module/spl/spl-vmem.c
+++ b/module/spl/spl-vmem.c
@@ -24,6 +24,7 @@
 
 #include <sys/debug.h>
 #include <sys/vmem.h>
+#include <linux/api_compat.h>
 #include <linux/mm_compat.h>
 #include <linux/module.h>
 
@@ -103,22 +104,22 @@ EXPORT_SYMBOL(spl_vmem_free);
 void *
 spl_vmalloc(unsigned long size, gfp_t lflags, pgprot_t prot)
 {
-#if defined(PF_MEMALLOC_NOIO)
 	void *ptr;
+#if defined(PF_MEMALLOC_NOIO)
 	unsigned noio_flag = 0;
 
 	if (spl_fstrans_check())
 		noio_flag = memalloc_noio_save();
 
-	ptr =  __vmalloc(size, lflags, prot);
+	LINUX_API_CALL(ptr, __vmalloc, size, lflags, prot);
 
 	if (spl_fstrans_check())
 		memalloc_noio_restore(noio_flag);
 
-	return (ptr);
 #else
-	return (__vmalloc(size, lflags, prot));
+	LINUX_API_CALL(ptr, __vmalloc, size, lflags, prot);
 #endif
+	return (ptr);
 }
 EXPORT_SYMBOL(spl_vmalloc);
 

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -27,6 +27,7 @@
 #include <sys/cred.h>
 #include <sys/vnode.h>
 #include <sys/kmem_cache.h>
+#include <linux/api_compat.h>
 #include <linux/falloc.h>
 #include <linux/file_compat.h>
 
@@ -157,9 +158,9 @@ vn_open(const char *path, uio_seg_t seg, int flags, int mode,
 		return (-PTR_ERR(fp));
 
 #ifdef HAVE_2ARGS_VFS_GETATTR
-	rc = vfs_getattr(&fp->f_path, &stat);
+	LINUX_API_CALL(rc, vfs_getattr, &fp->f_path, &stat);
 #else
-	rc = vfs_getattr(fp->f_path.mnt, fp->f_dentry, &stat);
+	LINUX_API_CALL(rc, vfs_getattr, fp->f_path.mnt, fp->f_dentry, &stat);
 #endif
 	if (rc) {
 		filp_close(fp, 0);
@@ -191,19 +192,20 @@ vn_openat(const char *path, uio_seg_t seg, int flags, int mode,
 	  vnode_t **vpp, int x1, void *x2, vnode_t *vp, int fd)
 {
 	char *realpath;
-	int len, rc;
+	int len, rc = ENOMEM;
 
 	ASSERT(vp == rootdir);
 
 	len = strlen(path) + 2;
-	realpath = kmalloc(len, kmem_flags_convert(KM_SLEEP));
+	LINUX_API_CALL(realpath, kmalloc, len, kmem_flags_convert(KM_SLEEP));
 	if (!realpath)
-		return (ENOMEM);
+		goto ret;
 
 	(void)snprintf(realpath, len, "/%s", path);
 	rc = vn_open(realpath, seg, flags, mode, vpp, x1, x2);
-	kfree(realpath);
+	LINUX_API_CALL_VOID(kfree, realpath);
 
+ret:
 	return (rc);
 } /* vn_openat() */
 EXPORT_SYMBOL(vn_openat);
@@ -237,9 +239,9 @@ vn_rdwr(uio_rw_t uio, vnode_t *vp, void *addr, ssize_t len, offset_t off,
         set_fs(get_ds());
 
 	if (uio & UIO_WRITE)
-		rc = vfs_write(fp, addr, len, &offset);
+		LINUX_API_CALL(rc, vfs_write, fp, addr, len, &offset);
 	else
-		rc = vfs_read(fp, addr, len, &offset);
+		LINUX_API_CALL(rc, vfs_read, fp, addr, len, &offset);
 
 	set_fs(saved_fs);
 	fp->f_pos = offset;
@@ -395,9 +397,9 @@ vn_remove(const char *path, uio_seg_t seg, int flags)
 		}
 
 #ifdef HAVE_2ARGS_VFS_UNLINK
-		rc = vfs_unlink(parent.dentry->d_inode, dentry);
+		LINUX_API_CALL(rc, vfs_unlink, parent.dentry->d_inode, dentry);
 #else
-		rc = vfs_unlink(parent.dentry->d_inode, dentry, NULL);
+		LINUX_API_CALL(rc, vfs_unlink, parent.dentry->d_inode, dentry, NULL);
 #endif /* HAVE_2ARGS_VFS_UNLINK */
 exit1:
 		dput(dentry);
@@ -478,13 +480,13 @@ vn_rename(const char *oldname, const char *newname, int x1)
 	}
 
 #if defined(HAVE_4ARGS_VFS_RENAME)
-	rc = vfs_rename(old_dir->d_inode, old_dentry,
+	LINUX_API_CALL(rc, vfs_rename, old_dir->d_inode, old_dentry,
 	    new_dir->d_inode, new_dentry);
 #elif defined(HAVE_5ARGS_VFS_RENAME)
-	rc = vfs_rename(old_dir->d_inode, old_dentry,
+	LINUX_API_CALL(rc, vfs_rename, old_dir->d_inode, old_dentry,
 	    new_dir->d_inode, new_dentry, NULL);
 #else
-	rc = vfs_rename(old_dir->d_inode, old_dentry,
+	LINUX_API_CALL(rc, vfs_rename, old_dir->d_inode, old_dentry,
 	    new_dir->d_inode, new_dentry, NULL, 0);
 #endif
 exit4:
@@ -514,9 +516,9 @@ vn_getattr(vnode_t *vp, vattr_t *vap, int flags, void *x3, void *x4)
 	fp = vp->v_file;
 
 #ifdef HAVE_2ARGS_VFS_GETATTR
-	rc = vfs_getattr(&fp->f_path, &stat);
+	LINUX_API_CALL(rc, vfs_getattr, &fp->f_path, &stat);
 #else
-	rc = vfs_getattr(fp->f_path.mnt, fp->f_dentry, &stat);
+	LINUX_API_CALL(rc, vfs_getattr, fp->f_path.mnt, fp->f_dentry, &stat);
 #endif
 	if (rc)
 		return (-rc);
@@ -684,9 +686,9 @@ vn_getf(int fd)
 		goto out_fget;
 
 #ifdef HAVE_2ARGS_VFS_GETATTR
-	rc = vfs_getattr(&lfp->f_path, &stat);
+	LINUX_API_CALL(rc, vfs_getattr, &lfp->f_path, &stat);
 #else
-	rc = vfs_getattr(lfp->f_path.mnt, lfp->f_dentry, &stat);
+	LINUX_API_CALL(rc, vfs_getattr, lfp->f_path.mnt, lfp->f_dentry, &stat);
 #endif
         if (rc)
 		goto out_vnode;


### PR DESCRIPTION
The ->journal_info pointer in the task_struct is reserved for use by
filesystems and because the kernel can have multiple file systems on the
same stack due to direct reclaim, each filesystem that touches
->journal_info in a callback function will save the value at the start
of its frame and restore it at the end of its frame.  This allows us to
safely use ->journal_info to store a pointer to the taskq's struct in
taskq threads so that ZFS code paths can detect the presence of a taskq.
This could break if the ZFS code were to use taskq_member from the
context of direct reclaim. However, there are no such uses of it in that
manner, so this is safe.

This eliminates an O(N) list traversal under a spinlock with an O(1)
unlocked pointer comparison.

Closes zfsonlinux/spl#500
Signed-off-by: Richard Yao <ryao@gentoo.org>