### PR TITLE
Linux 4.5 compat: pfn_t typedef

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -58,7 +58,6 @@ typedef longlong_t			diskaddr_t;
 typedef ushort_t			o_mode_t;
 typedef uint_t				major_t;
 typedef uint_t				minor_t;
-typedef ulong_t				pfn_t;
 typedef ulong_t				pgcnt_t;
 typedef long				spgcnt_t;
 typedef short				index_t;


### PR DESCRIPTION
The pfn_t typedef was inherited from Illumos but never directly
used by any SPL consumers.  This didn't cause any issues until
the Linux 4.5 kernel introduced a typedef of the same name.
See torvalds/linux/commit/34c0fd54, this patch removes the
unused Illumos version to prevent a conflict.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>