### PR TITLE
Fix HAVE_MUTEX_OWNER test for kernels prior to 4.6

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -1516,6 +1516,7 @@ AC_DEFUN([SPL_AC_MUTEX_OWNER], [
 	EXTRA_KCFLAGS="-Werror"
 	SPL_LINUX_TRY_COMPILE([
 		#include <linux/mutex.h>
+		#include <linux/spinlock.h>
 	],[
 		DEFINE_MUTEX(m);
 		struct task_struct *t __attribute__ ((unused));


### PR DESCRIPTION
Recent 4.X kernels prior to 4.6 require #include of spinlock.h in
order to get the definition of __ARCH_SPIN_LOCK_UNLOCKED which is used
by DEFINE_MUTEX().

[EDIT: missing space in commit comment fixed but not yet committed/pushed]