### PR TITLE
Create spl-kmod-debuginfo rpm with redhat spec file

### DIFF
--- a/rpm/generic/spl-kmod.spec.in
+++ b/rpm/generic/spl-kmod.spec.in
@@ -152,6 +152,8 @@ for kernel_version in %{?kernel_versions}; do
         INSTALL_MOD_DIR=%{kmodinstdir_postfix}
     cd ..
 done
+
+# find-debuginfo.sh only considers executables
 chmod u+x ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/*/extra/*/*/*
 %{?akmod_install}
 

--- a/rpm/redhat/spl-kmod.spec.in
+++ b/rpm/redhat/spl-kmod.spec.in
@@ -27,7 +27,6 @@ This package contains the kernel modules required to emulate
 several interfaces provided by the Solaris kernel.
 
 %define kmod_name spl
-%define debug_package %{nil}
 
 %kernel_module_package -n %{kmod_name} -p %{_sourcedir}/kmod-preamble
 
@@ -96,6 +95,8 @@ make install \
         DESTDIR=${RPM_BUILD_ROOT} \
         INSTALL_MOD_DIR=extra/%{kmod_name}
 %{__rm} -f %{buildroot}/lib/modules/%{kverrel}/modules.*
+# find-debuginfo.sh only considers executables
+%{__chmod} u+x  %{buildroot}/lib/modules/%{kverrel}/extra/*/*/*
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Correct the redhat specfile so that working debuginfo rpms are created
for the kernel modules.  The generic specfile already does the right
thing.

SPL equivalent of zfsonlinux/zfs Issue 4224