### PR TITLE
Use raw_smp_processor_id instead of smp_processor_id

### DIFF
--- a/include/sys/processor.h
+++ b/include/sys/processor.h
@@ -25,7 +25,7 @@
 #ifndef	_SPL_PROCESSOR_H
 #define	_SPL_PROCESSOR_H
 
-#define getcpuid() smp_processor_id()
+#define getcpuid() raw_smp_processor_id()
 
 typedef int	processorid_t;
 

--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -79,7 +79,7 @@
 #define curproc				current
 #define max_ncpus			num_possible_cpus()
 #define boot_ncpus			num_online_cpus()
-#define CPU_SEQID			smp_processor_id()
+#define CPU_SEQID			raw_smp_processor_id()
 #define _NOTE(x)
 #define is_system_labeled()		0
 


### PR DESCRIPTION
This means callers do not need to turn off preemption in places where
using this information is safe. Consequently, there is no need to modify
consumers to call `kpreempt_disable()` and `kpreempt_enable()`, which
means that we do not insert a `preempt_schedule()` into places where
there is none on Illumos.

Signed-off-by: Richard Yao <ryao@gentoo.org>