### PR TITLE
Add system_delay_taskq for long delay

### DIFF
--- a/include/sys/taskq.h
+++ b/include/sys/taskq.h
@@ -129,6 +129,8 @@ typedef struct taskq_thread {
 
 /* Global system-wide dynamic task queue available for all consumers */
 extern taskq_t *system_taskq;
+/* Global dynamic task queue for long delay */
+extern taskq_t *system_delay_taskq;
 
 /* List of all taskqs */
 extern struct list_head tq_list;


### PR DESCRIPTION
Add a dedicated system_delay_taskq for long delay like spa_deadman and
zpl_posix_acl_free. This will allow us to use system_taskq in the manner of
dispatch multiple tasks and call taskq_wait_outstanding.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>