### PR TITLE
Reimplement rt_mutex_owner to fix build with DEBUG & PREEMPT_RT_FULL.

### DIFF
--- a/module/spl/spl-rwlock.c
+++ b/module/spl/spl-rwlock.c
@@ -35,11 +35,15 @@
 #if defined(CONFIG_PREEMPT_RT_FULL)
 
 #include <linux/rtmutex.h>
+#define	RT_MUTEX_OWNER_MASKALL	1UL
 
 static int
 __rwsem_tryupgrade(struct rw_semaphore *rwsem)
 {
-	ASSERT(rt_mutex_owner(&rwsem->lock) == current);
+
+	ASSERT((struct task_struct *)
+	    ((unsigned long)rwsem->lock.owner & ~RT_MUTEX_OWNER_MASKALL) ==
+	    current);
 
 	/*
 	 * Under the realtime patch series, rwsem is implemented as a


### PR DESCRIPTION
8e99d66 broke the debug build under a PREEMPT_RT_FULL kernel by relying on an undefined/unexported symbol.
