### PR TITLE
Linux 4.9 compat: supplementary groups

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -33,6 +33,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_INODE_TRUNCATE_RANGE
 	SPL_AC_FS_STRUCT_SPINLOCK
 	SPL_AC_KUIDGID_T
+	SPL_AC_GROUP_INFO_GRP
 	SPL_AC_PUT_TASK_STRUCT
 	SPL_AC_KERNEL_FALLOCATE
 	SPL_AC_CONFIG_ZLIB_INFLATE
@@ -1075,6 +1076,30 @@ AC_DEFUN([SPL_AC_KUIDGID_T], [
 			AC_MSG_RESULT(yes; mandatory)
 			AC_DEFINE(HAVE_KUIDGID_T, 1, [kuid_t/kgid_t in use])
 		])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
+dnl # 4.9 API change,
+dnl # Credential supplementary groups converted to gid array.
+dnl #
+AC_DEFUN([SPL_AC_GROUP_INFO_GRP], [
+	AC_MSG_CHECKING([whether gi->gid[] is available])
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/uidgid.h>
+		#include <linux/cred.h>
+	], [
+		struct group_info *gi;
+
+		gi = groups_alloc(1);
+		gi->gid[0] = KGIDT_INIT(0);
+		groups_free(gi);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_GROUP_INFO_GRP, 1,
+		          [struct group_info has member gid])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/module/spl/spl-cred.c
+++ b/module/spl/spl-cred.c
@@ -49,8 +49,13 @@ cr_groups_search(const struct group_info *group_info, gid_t grp)
 	right = group_info->ngroups;
 	while (left < right) {
 		mid = (left + right) / 2;
+#ifdef HAVE_GROUP_INFO_GRP
+		cmp = KGID_TO_SGID(grp) -
+		    KGID_TO_SGID(group_info->gid[mid]);
+#else
 		cmp = KGID_TO_SGID(grp) -
 		    KGID_TO_SGID(GROUP_AT(group_info, mid));
+#endif
 
 		if (cmp > 0)
 			left = mid + 1;
@@ -104,7 +109,11 @@ crgetgroups(const cred_t *cr)
 	gid_t *gids;
 
 	gi = get_group_info(cr->group_info);
+#ifdef HAVE_GROUP_INFO_GRP
+	gids = KGIDP_TO_SGIDP(&gi->gid[0]);
+#else
 	gids = KGIDP_TO_SGIDP(gi->blocks[0]);
+#endif
 	put_group_info(gi);
 
 	return gids;


### PR DESCRIPTION
Commit torvalds/linux@81243ea reworked the supplementary groups to
dynamically allocate the required memory.  This resulted in changes
to the group_info structure which need to be handled.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>