### PR TITLE
Linux 4.11 compat: vfs_getattr() takes 4 args

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -33,7 +33,6 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_INODE_TRUNCATE_RANGE
 	SPL_AC_FS_STRUCT_SPINLOCK
 	SPL_AC_KUIDGID_T
-	SPL_AC_PUT_TASK_STRUCT
 	SPL_AC_KERNEL_FALLOCATE
 	SPL_AC_CONFIG_ZLIB_INFLATE
 	SPL_AC_CONFIG_ZLIB_DEFLATE
@@ -1081,25 +1080,6 @@ AC_DEFUN([SPL_AC_KUIDGID_T], [
 			AC_DEFINE(HAVE_KUIDGID_T, 1, [kuid_t/kgid_t in use])
 		])
 	],[
-		AC_MSG_RESULT(no)
-	])
-])
-
-dnl #
-dnl # 2.6.39 API change,
-dnl # __put_task_struct() was exported by the mainline kernel.
-dnl #
-AC_DEFUN([SPL_AC_PUT_TASK_STRUCT],
-	[AC_MSG_CHECKING([whether __put_task_struct() is available])
-	SPL_LINUX_TRY_COMPILE_SYMBOL([
-		#include <linux/sched.h>
-	], [
-		__put_task_struct(NULL);
-	], [__put_task_struct], [], [
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_PUT_TASK_STRUCT, 1,
-		          [__put_task_struct() is available])
-	], [
 		AC_MSG_RESULT(no)
 	])
 ])

--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -43,6 +43,8 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_RWSEM_ACTIVITY
 	SPL_AC_RWSEM_ATOMIC_LONG_COUNT
 	SPL_AC_SCHED_RT_HEADER
+	SPL_AC_4ARGS_VFS_GETATTR
+	SPL_AC_3ARGS_VFS_GETATTR
 	SPL_AC_2ARGS_VFS_GETATTR
 	SPL_AC_USLEEP_RANGE
 	SPL_AC_KMEM_CACHE_ALLOCFLAGS
@@ -1409,34 +1411,67 @@ AC_DEFUN([SPL_AC_SCHED_RT_HEADER],
 	])
 ])
 
+
 dnl #
-dnl # 3.9 API change,
-dnl # vfs_getattr() uses 2 args
-dnl # It takes struct path * instead of struct vfsmount * and struct dentry *
+dnl # 4.11 API, a528d35e@torvalds/linux
+dnl # vfs_getattr(const struct path *p, struct kstat *s, u32 m, unsigned int f)
+dnl #
+AC_DEFUN([SPL_AC_4ARGS_VFS_GETATTR], [
+	AC_MSG_CHECKING([whether vfs_getattr() wants 4 args])
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/fs.h>
+	],[
+		vfs_getattr((const struct path *)NULL,
+			(struct kstat *)NULL,
+			(u32)0,
+			(unsigned int)0);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_4ARGS_VFS_GETATTR, 1,
+		  [vfs_getattr wants 4 args])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
+dnl # 3.9 API 
+dnl # vfs_getattr(struct path *p, struct kstat *s)
 dnl #
 AC_DEFUN([SPL_AC_2ARGS_VFS_GETATTR], [
-	AC_MSG_CHECKING([whether vfs_getattr() wants])
+	AC_MSG_CHECKING([whether vfs_getattr() wants 2 args])
 	SPL_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
 	],[
 		vfs_getattr((struct path *) NULL,
 			(struct kstat *)NULL);
 	],[
-		AC_MSG_RESULT(2 args)
+		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_2ARGS_VFS_GETATTR, 1,
-		          [vfs_getattr wants 2 args])
+			  [vfs_getattr wants 2 args])
 	],[
-		SPL_LINUX_TRY_COMPILE([
-			#include <linux/fs.h>
-		],[
-			vfs_getattr((struct vfsmount *)NULL,
-				(struct dentry *)NULL,
-				(struct kstat *)NULL);
-		],[
-			AC_MSG_RESULT(3 args)
-		],[
-			AC_MSG_ERROR(unknown)
-		])
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
+dnl # <3.9 API 
+dnl # vfs_getattr(struct vfsmount *v, struct dentry *d, struct kstat *k)
+dnl #
+AC_DEFUN([SPL_AC_3ARGS_VFS_GETATTR], [
+	AC_MSG_CHECKING([whether vfs_getattr() wants 3 args])
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/fs.h>
+	],[
+		vfs_getattr((struct vfsmount *)NULL,
+			(struct dentry *)NULL,
+			(struct kstat *)NULL);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_3ARGS_VFS_GETATTR, 1,
+		  [vfs_getattr wants 3 args])
+	],[
+		AC_MSG_RESULT(no)
 	])
 ])
 

--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -43,6 +43,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_RWSEM_ACTIVITY
 	SPL_AC_RWSEM_ATOMIC_LONG_COUNT
 	SPL_AC_SCHED_RT_HEADER
+	SPL_AC_SCHED_SIGNAL_HEADER
 	SPL_AC_4ARGS_VFS_GETATTR
 	SPL_AC_3ARGS_VFS_GETATTR
 	SPL_AC_2ARGS_VFS_GETATTR
@@ -1411,6 +1412,24 @@ AC_DEFUN([SPL_AC_SCHED_RT_HEADER],
 	])
 ])
 
+dnl #
+dnl # 4.11 API change,
+dnl # Moved things from linux/sched.h to linux/sched/signal.h
+dnl #
+AC_DEFUN([SPL_AC_SCHED_SIGNAL_HEADER],
+	[AC_MSG_CHECKING([whether header linux/sched/signal.h exists])
+	SPL_LINUX_TRY_COMPILE([
+		#include <linux/sched.h>
+		#include <linux/sched/signal.h>
+	],[
+		return 0;
+	],[
+		AC_DEFINE(HAVE_SCHED_SIGNAL_HEADER, 1, [linux/sched/signal.h exists])
+		AC_MSG_RESULT(yes)
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
 
 dnl #
 dnl # 4.11 API, a528d35e@torvalds/linux

--- a/include/sys/signal.h
+++ b/include/sys/signal.h
@@ -27,6 +27,10 @@
 
 #include <linux/sched.h>
 
+#ifdef HAVE_SCHED_SIGNAL_HEADER
+#include <linux/sched/signal.h>
+#endif
+
 #define	FORREAL		0	/* Usual side-effects */
 #define	JUSTLOOKING	1	/* Don't stop the process */
 

--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -459,22 +459,6 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 }
 EXPORT_SYMBOL(ddi_copyout);
 
-#ifndef HAVE_PUT_TASK_STRUCT
-/*
- * This is only a stub function which should never be used.  The SPL should
- * never be putting away the last reference on a task structure so this will
- * not be called.  However, we still need to define it so the module does not
- * have undefined symbol at load time.  That all said if this impossible
- * thing does somehow happen PANIC immediately so we know about it.
- */
-void
-__put_task_struct(struct task_struct *t)
-{
-	PANIC("Unexpectly put last reference on task %d\n", (int)t->pid);
-}
-EXPORT_SYMBOL(__put_task_struct);
-#endif /* HAVE_PUT_TASK_STRUCT */
-
 /*
  * Read the unique system identifier from the /etc/hostid file.
  *

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -153,7 +153,9 @@ vn_open(const char *path, uio_seg_t seg, int flags, int mode,
 	if (IS_ERR(fp))
 		return (-PTR_ERR(fp));
 
-#ifdef HAVE_2ARGS_VFS_GETATTR
+#if defined(HAVE_4ARGS_VFS_GETATTR)
+	rc = vfs_getattr(&fp->f_path, &stat, STATX_TYPE, AT_STATX_SYNC_AS_STAT);
+#elif defined(HAVE_2ARGS_VFS_GETATTR)
 	rc = vfs_getattr(&fp->f_path, &stat);
 #else
 	rc = vfs_getattr(fp->f_path.mnt, fp->f_dentry, &stat);
@@ -510,7 +512,10 @@ vn_getattr(vnode_t *vp, vattr_t *vap, int flags, void *x3, void *x4)
 
 	fp = vp->v_file;
 
-#ifdef HAVE_2ARGS_VFS_GETATTR
+#if defined(HAVE_4ARGS_VFS_GETATTR)
+	rc = vfs_getattr(&fp->f_path, &stat, STATX_BASIC_STATS,
+	    AT_STATX_SYNC_AS_STAT);
+#elif defined(HAVE_2ARGS_VFS_GETATTR)
 	rc = vfs_getattr(&fp->f_path, &stat);
 #else
 	rc = vfs_getattr(fp->f_path.mnt, fp->f_dentry, &stat);
@@ -708,7 +713,9 @@ vn_getf(int fd)
 	if (vp == NULL)
 		goto out_fget;
 
-#ifdef HAVE_2ARGS_VFS_GETATTR
+#if defined(HAVE_4ARGS_VFS_GETATTR)
+	rc = vfs_getattr(&lfp->f_path, &stat, STATX_TYPE, AT_STATX_SYNC_AS_STAT);
+#elif defined(HAVE_2ARGS_VFS_GETATTR)
 	rc = vfs_getattr(&lfp->f_path, &stat);
 #else
 	rc = vfs_getattr(lfp->f_path.mnt, lfp->f_dentry, &stat);


### PR DESCRIPTION
There are changes to vfs_getattr() in torvalds/linux@a528d35.  The new
interface is:

int vfs_getattr(const struct path *path, struct kstat *stat,
               u32 request_mask, unsigned int query_flags)

The request_mask argument indicates which field(s) the caller intends to
use.  Fields the caller does not specify via request_mask may be
returned anyway, but may be approximate.

The query_flags argument indicates whether the filesystem must update
the attributes from the backing store.

This patch uses the query_flags which result in vfs_getattr behaving the same
as it did with the 2-argument version which the kernel provided before
Linux 4.11.

Members blksize and blocks are now always the same size regardless of
arch.  They match the size of the equivalent members in vnode_t.

The configure checks are modified to ensure that the appropriate
vfs_getattr() interface is used.

A more complete fix, removing the ZFS dependency on vfs_getattr()
entirely, is deferred as it is a much larger project.

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>