### PR TITLE
Support 4.9.20-rt16 style RW semaphores.

### DIFF
--- a/include/linux/rwsem_compat.h
+++ b/include/linux/rwsem_compat.h
@@ -28,8 +28,13 @@
 #include <linux/rwsem.h>
 
 #if defined(CONFIG_PREEMPT_RT_FULL)
+#if defined(READER_BIAS)
+#define	SPL_RWSEM_SINGLE_READER_VALUE	(READER_BIAS + 1)
+#define	SPL_RWSEM_SINGLE_WRITER_VALUE	(WRITER_BIAS)
+#else
 #define	SPL_RWSEM_SINGLE_READER_VALUE	(1)
 #define	SPL_RWSEM_SINGLE_WRITER_VALUE	(0)
+#endif
 #elif defined(CONFIG_RWSEM_GENERIC_SPINLOCK)
 #define	SPL_RWSEM_SINGLE_READER_VALUE	(1)
 #define	SPL_RWSEM_SINGLE_WRITER_VALUE	(-1)
@@ -40,7 +45,11 @@
 
 /* Linux 3.16 changed activity to count for rwsem-spinlock */
 #if defined(CONFIG_PREEMPT_RT_FULL)
+#if defined(READER_BIAS)
+#define	RWSEM_COUNT(sem)        atomic_read(&(sem)->readers)
+#else
 #define	RWSEM_COUNT(sem)	sem->read_depth
+#endif
 #elif defined(HAVE_RWSEM_ACTIVITY)
 #define	RWSEM_COUNT(sem)	sem->activity
 /* Linux 4.8 changed count to an atomic_long_t for !rwsem-spinlock */

--- a/module/splat/splat-rwlock.c
+++ b/module/splat/splat-rwlock.c
@@ -106,7 +106,7 @@ void splat_init_rw_priv(rw_priv_t *rwp, struct file *file)
 	rwp->rw_type = 0;
 }
 
-#if defined(CONFIG_PREEMPT_RT_FULL)
+#if defined(CONFIG_PREEMPT_RT_FULL) && !defined(READER_BIAS)
 static int
 splat_rwlock_test1(struct file *file, void *arg)
 {
@@ -537,7 +537,7 @@ splat_rwlock_test4(struct file *file, void *arg)
 	rc1 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_WRITER, RW_WRITER);
 	rc2 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_WRITER, RW_READER);
 	rc3 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_READER, RW_WRITER);
-#if defined(CONFIG_PREEMPT_RT_FULL)
+#if defined(CONFIG_PREEMPT_RT_FULL) && !defined(READER_BIAS)
 	rc4 = splat_rwlock_test4_type(tq, rwp, -EBUSY, RW_READER, RW_READER);
 #else
 	rc4 = splat_rwlock_test4_type(tq, rwp, 0,      RW_READER, RW_READER);


### PR DESCRIPTION
Thanks to Thomas Glexiner <tglx@linutronix.de> for feedback on the implementation.