### PR TITLE
Linux 4.11 compat: set_task_state() removed

### DIFF
--- a/module/spl/spl-err.c
+++ b/module/spl/spl-err.c
@@ -65,7 +65,7 @@ spl_panic(const char *file, const char *func, int line, const char *fmt, ...) {
 	spl_dumpstack();
 
 	/* Halt the thread to facilitate further debugging */
-	set_task_state(current, TASK_UNINTERRUPTIBLE);
+	set_current_state(TASK_UNINTERRUPTIBLE);
 	while (1)
 		schedule();
 
@@ -98,7 +98,7 @@ vcmn_err(int ce, const char *fmt, va_list ap)
 		spl_dumpstack();
 
 		/* Halt the thread to facilitate further debugging */
-		set_task_state(current, TASK_UNINTERRUPTIBLE);
+		set_current_state(TASK_UNINTERRUPTIBLE);
 		while (1)
 			schedule();
 	}


### PR DESCRIPTION
Replace uses of set_task_state(current, STATE) with
set_current_state(STATE).

In Linux 4.11, torvalds/linux@642fa44, set_task_state() is removed.

All spl uses are of the form set_task_state(current, STATE).
set_current_state(STATE) is equivalent and has been available since
Linux 2.2.26.

Furthermore, set_current_state(STATE) is already used in about 15
locations within spl.  This change should have no impact other than
removing an unnecessary dependency.

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>