### PR TITLE
Remove identical if statements in module/spl/spl-vnode.c

### DIFF
--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -63,9 +63,6 @@ vn_mode_to_vtype(mode_t mode)
 	if (S_ISSOCK(mode))
 		return VSOCK;
 
-	if (S_ISCHR(mode))
-		return VCHR;
-
 	return VNON;
 } /* vn_mode_to_vtype() */
 EXPORT_SYMBOL(vn_mode_to_vtype);


### PR DESCRIPTION
There are already one identical `if` statement with `return` in it (line 51), so second `if` is senseless.