### PR TITLE
Update struct member intializers to C89

### DIFF
--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -628,11 +628,11 @@ static struct ctl_table spl_kmem_table[] = {
                 .mode     = 0444,
                 .proc_handler = &proc_doslab,
         },
-	{0},
+	{},
 };
 
 static struct ctl_table spl_kstat_table[] = {
-	{0},
+	{},
 };
 
 static struct ctl_table spl_table[] = {
@@ -663,7 +663,7 @@ static struct ctl_table spl_table[] = {
 		.mode     = 0555,
 		.child    = spl_kstat_table,
 	},
-        { 0 },
+        {},
 };
 
 static struct ctl_table spl_dir[] = {
@@ -672,7 +672,7 @@ static struct ctl_table spl_dir[] = {
                 .mode     = 0555,
                 .child    = spl_table,
         },
-        { 0 }
+        {}
 };
 
 static struct ctl_table spl_root[] = {
@@ -684,7 +684,7 @@ static struct ctl_table spl_root[] = {
 	.mode = 0555,
 	.child = spl_dir,
 	},
-	{ 0 }
+	{}
 };
 
 int


### PR DESCRIPTION
When building SPL within the kernel tree, C99 initializers cause
build failures and need to be converted to C89 as kernel CFLAGS
specify -std=gnu89.
This fix was provided by @behlendorf in #595 discussion notes and
manually implemented in the current master revision.

Testing:
Initial builds succeeded, module loading has not been tested yet as
similar initialzer issues need to be addressed in the ICP module
of ZFS first.