### PR TITLE
mutex: serialize exit()/destroy() without spinlock

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -20,6 +20,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_DEBUG
 	SPL_AC_DEBUG_KMEM
 	SPL_AC_DEBUG_KMEM_TRACKING
+	SPL_AC_DEBUG_LOCK_TRACKING
 	SPL_AC_TEST_MODULE
 	SPL_AC_ATOMIC_SPINLOCK
 	SPL_AC_SHRINKER_CALLBACK
@@ -155,7 +156,7 @@ AC_DEFUN([SPL_AC_KERNEL], [
 
 	if test "$utsrelease"; then
 		kernsrcver=`(echo "#include <$utsrelease>";
-		             echo "kernsrcver=UTS_RELEASE") | 
+		             echo "kernsrcver=UTS_RELEASE") |
 		             cpp -I $kernelbuild/include |
 		             grep "^kernsrcver=" | cut -d \" -f 2`
 
@@ -226,7 +227,7 @@ AC_DEFUN([SPL_AC_RPM], [
 		AC_MSG_RESULT([$HAVE_RPMBUILD])
 	])
 
-	RPM_DEFINE_COMMON='--define "$(DEBUG_SPL) 1" --define "$(DEBUG_KMEM) 1" --define "$(DEBUG_KMEM_TRACKING) 1"'
+	RPM_DEFINE_COMMON='--define "$(DEBUG_SPL) 1" --define "$(DEBUG_KMEM) 1" --define "$(DEBUG_KMEM_TRACKING) 1" --define "$(DEBUG_LOCK_TRACKING) 1"'
 	RPM_DEFINE_UTIL=
 	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)"'
 	RPM_DEFINE_DKMS=
@@ -516,6 +517,33 @@ AC_DEFUN([SPL_AC_DEBUG_KMEM_TRACKING], [
 	AC_SUBST(DEBUG_KMEM_TRACKING)
 	AC_MSG_CHECKING([whether detailed kmem tracking is enabled])
 	AC_MSG_RESULT([$enable_debug_kmem_tracking])
+])
+
+dnl #
+dnl # Disabled by default it provides detailed lock liveness tracking.
+dnl # This feature tracks location of init() calls for kmutex_t, kcondvar_t and
+dnl # krwlock_t, and matching destroy calls. List of unmatched variables is
+dnl # kprint-ed on SPL module unload.
+dnl #
+AC_DEFUN([SPL_AC_DEBUG_LOCK_TRACKING], [
+	AC_ARG_ENABLE([debug-lock-tracking],
+		[AS_HELP_STRING([--enable-debug-lock-tracking],
+		[Enable detailed lock init/destroy tracking  @<:@default=no@:>@])],
+		[],
+		[enable_debug_lock_tracking=no])
+
+	AS_IF([test "x$enable_debug_lock_tracking" = xyes],
+	[
+		DEBUG_LOCK_TRACKING="_with_debug_lock_tracking"
+		AC_DEFINE([DEBUG_LOCK_TRACKING], [1],
+		[Define to 1 to enable detailed lock tracking])
+	], [
+		DEBUG_LOCK_TRACKING="_without_debug_lock_tracking"
+	])
+
+	AC_SUBST(DEBUG_LOCK_TRACKING)
+	AC_MSG_CHECKING([whether detailed lock init/destroy tracking is enabled])
+	AC_MSG_RESULT([$enable_debug_lock_tracking])
 ])
 
 dnl #

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -5,6 +5,7 @@ COMMON_H =
 KERNEL_H = \
 	$(top_srcdir)/include/splat-ctl.h \
 	$(top_srcdir)/include/spl-ctl.h \
+	$(top_srcdir)/include/spl-lockdbg.h \
 	$(top_srcdir)/include/strings.h \
 	$(top_srcdir)/include/unistd.h
 

--- a/include/spl-lockdbg.h
+++ b/include/spl-lockdbg.h
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (C) 2016 Gvozden Neskovic <neskovic@gmail.com>
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SPL_LOCKDBG_H
+#define	_SPL_LOCKDBG_H
+
+#ifdef DEBUG_LOCK_TRACKING
+
+#include <linux/types.h>
+#include <linux/rbtree.h>
+#include <linux/hash.h>
+#include <linux/slab.h>
+#include <linux/ratelimit.h>
+#include <linux/stacktrace.h>
+#include <linux/seq_file.h>
+#include <linux/proc_fs.h>
+#include <linux/jiffies.h>
+
+#define	SLT_BCKT_SIZE_BITS	(9)
+#define	SLT_BCKT_SIZE		(1U << SLT_BCKT_SIZE_BITS)
+#define	SLT_HASH(x)		(hash_ptr((void *)x, SLT_BCKT_SIZE_BITS))
+
+typedef struct spl_lock_tracking {
+	rwlock_t		slt_rwlock;		/* global rwlock */
+	struct rb_root		slt_buckets[SLT_BCKT_SIZE]; /* tracked */
+	spinlock_t		slt_locks[SLT_BCKT_SIZE]; /* tracked locks */
+	atomic_t		slt_cnt;		/* tracked count */
+	struct rb_root		slt_mismatched;		/* mismatched */
+	spinlock_t		slt_mismatched_lock;	/* mismatched locks */
+	atomic_t		slt_mismatched_cnt;	/* mismatched count */
+} spl_lock_tracking_t;
+
+extern spl_lock_tracking_t lock_tracker;
+
+#define	SLT_FILE_LOC(l)		(strrchr(l, '/') ? strrchr(l, '/') + 1 : (l))
+
+#define	SLT_RWLOCK(sltp)		(&(sltp)->slt_rwlock)
+#define	SLT_BUCKET(sltp, idx)		(&((sltp)->slt_buckets[idx]))
+#define	SLT_BUCKET_LOCK(sltp, idx)	(&((sltp)->slt_locks[idx]))
+
+#define	SLT_TRACKED_NUM(sltp)		atomic_read(&((sltp)->slt_cnt))
+#define	SLT_TRACKED_INC(sltp)		atomic_inc(&((sltp)->slt_cnt))
+#define	SLT_TRACKED_DEC(sltp)		atomic_dec(&((sltp)->slt_cnt))
+
+#define	SLT_MISMATCHED(sltp)		(&((sltp)->slt_mismatched))
+#define	SLT_MISMATCHED_LOCK(sltp)	(&((sltp)->slt_mismatched_lock))
+#define	SLT_MISMATCHED_NUM(sltp)	atomic_read(&(sltp)->slt_mismatched_cnt)
+#define	SLT_MISMATCHED_INC(sltp)	atomic_inc(&(sltp)->slt_mismatched_cnt)
+#define	SLT_MISMATCHED_DEC(sltp)	atomic_dec(&(sltp)->slt_mismatched_cnt)
+
+#define	_OBJ_INIT_LOC1(x) #x
+#define	_OBJ_INIT_LOC2(x) _OBJ_INIT_LOC1(x)
+#define	OBJ_INIT_LOC __FILE__ ":" _OBJ_INIT_LOC2(__LINE__)
+
+typedef enum  lock_type {
+	SLT_MUTEX	= 0,
+	SLT_RWLOCK	= 1,
+	SLT_CONDVAR	= 2,
+} lock_type_t;
+
+typedef struct lock_tracking_node {
+	struct rb_node	lt_rbnode;
+	ulong_t		lt_ptr;
+	lock_type_t	lt_type;
+#define	LT_LOC_SIZE	32
+	char		lt_loc[LT_LOC_SIZE];
+#define	LT_STACK_TRACE_SIZE	22
+	ulong_t		lt_trace[LT_STACK_TRACE_SIZE];
+	ulong_t		lt_trace_nr;
+} lock_tracking_node_t;
+
+
+extern struct file_operations proc_rwlock_tracking_operations;
+extern struct file_operations proc_mutex_tracking_operations;
+extern struct file_operations proc_condvar_tracking_operations;
+
+/*
+ * Tracker interface:
+ * - spl_lock_tracking_record_init(lock_type_t, ulong_t, char *)
+ * - spl_lock_tracking_record_destroy(lock_type_t, ulong_t, char *)
+ */
+void spl_lock_tracking_record_init(lock_type_t type, ulong_t lp, char *loc);
+void spl_lock_tracking_record_destroy(lock_type_t type, ulong_t lp, char *loc);
+
+void spl_lockdbg_fini(void);
+
+#else
+
+#define	DEFINE_LOCK_TRACKING(module)	void *module = NULL
+
+#define	spl_lock_tracking_record_init(a, b, c)		do {} while (0)
+#define	spl_lock_tracking_record_destroy(a, b, c)	do {} while (0)
+#define	spl_lockdbg_fini()				do {} while (0)
+
+#endif /* DEBUG_LOCK_TRACKING */
+
+#endif /* _SPL_LOCKDBG_H */

--- a/include/sys/condvar.h
+++ b/include/sys/condvar.h
@@ -31,6 +31,7 @@
 #include <sys/kmem.h>
 #include <sys/mutex.h>
 #include <sys/callo.h>
+#include <spl-lockdbg.h>
 
 /*
  * The kcondvar_t struct is protected by mutex taken externally before
@@ -64,8 +65,20 @@ extern clock_t cv_timedwait_sig_hires(kcondvar_t *, kmutex_t *, hrtime_t,
 extern void __cv_signal(kcondvar_t *);
 extern void __cv_broadcast(kcondvar_t *c);
 
-#define	cv_init(cvp, name, type, arg)		__cv_init(cvp, name, type, arg)
-#define	cv_destroy(cvp)				__cv_destroy(cvp)
+#define	cv_init(cvp, name, type, arg)					\
+do {									\
+	__cv_init(cvp, name, type, arg);				\
+	spl_lock_tracking_record_init(SLT_CONDVAR, (ulong_t)cvp,	\
+	    OBJ_INIT_LOC);						\
+} while (0)
+
+#define	cv_destroy(cvp)							\
+do {									\
+	__cv_destroy(cvp);						\
+	spl_lock_tracking_record_destroy(SLT_CONDVAR, (ulong_t)cvp,	\
+	    OBJ_INIT_LOC);						\
+} while (0)
+
 #define	cv_wait(cvp, mp)			__cv_wait(cvp, mp)
 #define	cv_wait_io(cvp, mp)			__cv_wait_io(cvp, mp)
 #define	cv_wait_sig(cvp, mp)			__cv_wait_sig(cvp, mp)
@@ -75,5 +88,9 @@ extern void __cv_broadcast(kcondvar_t *c);
 #define	cv_timedwait_interruptible(cvp, mp, t)	cv_timedwait_sig(cvp, mp, t)
 #define	cv_signal(cvp)				__cv_signal(cvp)
 #define	cv_broadcast(cvp)			__cv_broadcast(cvp)
+
+
+int spl_condvar_init(void);
+void spl_condvar_fini(void);
 
 #endif /* _SPL_CONDVAR_H */

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -31,22 +31,24 @@
 #include <linux/lockdep.h>
 
 typedef enum {
-	MUTEX_DEFAULT	= 0,
-	MUTEX_SPIN	= 1,
-	MUTEX_ADAPTIVE	= 2,
-	MUTEX_NOLOCKDEP	= 3
+	MUTEX_DEFAULT   = 0,
+	MUTEX_NOLOCKDEP = 1
 } kmutex_type_t;
 
 typedef struct {
+	atomic_t		m_flags; /* use lower bits for sync counter */
 	struct mutex		m_mutex;
-	spinlock_t		m_lock;	/* used for serializing mutex_exit */
 	kthread_t		*m_owner;
-#ifdef CONFIG_LOCKDEP
-	kmutex_type_t		m_type;
-#endif /* CONFIG_LOCKDEP */
 } kmutex_t;
 
+/* Use upper portion of m_flags to store flags */
+#define	MUTEX_FLAG_NOLOCKDEP	((u32)1 << 31)
+#define	MUTEX_FLAG_MASK		(~(((u32)1 << 31) - 1))
+
 #define	MUTEX(mp)		(&((mp)->m_mutex))
+#define	MUTEX_FLAGS(mp)		(atomic_read(&(mp)->m_flags) & MUTEX_FLAG_MASK)
+#define	MUTEX_COUNTER(mp)	(&((mp)->m_flags))
+#define	MUTEX_COUNTER_VAL(mp)	(atomic_read(&(mp)->m_flags) & ~MUTEX_FLAG_MASK)
 
 static inline void
 spl_mutex_set_owner(kmutex_t *mp)
@@ -60,31 +62,52 @@ spl_mutex_clear_owner(kmutex_t *mp)
 	mp->m_owner = NULL;
 }
 
+static inline void
+spl_mutex_set_type(kmutex_t *mp, kmutex_type_t type)
+{
+	u32 t = 0;
+
+	/*
+	 * Mutex m_flags flag/counter bits:
+	 * bit 31 : NOLOCKDEP
+	 * bits [30 - 0]: mutex_exit counter (m_flags & ~MUTEX_FLAG_MASK)
+	 */
+
+	if (type == MUTEX_NOLOCKDEP)
+		t |= MUTEX_FLAG_NOLOCKDEP;
+
+	atomic_set(&mp->m_flags, t & MUTEX_FLAG_MASK);
+}
+
+static inline kmutex_type_t
+spl_mutex_get_type(kmutex_t *mp)
+{
+	if (MUTEX_FLAGS(mp) & MUTEX_FLAG_NOLOCKDEP)
+		return MUTEX_NOLOCKDEP;
+
+	return MUTEX_DEFAULT;
+}
+
 #define	mutex_owner(mp)		(ACCESS_ONCE((mp)->m_owner))
 #define	mutex_owned(mp)		(mutex_owner(mp) == current)
-#define	MUTEX_HELD(mp)		mutex_owned(mp)
+#define	MUTEX_HELD(mp)		(mutex_owned(mp))
 #define	MUTEX_NOT_HELD(mp)	(!MUTEX_HELD(mp))
 
 #ifdef CONFIG_LOCKDEP
 static inline void
-spl_mutex_set_type(kmutex_t *mp, kmutex_type_t type)
+spl_mutex_lockdep_off_maybe(kmutex_t *mp)
 {
-	mp->m_type = type;
+	if (mp && (spl_mutex_get_type(mp) == MUTEX_NOLOCKDEP))
+		lockdep_off();
 }
+
 static inline void
-spl_mutex_lockdep_off_maybe(kmutex_t *mp)			\
-{								\
-	if (mp && mp->m_type == MUTEX_NOLOCKDEP)		\
-		lockdep_off();					\
-}
-static inline void
-spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
-{								\
-	if (mp && mp->m_type == MUTEX_NOLOCKDEP)		\
-		lockdep_on();					\
+spl_mutex_lockdep_on_maybe(kmutex_t *mp)
+{
+	if (mp && (spl_mutex_get_type(mp) == MUTEX_NOLOCKDEP))
+		lockdep_on();
 }
 #else  /* CONFIG_LOCKDEP */
-#define spl_mutex_set_type(mp, type)
 #define spl_mutex_lockdep_off_maybe(mp)
 #define spl_mutex_lockdep_on_maybe(mp)
 #endif /* CONFIG_LOCKDEP */
@@ -96,59 +119,62 @@ spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
  * for the built in kernel lock analysis tools
  */
 #undef mutex_init
-#define	mutex_init(mp, name, type, ibc)				\
-{								\
-	static struct lock_class_key __key;			\
-	ASSERT(type == MUTEX_DEFAULT || type == MUTEX_NOLOCKDEP); \
-								\
-	__mutex_init(MUTEX(mp), (name) ? (#name) : (#mp), &__key); \
-	spin_lock_init(&(mp)->m_lock);				\
-	spl_mutex_clear_owner(mp);				\
-	spl_mutex_set_type(mp, type);				\
-}
+#define	mutex_init(mp, name, type, ibc)					\
+do {									\
+	static struct lock_class_key __key;				\
+	VERIFY3P((mp), !=, NULL);					\
+									\
+	__mutex_init(MUTEX(mp), (name) ? (#name) : (#mp), &__key);	\
+	spl_mutex_clear_owner(mp);					\
+	spl_mutex_set_type(mp, type);					\
+} while(0)
 
-#undef mutex_destroy
-#define	mutex_destroy(mp)					\
-{								\
-	VERIFY3P(mutex_owner(mp), ==, NULL);			\
-}
-
-#define	mutex_tryenter(mp)					\
-({								\
-	int _rc_;						\
-								\
-	spl_mutex_lockdep_off_maybe(mp);			\
-	if ((_rc_ = mutex_trylock(MUTEX(mp))) == 1)		\
-		spl_mutex_set_owner(mp);			\
-	spl_mutex_lockdep_on_maybe(mp);				\
-								\
-	_rc_;							\
+#define	mutex_tryenter(mp)						\
+({									\
+	int _rc_;							\
+									\
+	spl_mutex_lockdep_off_maybe(mp);				\
+	if ((_rc_ = mutex_trylock(MUTEX(mp))) == 1)			\
+		spl_mutex_set_owner(mp);				\
+	spl_mutex_lockdep_on_maybe(mp);					\
+									\
+	_rc_;								\
 })
 
 #ifdef CONFIG_DEBUG_LOCK_ALLOC
-#define	mutex_enter_nested(mp, subclass)			\
-{								\
-	ASSERT3P(mutex_owner(mp), !=, current);			\
-	spl_mutex_lockdep_off_maybe(mp);			\
-	mutex_lock_nested(MUTEX(mp), (subclass));		\
-	spl_mutex_lockdep_on_maybe(mp);				\
-	spl_mutex_set_owner(mp);				\
-}
+#define	mutex_enter_nested(mp, subclass)				\
+do {									\
+	ASSERT3P(mutex_owner(mp), !=, current);				\
+	spl_mutex_lockdep_off_maybe(mp);				\
+	mutex_lock_nested(MUTEX(mp), (subclass));			\
+	spl_mutex_lockdep_on_maybe(mp);					\
+	spl_mutex_set_owner(mp);					\
+} while(0)
 #else /* CONFIG_DEBUG_LOCK_ALLOC */
-#define	mutex_enter_nested(mp, subclass)			\
-{								\
-	ASSERT3P(mutex_owner(mp), !=, current);			\
-	spl_mutex_lockdep_off_maybe(mp);			\
-	mutex_lock(MUTEX(mp));					\
-	spl_mutex_lockdep_on_maybe(mp);				\
-	spl_mutex_set_owner(mp);				\
-}
+#define	mutex_enter_nested(mp, subclass)				\
+do {									\
+	ASSERT3P(mutex_owner(mp), !=, current);				\
+	spl_mutex_lockdep_off_maybe(mp);				\
+	mutex_lock(MUTEX(mp));						\
+	spl_mutex_lockdep_on_maybe(mp);					\
+	spl_mutex_set_owner(mp);					\
+} while(0)
 #endif /*  CONFIG_DEBUG_LOCK_ALLOC */
 
 #define	mutex_enter(mp) mutex_enter_nested((mp), 0)
 
+#define	mutex_exit(mp)							\
+do {									\
+	spl_mutex_clear_owner(mp);					\
+	atomic_inc(MUTEX_COUNTER(mp));					\
+	spl_mutex_lockdep_off_maybe(mp);				\
+	mutex_unlock(MUTEX(mp));					\
+	spl_mutex_lockdep_on_maybe(mp);					\
+	atomic_dec(MUTEX_COUNTER(mp));					\
+} while(0)
+
 /*
- * The reason for the spinlock:
+ * The reason for the spinning in mutex_destroy():
  *
  * The Linux mutex is designed with a fast-path/slow-path design such that it
  * does not guarantee serialization upon itself, allowing a race where latter
@@ -161,21 +187,20 @@ spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
  *
  * However, there are many places in ZFS where the mutex is used for
  * serializing object freeing, and the code is shared among other OSes without
- * this issue. Thus, we need the spinlock to force the serialization on
- * mutex_exit().
+ * this issue. Thus, we need to spin in mutex_destroy() until we're sure that
+ * all threads have finished slow-path in mutex_exit(), avoiding use-after-free.
  *
  * See http://lwn.net/Articles/575477/ for the information about the race.
  */
-#define	mutex_exit(mp)						\
-{								\
-	spl_mutex_clear_owner(mp);				\
-	spin_lock(&(mp)->m_lock);				\
-	spl_mutex_lockdep_off_maybe(mp);			\
-	mutex_unlock(MUTEX(mp));				\
-	spl_mutex_lockdep_on_maybe(mp);				\
-	spin_unlock(&(mp)->m_lock);				\
-	/* NOTE: do not dereference mp after this point */	\
-}
+
+#undef mutex_destroy
+#define	mutex_destroy(mp)						\
+do {									\
+	while (MUTEX_COUNTER_VAL(mp) != 0)				\
+		cpu_relax();						\
+									\
+	VERIFY3P(mutex_owner(mp), ==, NULL);				\
+} while(0)
 
 int spl_mutex_init(void);
 void spl_mutex_fini(void);

--- a/module/spl/Makefile.in
+++ b/module/spl/Makefile.in
@@ -28,3 +28,4 @@ $(MODULE)-objs += spl-xdr.o
 $(MODULE)-objs += spl-cred.o
 $(MODULE)-objs += spl-tsd.o
 $(MODULE)-objs += spl-zlib.o
+$(MODULE)-objs += spl-lockdbg.o

--- a/module/spl/spl-condvar.c
+++ b/module/spl/spl-condvar.c
@@ -28,6 +28,17 @@
 #include <sys/time.h>
 #include <linux/hrtimer.h>
 
+int
+spl_condvar_init(void)
+{
+	return 0;
+}
+
+void
+spl_condvar_fini(void)
+{
+}
+
 void
 __cv_init(kcondvar_t *cvp, char *name, kcv_type_t type, void *arg)
 {

--- a/module/spl/spl-lockdbg.c
+++ b/module/spl/spl-lockdbg.c
@@ -1,0 +1,430 @@
+/*
+ *  Copyright (C) 2016 Gvozden Neskovic <neskovic@gmail.com>
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef DEBUG_LOCK_TRACKING
+
+#include <sys/types.h>
+#include <spl-lockdbg.h>
+
+spl_lock_tracking_t lock_tracker = {
+	.slt_rwlock = __RW_LOCK_UNLOCKED(slt_rwlock),
+	.slt_buckets = { [0 ... (SLT_BCKT_SIZE - 1)] = RB_ROOT },
+	.slt_locks =
+	    { [0 ... (SLT_BCKT_SIZE - 1)] = __SPIN_LOCK_UNLOCKED(slt_locks) },
+	.slt_cnt = ATOMIC_INIT(0),
+	.slt_mismatched = RB_ROOT,
+	.slt_mismatched_lock = __SPIN_LOCK_UNLOCKED(slt_mismatched_lock),
+	.slt_mismatched_cnt = ATOMIC_INIT(0)
+};
+
+static const char *lock_type_names[] = {
+	"kmutex_t",
+	"krwlock_t",
+	"kcondvar_t"
+};
+
+static const char *
+slt_lock_name(lock_type_t lock)
+{
+	return (lock_type_names[lock]);
+}
+
+/* Stack trace helpers */
+static void
+slt_record_stack_trace(lock_tracking_node_t *ltnp)
+{
+	struct stack_trace trace = { 0 };
+
+	trace.nr_entries = 0;
+	trace.max_entries = LT_STACK_TRACE_SIZE;
+	trace.entries = ltnp->lt_trace;
+	trace.skip = 2;
+
+	save_stack_trace(&trace);
+	ltnp->lt_trace_nr = MAX((int)trace.nr_entries - 1, 0);
+}
+
+/* Tracker */
+typedef int (*slt_cmp_fn)(const void *, const void *);
+
+static int
+slt_ptr_cmp(const void *a, const void *b)
+{
+	uintptr_t _a = (uintptr_t)a;
+	uintptr_t _b = (uintptr_t)b;
+
+	return ((_a > _b) - (_a < _b));
+}
+
+static int
+slt_str_cmp(const void *a, const void *b)
+{
+	return (strncmp(a, b, LT_LOC_SIZE));
+}
+
+static inline lock_tracking_node_t *
+slt_lookup(struct rb_root *root, slt_cmp_fn cmp_fn, const void *val)
+{
+	struct rb_node *n = root->rb_node;
+	lock_tracking_node_t *mtp;
+	int cmp;
+
+	while (n) {
+		mtp = rb_entry(n, lock_tracking_node_t, lt_rbnode);
+
+		if (cmp_fn == slt_ptr_cmp)
+			cmp = cmp_fn(val, (void *)mtp->lt_ptr);
+		else
+			cmp = cmp_fn(val, (void *)mtp->lt_loc);
+
+		if (cmp < 0)
+			n = n->rb_left;
+		else if (cmp > 0)
+			n = n->rb_right;
+		else
+			return (mtp);
+	}
+	return (NULL);
+}
+
+static inline void
+slt_insert(struct rb_root *root, slt_cmp_fn cmp_fn,
+    lock_tracking_node_t *mtp)
+{
+	struct rb_node **p = &(root->rb_node);
+	struct rb_node *parent = NULL;
+	lock_tracking_node_t *mtp_tmp;
+	int cmp;
+	void *cmp_arg1 = (cmp_fn == slt_ptr_cmp) ? (void *)mtp->lt_ptr :
+	    (void *)mtp->lt_loc;
+	void *cmp_arg2 = NULL;
+
+	while (*p) {
+		mtp_tmp = rb_entry(*p, lock_tracking_node_t, lt_rbnode);
+		parent = *p;
+
+		cmp_arg2 = (cmp_fn == slt_ptr_cmp) ? (void *)mtp_tmp->lt_ptr :
+		    (void *)mtp_tmp->lt_loc;
+		cmp = cmp_fn(cmp_arg1, cmp_arg2);
+
+		if (cmp < 0)
+			p = &((*p)->rb_left);
+		else if (cmp > 0)
+			p = &((*p)->rb_right);
+		else
+			return;
+	}
+
+	rb_link_node(&mtp->lt_rbnode, parent, p);
+	rb_insert_color(&mtp->lt_rbnode, root);
+}
+
+static inline void
+slt_remove(struct rb_root *root, lock_tracking_node_t *mtp)
+{
+	rb_erase(&mtp->lt_rbnode, root);
+}
+
+void
+spl_lockdbg_fini()
+{
+	spl_lock_tracking_t *sltp = &lock_tracker;
+	lock_tracking_node_t *mtp;
+	struct rb_node *n;
+	struct rb_root *root;
+	int i;
+
+	/* Print 'header' for mismatched calls */
+	if (SLT_MISMATCHED_NUM(sltp) > 0)
+		printk(KERN_WARNING
+		    "\n******************************************************\n"
+		    "SPL Lock Tracker: missing destroy\n"
+		    "******************************************************\n");
+
+	root = SLT_MISMATCHED(sltp);
+	while ((n = rb_first(root)) != NULL) {
+		mtp = rb_entry(n, lock_tracking_node_t, lt_rbnode);
+
+		slt_remove(root, mtp);
+
+		/* Report mismatch */
+		printk(KERN_WARNING "missing destroy: object (%s) [0x%p]\n"
+		    "  init location = %s", slt_lock_name(mtp->lt_type),
+		    (void *)mtp->lt_ptr, mtp->lt_loc);
+		kfree(mtp);
+	}
+
+	/* Print 'header' if lock tracking is not empty */
+	if (SLT_TRACKED_NUM(sltp) > 0)
+		printk(KERN_WARNING
+		    "\n******************************************************\n"
+		    "SPL Lock Tracker: missing teardown\n"
+		    "******************************************************\n");
+
+	for (i = 0; i < SLT_BCKT_SIZE; i++) {
+		root = SLT_BUCKET(sltp, i);
+
+		while ((n = rb_first(root)) != NULL) {
+			mtp = rb_entry(n, lock_tracking_node_t, lt_rbnode);
+
+			slt_remove(root, mtp);
+
+			/* Report mismatch */
+			printk(KERN_WARNING "missing teardown: "
+			    "object (%s) [0x%p]\n"
+			    "  init location = %s",
+			    slt_lock_name(mtp->lt_type),
+			    (void *)mtp->lt_ptr, mtp->lt_loc);
+			kfree(mtp);
+		}
+	}
+}
+
+void
+spl_lock_tracking_record_init(lock_type_t type, ulong_t lp, char *loc)
+{
+	spl_lock_tracking_t *sltp = &lock_tracker;
+	lock_tracking_node_t *ltp;
+	ulong_t flags, rwflags, mis_flags;
+	const ulong_t idx = SLT_HASH(lp);
+
+	/* get filename if string starts with full path */
+	loc = SLT_FILE_LOC(loc);
+
+	read_lock_irqsave(SLT_RWLOCK(sltp), rwflags);
+	spin_lock_irqsave(SLT_BUCKET_LOCK(sltp, idx), flags);
+
+	/* Check if the lock already exists */
+	ltp = slt_lookup(SLT_BUCKET(sltp, idx), slt_ptr_cmp, (void *)lp);
+	if (ltp != NULL) {
+		slt_remove(SLT_BUCKET(sltp, idx), ltp);
+		SLT_TRACKED_DEC(sltp);
+
+		spin_lock_irqsave(SLT_MISMATCHED_LOCK(sltp), mis_flags);
+		if (slt_lookup(SLT_MISMATCHED(sltp), slt_str_cmp, ltp->lt_loc)
+		    == NULL) {
+			/* insert into the mismatched tree */
+			slt_insert(SLT_MISMATCHED(sltp), slt_str_cmp, ltp);
+			SLT_MISMATCHED_INC(sltp);
+		} else
+			kfree(ltp); /* already known */
+		spin_unlock_irqrestore(SLT_MISMATCHED_LOCK(sltp), mis_flags);
+	}
+
+	ltp = kzalloc(sizeof (*ltp), GFP_ATOMIC);
+	if (ltp) {
+		ltp->lt_ptr = (ulong_t)lp;
+		ltp->lt_type = type;
+		strlcpy(ltp->lt_loc, loc, LT_LOC_SIZE);
+		slt_record_stack_trace(ltp);
+
+		slt_insert(SLT_BUCKET(sltp, idx), slt_ptr_cmp, ltp);
+		SLT_TRACKED_INC(sltp);
+	}
+
+	spin_unlock_irqrestore(SLT_BUCKET_LOCK(sltp, idx), flags);
+	read_unlock_irqrestore(SLT_RWLOCK(sltp), rwflags);
+}
+
+/*
+ * Limit the number of stack traces dumped to not more than 1 every 60 seconds
+ * to prevent denial-of-service attacks from debug code. Lock destroy mismatch
+ * might be caused by low RAM condition.
+ */
+static DEFINE_RATELIMIT_STATE(lock_destroy_ratelimit_state, 60 * HZ, 1);
+
+void
+spl_lock_tracking_record_destroy(lock_type_t type, ulong_t lp, char *loc)
+{
+	spl_lock_tracking_t *sltp = &lock_tracker;
+	lock_tracking_node_t *mtp;
+	ulong_t flags, rwflags;
+	const ulong_t idx = SLT_HASH(lp);
+
+	read_lock_irqsave(SLT_RWLOCK(sltp), rwflags);
+	spin_lock_irqsave(SLT_BUCKET_LOCK(sltp, idx), flags);
+
+	/* Check if exists */
+	mtp = slt_lookup(SLT_BUCKET(sltp, idx), slt_ptr_cmp, (void *)lp);
+	if (mtp == NULL) {
+		/* get filename if string starts with full path */
+		loc = SLT_FILE_LOC(loc);
+		if (__ratelimit(&lock_destroy_ratelimit_state)) {
+			printk(KERN_WARNING "SPL Lock Tracker [%s]: possible "
+			    "spurious destroy() at: %s",
+			    slt_lock_name(type), loc);
+			dump_stack();
+		}
+		goto out;
+	}
+
+	slt_remove(SLT_BUCKET(sltp, idx), mtp);
+	SLT_TRACKED_DEC(sltp);
+	kfree(mtp);
+
+out:
+	spin_unlock_irqrestore(SLT_BUCKET_LOCK(sltp, idx), flags);
+	read_unlock_irqrestore(SLT_RWLOCK(sltp), rwflags);
+}
+
+
+
+/* Proc file */
+typedef struct slt_seq_file_desc {
+	spl_lock_tracking_t	*sfd_tracker;
+	lock_type_t		sfd_type;
+} slt_seq_file_desc_t;
+
+static void*
+slt_seq_file_start(struct seq_file *file, loff_t *pos)
+{
+	slt_seq_file_desc_t *desc = file->private;
+	spl_lock_tracking_t *sltp = desc->sfd_tracker;
+	struct rb_node *n = rb_first(SLT_MISMATCHED(sltp));
+	loff_t off = *pos;
+
+	/*
+	 * NOTE: SLT_RWLOCK(sltp) is used in a non-standard way: seq-file
+	 * traversal locks for WRITING and actual modification methods for
+	 * READING. This is safe because modification of the tracking structure
+	 * is protected by finer-grained locks.
+	 */
+	write_lock(SLT_RWLOCK(sltp));
+
+	while (n != NULL && (off--) > 0)
+		n = rb_next(n);
+
+	return (n);
+}
+
+static void
+slt_seq_file_stop(struct seq_file *file, void *v)
+{
+	slt_seq_file_desc_t *desc = file->private;
+	spl_lock_tracking_t *sltp = desc->sfd_tracker;
+
+	write_unlock(SLT_RWLOCK(sltp));
+}
+
+static void*
+slt_seq_file_next(struct seq_file *file, void *p, loff_t *pos)
+{
+	struct rb_node *n = (struct rb_node *)p;
+
+	(*pos)++;
+
+	return (rb_next(n));
+}
+
+static int
+slt_seq_file_show(struct seq_file *file, void *p)
+{
+	slt_seq_file_desc_t *desc = (slt_seq_file_desc_t *)file->private;
+	struct rb_node *n = (struct rb_node *)p;
+	lock_tracking_node_t *mtp;
+	const char *type_name = slt_lock_name(desc->sfd_type);
+	int i;
+
+	ASSERT3P(p, !=, NULL);
+
+	mtp = rb_entry(n, lock_tracking_node_t, lt_rbnode);
+	if (mtp->lt_type != desc->sfd_type)
+		return (0);
+
+	/* Report the mismatch */
+	seq_printf(file, "object (%s) [0x%p] is missing destroy\n"
+	    "  init location = %s\n", type_name, (void *)mtp->lt_ptr,
+	    mtp->lt_loc);
+	seq_printf(file, "  backtrace:\n");
+	for (i = 0; i < mtp->lt_trace_nr; i++)
+		seq_printf(file, "    %pS\n", (void *)mtp->lt_trace[i]);
+
+	return (0);
+}
+
+static struct seq_operations slt_seq_ops = {
+	.show  = slt_seq_file_show,
+	.start = slt_seq_file_start,
+	.next  = slt_seq_file_next,
+	.stop  = slt_seq_file_stop,
+};
+
+static int
+proc_tracking_open(lock_type_t type, struct inode *inode, struct file *fp)
+{
+	slt_seq_file_desc_t *desc;
+	void *p = __seq_open_private(fp, &slt_seq_ops,
+	    sizeof (slt_seq_file_desc_t));
+	if (p == NULL)
+		return (-ENOMEM);
+
+	desc = (slt_seq_file_desc_t *)p;
+	memset(desc, 0, sizeof (slt_seq_file_desc_t));
+	desc->sfd_tracker = &lock_tracker;
+	desc->sfd_type = type;
+	return (0);
+}
+
+static int
+proc_tracking_mutex_open(struct inode *inode, struct file *fp)
+{
+	return (proc_tracking_open(SLT_MUTEX, inode, fp));
+}
+
+struct file_operations proc_mutex_tracking_operations = {
+	.owner		= THIS_MODULE,
+	.open		= proc_tracking_mutex_open,
+	.read		= seq_read,
+	.llseek		= seq_lseek,
+	.release	= seq_release_private,
+};
+
+static int
+proc_tracking_rwlock_open(struct inode *inode, struct file *fp)
+{
+	return (proc_tracking_open(SLT_RWLOCK, inode, fp));
+}
+
+struct file_operations proc_rwlock_tracking_operations = {
+	.owner		= THIS_MODULE,
+	.open		= proc_tracking_rwlock_open,
+	.read		= seq_read,
+	.llseek		= seq_lseek,
+	.release	= seq_release_private,
+};
+
+static int
+proc_tracking_condvar_open(struct inode *inode, struct file *fp)
+{
+	return (proc_tracking_open(SLT_CONDVAR, inode, fp));
+}
+
+struct file_operations proc_condvar_tracking_operations = {
+	.owner		= THIS_MODULE,
+	.open		= proc_tracking_condvar_open,
+	.read		= seq_read,
+	.llseek		= seq_lseek,
+	.release	= seq_release_private,
+};
+
+EXPORT_SYMBOL(spl_lock_tracking_record_init);
+EXPORT_SYMBOL(spl_lock_tracking_record_destroy);
+
+#endif /* DEBUG_LOCK_TRACKING */


### PR DESCRIPTION
Attempt to remove spinlock operations in mutex_exit().  Instead, perform synchronization in mutex_destroy() to avoid use after free.