### PR TITLE
Add configure option to enable ksym's for rpms

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -240,6 +240,15 @@ AC_DEFUN([SPL_AC_RPM], [
 	AC_MSG_CHECKING([whether spec files are available])
 	AC_MSG_RESULT([yes ($RPM_SPEC_DIR/*.spec.in)])
 
+	AC_MSG_CHECKING([whether rpms will use ksyms])
+	AC_ARG_ENABLE([rpm-ksym],
+		[AC_HELP_STRING([--enable-rpm-ksym],
+		[Build RPMs with ksym() in Provides])],[
+		       AC_MSG_RESULT([yes])
+		       RPM_DEFINE_KMOD=$RPM_DEFINE_KMOD' --define "_use_internal_dependency_generator 0"'
+		],
+		[AC_MSG_RESULT([no])])
+
 	AC_SUBST(HAVE_RPM)
 	AC_SUBST(RPM)
 	AC_SUBST(RPM_VERSION)


### PR DESCRIPTION
Add ability to build with ksym's in rpm.  This is needed for weak-modules.
This is also needed for master builds of lustre.

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>