### PR TITLE
Add isa_defs for MIPS

### DIFF
--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -162,9 +162,10 @@
 
 #define	_SUNOS_VTOC_16
 
-#else /* Currently support
-       * x86_64, i386, arm, powerpc, s390, sparc, and mips
-       */
+#else
+/* Currently support
+ * x86_64, i386, arm, powerpc, s390, sparc, and mips
+ */
 #error "Unsupported ISA type"
 #endif
 

--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -157,12 +157,14 @@
 #endif
 
 #ifndef _LP64
-#define _ILP32
+#define	_ILP32
 #endif
 
 #define	_SUNOS_VTOC_16
 
-#else /* Currently x86_64, i386, arm, powerpc, s390, sparc, and mips are supported */
+#else /* Currently support
+       * x86_64, i386, arm, powerpc, s390, sparc, and mips
+       */
 #error "Unsupported ISA type"
 #endif
 

--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -145,7 +145,24 @@
 
 #define	_BIG_ENDIAN
 
-#else /* Currently x86_64, i386, arm, powerpc, s390, and sparc are supported */
+/* MIPS arch specific defines */
+#elif defined(__mips__)
+
+#if defined(__MIPSEB__)
+#define	_BIG_ENDIAN
+#elif defined(__MIPSEL__)
+#define	_LITTLE_ENDIAN
+#else
+#error MIPS no endian specified
+#endif
+
+#ifndef _LP64
+#define _ILP32
+#endif
+
+#define	_SUNOS_VTOC_16
+
+#else /* Currently x86_64, i386, arm, powerpc, s390, sparc, and mips are supported */
 #error "Unsupported ISA type"
 #endif
 

--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -163,7 +163,8 @@
 #define	_SUNOS_VTOC_16
 
 #else
-/* Currently support
+/*
+ * Currently support
  * x86_64, i386, arm, powerpc, s390, sparc, and mips
  */
 #error "Unsupported ISA type"


### PR DESCRIPTION
GCC for MIPS only defines _LP64 when 64bit,
while no _ILP32 defined when 32bit.