### PR TITLE
Update spl check script

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -28,7 +28,7 @@
 prog=check.sh
 spl_module=../module/spl/spl.ko
 splat_module=../module/splat/splat.ko
-splat_cmd=../cmd/splat
+splat_cmd=../cmd/splat/splat
 verbose=
 
 die() {


### PR DESCRIPTION
issues:
As script check.sh is executed, some problem can occur.

[root@brs172 /home/liuhua/OpenZFS/spl-master913/spl-master/scripts]# ./check.sh 
Loading ../module/spl/spl.ko
Loading ../module/splat/splat.ko
./check.sh: line 89: ../cmd/splat: is a directory
Unloading ../module/splat/splat.ko
Unloading ../module/spl/spl.ko

solution:
"splat_cmd=../cmd/splat" is a directory, so it must be "splat_cmd=../cmd/splat/splat" 