### PR TITLE
Changes needed for ZFS Encryption

### DIFF
--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -26,6 +26,7 @@
 #define _SPL_BYTEORDER_H
 
 #include <asm/byteorder.h>
+#include <sys/isa_defs.h>
 
 #define LE_16(x)	cpu_to_le16(x)
 #define LE_32(x)	cpu_to_le32(x)
@@ -42,5 +43,27 @@
 
 #define BE_IN32(xa) \
 	(((uint32_t)BE_IN16(xa) << 16) | BE_IN16((uint8_t *)(xa)+2))
+
+#ifdef _BIG_ENDIAN
+static __inline__ uint64_t
+htonll(uint64_t n) {
+	return (n);
+}
+
+static __inline__ uint64_t
+ntohll(uint64_t n) {
+	return (n);
+}
+#else
+static __inline__ uint64_t
+htonll(uint64_t n) {
+	return ((((uint64_t)htonl(n)) << 32) + htonl(n >> 32));
+}
+
+static __inline__ uint64_t
+ntohll(uint64_t n) {
+	return ((((uint64_t)ntohl(n)) << 32) + ntohl(n >> 32));
+}
+#endif
 
 #endif /* SPL_BYTEORDER_H */

--- a/include/sys/sunldi.h
+++ b/include/sys/sunldi.h
@@ -34,23 +34,4 @@
 
 #define SECTOR_SIZE 512
 
-typedef struct modlinkage {
-	int ml_rev;
-	struct modlfs *ml_modlfs;
-	struct modldrv *ml_modldrv;
-	major_t ml_major;
-	unsigned ml_minors;
-	void *pad1;
-} modlinkage_t;
-
-typedef struct ldi_ident {
-	char li_modname[MAXNAMELEN];
-	dev_t li_dev;
-} *ldi_ident_t;
-
-typedef struct block_device *ldi_handle_t;
-
-extern int ldi_ident_from_mod(struct modlinkage *modlp, ldi_ident_t *lip);
-extern void ldi_ident_release(ldi_ident_t li);
-
 #endif /* SPL_SUNLDI_H */


### PR DESCRIPTION
2 small changes: Deleted struct modlinkage which is currently unused and redefined in the Illumos Crypto Port (see https://github.com/zfsonlinux/zfs/pull/4329). Also added ntohll macros needed by several encryption algorithms.