### PR TITLE
SPL fixes

### DIFF
--- a/module/spl/spl-condvar.c
+++ b/module/spl/spl-condvar.c
@@ -311,9 +311,8 @@ cv_timedwait_hires_common(kcondvar_t *cvp, kmutex_t *mp, hrtime_t tim, hrtime_t 
 		tim = (tim / res) * res;
 	}
 
-	ASSERT(!(flag & CALLOUT_FLAG_ABSOLUTE));
-	/* get abs expire time */
-	tim += gethrtime();
+	if (!(flag & CALLOUT_FLAG_ABSOLUTE))
+		tim += gethrtime();
 
 	return (__cv_timedwait_hires(cvp, mp, tim, state));
 }

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -447,8 +447,8 @@ taskq_wait_outstanding_check(taskq_t *tq, taskqid_t id)
 void
 taskq_wait_outstanding(taskq_t *tq, taskqid_t id)
 {
-	wait_event(tq->tq_wait_waitq,
-	    taskq_wait_outstanding_check(tq, id ? id : tq->tq_next_id - 1));
+	id = id ? id : tq->tq_next_id - 1;
+	wait_event(tq->tq_wait_waitq, taskq_wait_outstanding_check(tq, id));
 }
 EXPORT_SYMBOL(taskq_wait_outstanding);
 

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -763,11 +763,12 @@ taskq_thread_spawn_task(void *arg)
 	taskq_t *tq = (taskq_t *)arg;
 	unsigned long flags;
 
-	(void) taskq_thread_create(tq);
-
-	spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
-	tq->tq_nspawn--;
-	spin_unlock_irqrestore(&tq->tq_lock, flags);
+	if (taskq_thread_create(tq) == NULL) {
+		/* restore spawning count if failed */
+		spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
+		tq->tq_nspawn--;
+		spin_unlock_irqrestore(&tq->tq_lock, flags);
+	}
 }
 
 /*
@@ -848,6 +849,14 @@ taskq_thread(void *args)
 
 	tsd_set(taskq_tsd, tq);
 	spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
+	/*
+	 * If we are dynamically spawned, decrease spawning count. Note that
+	 * we could be created during taskq_create, in which case we shouldn't
+	 * do the decrement. But it's fine because taskq_create will reset
+	 * tq_nspawn later.
+	 */
+	if (tq->tq_flags & TASKQ_DYNAMIC)
+		tq->tq_nspawn--;
 
 	/* Immediately exit if more threads than allowed were created. */
 	if (tq->tq_nthreads >= tq->tq_maxthreads)
@@ -1063,6 +1072,11 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 
 	/* Wait for all threads to be started before potential destroy */
 	wait_event(tq->tq_wait_waitq, tq->tq_nthreads == count);
+	/*
+	 * taskq_thread might have touched nspawn, but we don't want them to
+	 * because they're not dynamically spawned. So we reset it to 0
+	 */
+	tq->tq_nspawn = 0;
 
 	if (rc) {
 		taskq_destroy(tq);
@@ -1106,6 +1120,12 @@ taskq_destroy(taskq_t *tq)
 	up_write(&tq_list_sem);
 
 	spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
+	/* wait for spawning threads to insert themselves to the list */
+	while (tq->tq_nspawn) {
+		spin_unlock_irqrestore(&tq->tq_lock, flags);
+		schedule_timeout_interruptible(1);
+		spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
+	}
 
 	/*
 	 * Signal each thread to exit and block until it does.  Each thread

--- a/module/splat/splat-condvar.c
+++ b/module/splat/splat-condvar.c
@@ -90,7 +90,7 @@ splat_condvar_test12_thread(void *arg)
 
 	/* wait for main thread reap us */
 	while (!kthread_should_stop())
-		schedule();
+		schedule_timeout_interruptible(1);
 	return 0;
 }
 
@@ -123,14 +123,14 @@ splat_condvar_test1(struct file *file, void *arg)
 
 	/* Wait until all threads are waiting on the condition variable */
 	while (atomic_read(&cv.cv_condvar.cv_waiters) != count)
-		schedule();
+		schedule_timeout_interruptible(1);
 
 	/* Wake a single thread at a time, wait until it exits */
 	for (i = 1; i <= count; i++) {
 		cv_signal(&cv.cv_condvar);
 
 		while (atomic_read(&cv.cv_condvar.cv_waiters) > (count - i))
-			schedule();
+			schedule_timeout_interruptible(1);
 
 		/* Correct behavior 1 thread woken */
 		if (atomic_read(&cv.cv_condvar.cv_waiters) == (count - i))
@@ -149,7 +149,7 @@ splat_condvar_test1(struct file *file, void *arg)
 
 	/* Wait until that last nutex is dropped */
 	while (mutex_owner(&cv.cv_mtx))
-		schedule();
+		schedule_timeout_interruptible(1);
 
 	/* Wake everything for the failure case */
 	cv_broadcast(&cv.cv_condvar);
@@ -194,14 +194,14 @@ splat_condvar_test2(struct file *file, void *arg)
 
 	/* Wait until all threads are waiting on the condition variable */
 	while (atomic_read(&cv.cv_condvar.cv_waiters) != count)
-		schedule();
+		schedule_timeout_interruptible(1);
 
 	/* Wake all threads waiting on the condition variable */
 	cv_broadcast(&cv.cv_condvar);
 
 	/* Wait until all threads have exited */
 	while ((atomic_read(&cv.cv_condvar.cv_waiters) > 0) || mutex_owner(&cv.cv_mtx))
-		schedule();
+		schedule_timeout_interruptible(1);
 
         splat_vprint(file, SPLAT_CONDVAR_TEST2_NAME, "Correctly woke all "
 			   "%d sleeping threads at once\n", count);
@@ -251,7 +251,7 @@ splat_condvar_test34_thread(void *arg)
 
 	/* wait for main thread reap us */
 	while (!kthread_should_stop())
-		schedule();
+		schedule_timeout_interruptible(1);
 	return 0;
 }
 
@@ -284,14 +284,14 @@ splat_condvar_test3(struct file *file, void *arg)
 
 	/* Wait until all threads are waiting on the condition variable */
 	while (atomic_read(&cv.cv_condvar.cv_waiters) != count)
-		schedule();
+		schedule_timeout_interruptible(1);
 
 	/* Wake a single thread at a time, wait until it exits */
 	for (i = 1; i <= count; i++) {
 		cv_signal(&cv.cv_condvar);
 
 		while (atomic_read(&cv.cv_condvar.cv_waiters) > (count - i))
-			schedule();
+			schedule_timeout_interruptible(1);
 
 		/* Correct behavior 1 thread woken */
 		if (atomic_read(&cv.cv_condvar.cv_waiters) == (count - i))
@@ -315,7 +315,7 @@ splat_condvar_test3(struct file *file, void *arg)
 
 	/* Wait until that last nutex is dropped */
 	while (mutex_owner(&cv.cv_mtx))
-		schedule();
+		schedule_timeout_interruptible(1);
 
 	/* Wake everything for the failure case */
 	cv_broadcast(&cv.cv_condvar);
@@ -360,14 +360,14 @@ splat_condvar_test4(struct file *file, void *arg)
 
 	/* Wait until all threads are waiting on the condition variable */
 	while (atomic_read(&cv.cv_condvar.cv_waiters) != count)
-		schedule();
+		schedule_timeout_interruptible(1);
 
 	/* Wake a single thread at a time, wait until it exits */
 	for (i = 1; i <= count; i++) {
 		cv_signal(&cv.cv_condvar);
 
 		while (atomic_read(&cv.cv_condvar.cv_waiters) > (count - i))
-			schedule();
+			schedule_timeout_interruptible(1);
 
 		/* Correct behavior 1 thread woken */
 		if (atomic_read(&cv.cv_condvar.cv_waiters) == (count - i))
@@ -391,7 +391,7 @@ splat_condvar_test4(struct file *file, void *arg)
 
 	/* Wait until that last nutex is dropped */
 	while (mutex_owner(&cv.cv_mtx))
-		schedule();
+		schedule_timeout_interruptible(1);
 
 	/* Wake everything for the failure case */
 	cv_broadcast(&cv.cv_condvar);


### PR DESCRIPTION
1. Restore CALLOUT_FLAG_ABSOLUTE in cv_timedwait_hires
2. Fix splat-condvar on Linux 4.7
3. Fix race in taskq_destroy and dynamic spawing