### PR TITLE
kobj_read_file: Return -1 on vn_rdwr() error

### DIFF
--- a/include/sys/kobj.h
+++ b/include/sys/kobj.h
@@ -36,7 +36,7 @@ typedef struct _buf buf_t;
 extern struct _buf *kobj_open_file(const char *name);
 extern void kobj_close_file(struct _buf *file);
 extern int kobj_read_file(struct _buf *file, char *buf,
-			  ssize_t size, offset_t off);
+			  unsigned size, unsigned off);
 extern int kobj_get_filesize(struct _buf *file, uint64_t *size);
 
 #endif /* SPL_KOBJ_H */

--- a/module/spl/spl-kobj.c
+++ b/module/spl/spl-kobj.c
@@ -57,10 +57,15 @@ kobj_close_file(struct _buf *file)
 EXPORT_SYMBOL(kobj_close_file);
 
 int
-kobj_read_file(struct _buf *file, char *buf, ssize_t size, offset_t off)
+kobj_read_file(struct _buf *file, char *buf, unsigned size, unsigned off)
 {
-	return (vn_rdwr(UIO_READ, file->vp, buf, size, off,
-	       UIO_SYSSPACE, 0, RLIM64_INFINITY, 0, NULL));
+	ssize_t resid;
+
+	if (vn_rdwr(UIO_READ, file->vp, buf, size, (offset_t)off,
+	    UIO_SYSSPACE, 0, 0, 0, &resid) != 0)
+		return (-1);
+
+	return (size - resid);
 } /* kobj_read_file() */
 EXPORT_SYMBOL(kobj_read_file);
 


### PR DESCRIPTION
I noticed that the SPL implementation of kobj_read_file is not correct
after comparing it with the userland implementation of kobj_read_file()
in zfsonlinux/zfs#4104.

The function is tiny enough that my patch could qualify to be called a
"rewrite", so I am just copying the function on the basis that a rewrite
allows me to license the code under both the CDDL and GPL.

Signed-off-by: Richard Yao <ryao@gentoo.org>