### PR TITLE
Linux 4.8 compat: rw_semaphore atomic_long_t count

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -40,6 +40,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_SHRINK_CONTROL_STRUCT
 	SPL_AC_RWSEM_SPINLOCK_IS_RAW
 	SPL_AC_RWSEM_ACTIVITY
+	SPL_AC_RWSEM_ATOMIC_LONG_COUNT
 	SPL_AC_SCHED_RT_HEADER
 	SPL_AC_2ARGS_VFS_GETATTR
 	SPL_AC_USLEEP_RANGE
@@ -1335,6 +1336,31 @@ AC_DEFUN([SPL_AC_RWSEM_ACTIVITY], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_RWSEM_ACTIVITY, 1,
 		[struct rw_semaphore has member activity])
+	],[
+		AC_MSG_RESULT(no)
+	])
+	EXTRA_KCFLAGS="$tmp_flags"
+])
+
+dnl #
+dnl # 4.8 API Change
+dnl #
+dnl # rwsem "->count" changed to atomic_long_t type
+dnl #
+AC_DEFUN([SPL_AC_RWSEM_ATOMIC_LONG_COUNT], [
+	AC_MSG_CHECKING(
+	[whether struct rw_semaphore has atomic_long_t member count])
+	tmp_flags="$EXTRA_KCFLAGS"
+	EXTRA_KCFLAGS="-Werror"
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/rwsem.h>
+	],[
+		DECLARE_RWSEM(dummy_semaphore);
+		(void) atomic_long_read(&dummy_semaphore.count);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_RWSEM_ATOMIC_LONG_COUNT, 1,
+		[struct rw_semaphore has atomic_long_t member count])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/include/linux/rwsem_compat.h
+++ b/include/linux/rwsem_compat.h
@@ -35,9 +35,12 @@
 #define	SPL_RWSEM_SINGLE_WRITER_VALUE	(RWSEM_ACTIVE_WRITE_BIAS)
 #endif
 
-/* Linux 3.16 change activity to count for rwsem-spinlock */
-#ifdef HAVE_RWSEM_ACTIVITY
+/* Linux 3.16 changed activity to count for rwsem-spinlock */
+#if defined(HAVE_RWSEM_ACTIVITY)
 #define	RWSEM_COUNT(sem)	sem->activity
+/* Linux 4.8 changed count to an atomic_long_t for !rwsem-spinlock */
+#elif defined(HAVE_RWSEM_ATOMIC_LONG_COUNT)
+#define	RWSEM_COUNT(sem)	atomic_long_read(&(sem)->count)
 #else
 #define	RWSEM_COUNT(sem)	sem->count
 #endif


### PR DESCRIPTION
For non-rwsem-spinlocks the "count" member was changed from a
"long" to "atomic_long_t" type.  A configure check has been
added to detect this change along with new versions of the
_rwsem_tryupgrade() function and RWSEM_COUNT() macro.  See
torvalds/linux/commit/8ee62b18 for complete details.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #563