### PR TITLE
Fix powerpc build

### DIFF
--- a/rpm/generic/spl-kmod.spec.in
+++ b/rpm/generic/spl-kmod.spec.in
@@ -53,6 +53,11 @@ BuildRequires:  %{_bindir}/kmodtool
 %endif
 %endif
 
+# LDFLAGS are not sanitized by arch/powerpc/Makefile (unlike other arches)
+%ifarch ppc ppc64 ppc64le
+%global __global_ldflags %{nil}
+%endif
+
 %if 0%{?fedora} >= 17
 %define prefix  /usr
 %endif

--- a/rpm/redhat/spl-kmod.spec.in
+++ b/rpm/redhat/spl-kmod.spec.in
@@ -22,6 +22,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       @PACKAGE@ = %{version}\n\
 Conflicts:      @PACKAGE@-dkms\n\n" > %{_sourcedir}/kmod-preamble)
 
+# LDFLAGS are not sanitized by arch/powerpc/Makefile (unlike other arches)
+%ifarch ppc ppc64 ppc64le
+%global __global_ldflags %{nil}
+%endif
+
 %description
 This package contains the kernel modules required to emulate
 several interfaces provided by the Solaris kernel.


### PR DESCRIPTION
Unlike other architectures which sanitize the LDFLAGS from the
environment in arch/<arch>/Makefile.  The powerpc Makefile
allows LDFLAGS to be passed through resulting in the following
build failure.

  /usr/bin/ld: unrecognized option '-Wl,-z,relro'

LDFLAGS is set in /usr/lib/rpm/redhat/macros by default.  Clear
the environment variable when building kmods for powerpc.