### PR TITLE
Add assert and warning message/stack dump

### DIFF
--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -684,6 +684,12 @@ taskq_dispatch_ent(taskq_t *tq, task_func_t func, void *arg, uint_t flags,
 	spin_lock(&t->tqent_lock);
 
 	/*
+	 * Make sure the entry is not on some other taskq; it is important to
+	 * ASSERT() under lock
+	 */
+	ASSERT(taskq_empty_ent(t));
+
+	/*
 	 * Mark it as a prealloc'd task.  This is important
 	 * to ensure that we don't free it later.
 	 */


### PR DESCRIPTION
Add assert and warning message/stack dump under lock to detect cases
of dispach of a preallocated taskq work item to more than one queue
concurrently. Also, please see discussion in zfsonlinux issue #3840.