### PR TITLE
_ILP32 is always defined on SPARC

### DIFF
--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -118,10 +118,6 @@
 #define __sparc__
 #endif
 
-#if !defined(_ILP32)
-#define _ILP32
-#endif
-
 #if defined(__arch64__)
 #if !defined(_LP64)
 #define _LP64


### PR DESCRIPTION
When using a SPARC CPU, _ILP32 will always be defined. This wont result in any issues when compiling 32bit, but when compiling 64bit you will end up with _ILP32 and _LP64 defined which will trigger the following error.

````C
#if defined(_ILP32) && defined(_LP64)
#error "Both _ILP32 and _LP64 are defined"
#endif
````

As you can see below, we already have a check for 32bit vs 64bit. So having _ILP32 always be defined not only creates issues for 64bit but is also needlessly redundant.

````C
#if defined(__arch64__)
#if !defined(_LP64)
#define _LP64
#endif
#else
#if !defined(_ILP32)
#define _ILP32
#endif
#endif
````