### PR TITLE
OpenZFS 6673 - want a macro to convert seconds to nanoseconds and vic…

### DIFF
--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -46,6 +46,9 @@
 #define	MSEC2NSEC(m)	((hrtime_t)(m) * (NANOSEC / MILLISEC))
 #define	NSEC2MSEC(n)	((n) / (NANOSEC / MILLISEC))
 
+#define NSEC2SEC(n)     ((n) / (NANOSEC / SEC))
+#define SEC2NSEC(m)     ((hrtime_t)(m) * (NANOSEC / SEC))  
+
 static const int hz = HZ;
 
 #define	TIMESPEC_OVERFLOW(ts)		\


### PR DESCRIPTION
…e-versa

6673 want a macro to convert seconds to nanoseconds and vice-versa

    Reviewed by: Matthew Ahrens <mahrens@delphix.com>
    Reviewed by: Prakash Surya <prakash.surya@delphix.com>
    Reviewed by: Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
    Reviewed by: Robert Mustacchi <rm@joyent.com>
    Approved by: Dan McDonald <danmcd@omniti.com>

    OpenZFS-issue: https://www.illumos.org/issues/6673
    OpenZFS-commit: https://github.com/openzfs/openzfs/commit/571be5c