### PR TITLE
Fix RWSEM_SPINLOCK_IS_RAW check failed

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -1313,7 +1313,8 @@ AC_DEFUN([SPL_AC_RWSEM_SPINLOCK_IS_RAW], [
 		#include <linux/rwsem.h>
 	],[
 		struct rw_semaphore dummy_semaphore __attribute__ ((unused));
-		raw_spinlock_t dummy_lock __attribute__ ((unused));
+		raw_spinlock_t dummy_lock __attribute__ ((unused)) =
+		    __RAW_SPIN_LOCK_INITIALIZER(dummy_lock);
 		dummy_semaphore.wait_lock = dummy_lock;
 	],[
 		AC_MSG_RESULT(yes)


### PR DESCRIPTION
Initialize dummy_lock to fix the build error in gcc 7.1.1 with:
  error: ‘dummy_lock’ is used uninitialized in this function

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>