### PR TITLE
Fix out-of-bound in per_cpu in spl_random_init

### DIFF
--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -638,7 +638,7 @@ spl_random_init(void)
 		    "0x%016llx%016llx.", cpu_to_be64(s[0]), cpu_to_be64(s[1]));
 	}
 
-	for (i = 0; i < NR_CPUS; i++) {
+	for_each_possible_cpu(i) {
 		uint64_t *wordp = per_cpu(spl_pseudo_entropy, i);
 
 		spl_rand_jump(s);


### PR DESCRIPTION
When iterating per_cpu values, we need to use for_each_cpu. While NR_CPUS
indicates the number of CPU supported by the kernel, it might not initialize
all of them if the kernel decides it's not possible to use them.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>