### PR TITLE
config: allow --with-linux without --with-linux-obj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ cscope.*
 *.rpm
 *.deb
 *.tar.gz
+*.patch
+*.orig

--- a/cmd/splat/.gitignore
+++ b/cmd/splat/.gitignore
@@ -1,2 +1,1 @@
-/spl
 /splat

--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -113,6 +113,7 @@ AC_DEFUN([SPL_AC_KERNEL], [
 		if test "$kernelsrc" = "NONE"; then
 			kernsrcver=NONE
 		fi
+		withlinux=yes
 	fi
 
 	AC_MSG_RESULT([$kernelsrc])
@@ -125,7 +126,7 @@ AC_DEFUN([SPL_AC_KERNEL], [
 
 	AC_MSG_CHECKING([kernel build directory])
 	if test -z "$kernelbuild"; then
-		if test -e "/lib/modules/$(uname -r)/build"; then
+		if test x$withlinux != xyes -a -e "/lib/modules/$(uname -r)/build"; then
 			kernelbuild=`readlink -f /lib/modules/$(uname -r)/build`
 		elif test -d ${kernelsrc}-obj/${target_cpu}/${target_cpu}; then
 			kernelbuild=${kernelsrc}-obj/${target_cpu}/${target_cpu}

--- a/module/.gitignore
+++ b/module/.gitignore
@@ -9,3 +9,5 @@ modules.order
 /.tmp_versions
 /Module.markers
 /Module.symvers
+
+!Makefile.in


### PR DESCRIPTION
1. Improve gitignore

Exclude Makefile.in in module/ and fix the gitignore in cmd/
Also, ignore *.patch and *.orig files

2. config: allow --with-linux without --with-linux-obj

Don't use `uname -r` to determine kernel build directory when the user
specified kernel source with --with-linux. Otherwise, the user is forced
to use --with-linux-obj even if they are the same directory, which is
very counterintuitive.
