### PR TITLE
Fix automatically generated release number

### DIFF
--- a/config/spl-meta.m4
+++ b/config/spl-meta.m4
@@ -63,6 +63,14 @@ AC_DEFUN([SPL_AC_META], [
 			if test -n "${_release}"; then
 				SPL_META_RELEASE=${_release}
 				_spl_ac_meta_type="git describe"
+			else
+				_match="${SPL_META_NAME}-${SPL_META_VERSION}-${SPL_META_RELEASE}"
+	                        _alias=$(git describe --match=${_match} 2>/dev/null)
+	                        _release=$(echo ${_alias}|cut -f3- -d'-'|sed 's/-/_/g')
+				if test -n "${_release}"; then
+					SPL_META_RELEASE=${_release}
+					_spl_ac_meta_type="git describe"
+				fi
 			fi
 		fi
 


### PR DESCRIPTION
When building from the head of a branch a release number is
automatically generated with `git describe` using the last tag
on that branch as the base.  For this to work the last tag on the
branch needs to be predictable given the current META file.

This logic was accidentally broken when an -rcX tag was added to
the branch.  Update it to search for a VERSION or VERSION-RELEASE
tag.

Reviewed-by: Chris Siebenmann <cks.git01@cs.toronto.edu>
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue zfsonlinux/zfs#5105