### PR TITLE
Use vmem_free() in dfl_free() and add dfl_alloc()

### DIFF
--- a/include/sys/dkioc_free_util.h
+++ b/include/sys/dkioc_free_util.h
@@ -48,7 +48,11 @@ typedef struct dkioc_free_list_s {
 } dkioc_free_list_t;
 
 static inline void dfl_free(dkioc_free_list_t *dfl) {
-	kmem_free(dfl, DFL_SZ(dfl->dfl_num_exts));
+	vmem_free(dfl, DFL_SZ(dfl->dfl_num_exts));
+}
+
+static inline dkioc_free_list_t *dfl_alloc(uint64_t dfl_num_exts, int flags) {
+	return vmem_zalloc(DFL_SZ(dfl_num_exts), flags);
 }
 
 #endif /* _SPL_DKIOC_UTIL_H */

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -571,6 +571,9 @@ int vn_space(vnode_t *vp, int cmd, struct flock *bfp, int flag,
     offset_t offset, void *x6, void *x7)
 {
 	int error = EOPNOTSUPP;
+#ifdef FALLOC_FL_PUNCH_HOLE
+	int fstrans;
+#endif
 
 	if (cmd != F_FREESP || bfp->l_whence != 0)
 		return (EOPNOTSUPP);
@@ -581,12 +584,24 @@ int vn_space(vnode_t *vp, int cmd, struct flock *bfp, int flag,
 
 #ifdef FALLOC_FL_PUNCH_HOLE
 	/*
+	 * May enter XFS which generates a warning when PF_FSTRANS is set.
+	 * To avoid this the flag is cleared over vfs_sync() and then reset.
+	 */
+	fstrans = spl_fstrans_check();
+	if (fstrans)
+		current->flags &= ~(PF_FSTRANS);
+
+	/*
 	 * When supported by the underlying file system preferentially
 	 * use the fallocate() callback to preallocate the space.
 	 */
 	error = -spl_filp_fallocate(vp->v_file,
 	    FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE,
 	    bfp->l_start, bfp->l_len);
+
+	if (fstrans)
+		current->flags |= PF_FSTRANS;
+
 	if (error == 0)
 		return (0);
 #endif


### PR DESCRIPTION
This change was lost, somehow, in e5f9a9a.  Since the arrays can be
rather large, they need to be allocated with vmem_zalloc() and freed
with vmem_free().