### PR TITLE
Fix: handle NULL case in spl_kmem_free_track()

### DIFF
--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -383,6 +383,10 @@ spl_kmem_free_track(const void *ptr, size_t size)
 {
 	kmem_debug_t *dptr;
 
+	/* Ignore NULL pointer since we haven't tracked it at all*/
+	if (ptr == NULL)
+		return;
+
 	/* Must exist in hash due to kmem_alloc() */
 	dptr = kmem_del_init(&kmem_lock, kmem_table, KMEM_HASH_BITS, ptr);
 	ASSERT3P(dptr, !=, NULL);


### PR DESCRIPTION
Reference issue: #https://github.com/zfsonlinux/zfs/issues/4967

When DEBUG_KMEM_TRACKING is enabled in SPL, we keep tracking all the buffers alloced by
kmem_alloc() and kmem_zalloc().  If a NULL pointer which indicates no track info in SPL
is passed to spl_kmem_free_track, we just ignore it.