### PR TITLE
Add support for rw semaphore changes under PREEMPT_RT_FULL

### DIFF
--- a/include/linux/rwsem_compat.h
+++ b/include/linux/rwsem_compat.h
@@ -27,7 +27,10 @@
 
 #include <linux/rwsem.h>
 
-#ifdef CONFIG_RWSEM_GENERIC_SPINLOCK
+#if defined(CONFIG_PREEMPT_RT_FULL)
+#define	SPL_RWSEM_SINGLE_READER_VALUE	(1)
+#define	SPL_RWSEM_SINGLE_WRITER_VALUE	(0)
+#elif defined(CONFIG_RWSEM_GENERIC_SPINLOCK)
 #define	SPL_RWSEM_SINGLE_READER_VALUE	(1)
 #define	SPL_RWSEM_SINGLE_WRITER_VALUE	(-1)
 #else
@@ -36,7 +39,9 @@
 #endif
 
 /* Linux 3.16 changed activity to count for rwsem-spinlock */
-#if defined(HAVE_RWSEM_ACTIVITY)
+#if defined(CONFIG_PREEMPT_RT_FULL)
+#define	RWSEM_COUNT(sem)	sem->read_depth
+#elif defined(HAVE_RWSEM_ACTIVITY)
 #define	RWSEM_COUNT(sem)	sem->activity
 /* Linux 4.8 changed count to an atomic_long_t for !rwsem-spinlock */
 #elif defined(HAVE_RWSEM_ATOMIC_LONG_COUNT)

--- a/include/sys/rwlock.h
+++ b/include/sys/rwlock.h
@@ -213,14 +213,6 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	spl_rw_lockdep_on_maybe(rwp);					\
 })
 
-/*
- * This implementation of rw_tryupgrade() behaves slightly differently
- * from its counterparts on other platforms.  It drops the RW_READER lock
- * and then acquires the RW_WRITER lock leaving a small window where no
- * lock is held.  On other platforms the lock is never released during
- * the upgrade process.  This is necessary under Linux because the kernel
- * does not provide an upgrade function.
- */
 #define rw_tryupgrade(rwp)						\
 ({									\
 	int _rc_ = 0;							\

--- a/module/spl/spl-rwlock.c
+++ b/module/spl/spl-rwlock.c
@@ -32,7 +32,35 @@
 
 #define DEBUG_SUBSYSTEM S_RWLOCK
 
-#if defined(CONFIG_RWSEM_GENERIC_SPINLOCK)
+#if defined(CONFIG_PREEMPT_RT_FULL)
+
+#include <linux/rtmutex.h>
+
+static int
+__rwsem_tryupgrade(struct rw_semaphore *rwsem)
+{
+	ASSERT(rt_mutex_owner(&rwsem->lock) == current);
+
+	/* Under the realtime patch series, rwsem is implemented as a
+	 * single mutex held by readers and writers alike. However,
+	 * this implementation would prevent a thread from taking a
+	 * read lock twice, as the mutex would already be locked on
+	 * the second attempt. Therefore the implementation allows a
+	 * single thread to take a rwsem as read lock multiple times
+	 * tracking that nesting as read_depth counter.
+	 */
+	if (rwsem->read_depth <= 1) {
+		/* In case, the current thread has not taken the lock
+		 * more than once as read lock, we can allow an
+		 * upgrade to a write lock. rwsem_rt.h implements
+		 * write locks as read_depth == 0.
+		 */
+		rwsem->read_depth = 0;
+		return (1);
+	}
+	return (0);
+}
+#elif defined(CONFIG_RWSEM_GENERIC_SPINLOCK)
 static int
 __rwsem_tryupgrade(struct rw_semaphore *rwsem)
 {

--- a/module/splat/splat-rwlock.c
+++ b/module/splat/splat-rwlock.c
@@ -106,6 +106,15 @@ void splat_init_rw_priv(rw_priv_t *rwp, struct file *file)
 	rwp->rw_type = 0;
 }
 
+#if defined(CONFIG_PREEMPT_RT_FULL)
+static int
+splat_rwlock_test1(struct file *file, void *arg)
+{
+	// This test will never succeed on PREEMPT_RT_FULL because
+	// locks can only be held by a single thread.
+	return 0;
+}
+#else
 static int
 splat_rwlock_wr_thr(void *arg)
 {
@@ -297,6 +306,7 @@ splat_rwlock_test1(struct file *file, void *arg)
 
 	return rc;
 }
+#endif
 
 static void
 splat_rwlock_test2_func(void *arg)
@@ -518,7 +528,13 @@ splat_rwlock_test4(struct file *file, void *arg)
 	rc1 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_WRITER, RW_WRITER);
 	rc2 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_WRITER, RW_READER);
 	rc3 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_READER, RW_WRITER);
+#if defined(CONFIG_PREEMPT_RT_FULL)
+        // Under PREEMPT_RT_FULL, two read locks can only be taken by
+        // the same thread.
+	rc4 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_READER, RW_READER);
+#else
 	rc4 = splat_rwlock_test4_type(tq, rwp, 0,      RW_READER, RW_READER);
+#endif
 	rc5 = splat_rwlock_test4_type(tq, rwp, 0,      RW_NONE,   RW_WRITER);
 	rc6 = splat_rwlock_test4_type(tq, rwp, 0,      RW_NONE,   RW_READER);
 


### PR DESCRIPTION
The main complication from the RT patch set is that the RW semaphore locks change in that read locks on an rwsem can be taken only by a single thread. All other threads are locked out. This single thread can take a read lock multiple times though. The underlying implementation changes to a mutex with an additional read_depth count.

The implementation can be best understood by inspecting the [RT patch](https://drive.google.com/open?id=0B1gmniVI7XGqNDUyRm8tN1JvNHc). rwsem_rt.h and rt.c give the best insight into how RT rwsem works. My implementation for rwsem_tryupgrade is basically an inversion of rt_downgrade_write found in rt.c. Please see the comments in the code.

Unfortunately, I have to drop SPLAT rwlock test4 completely as this test tries to take multiple locks from different threads, which RT rwsems do not support. Otherwise SPLAT, zconfig.sh, zpios-sanity.sh and zfs-tests.sh pass on my Debian-testing VM with linux-image-4.8.0-1-rt-amd64.

Assuming this PR is the right direction, I'll add a test to execute "rw_enter(rwp, RW_READER); rw_enter(rwp, RW_READER); ASSERT(rwsem_tryupgrade(rwp) == -EBUSY);" in the same thread.
