### PR TITLE
Don't cache the system hostid

### DIFF
--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -203,7 +203,8 @@ proc_dohostid(struct ctl_table *table, int write,
                         return (-EINVAL);
 
         } else {
-                len = snprintf(str, sizeof(str), "%lx", spl_hostid);
+                len = snprintf(str, sizeof(str), "%lx",
+		    (unsigned long) zone_get_hostid(NULL));
                 if (*ppos >= len)
                         rc = 0;
                 else


### PR DESCRIPTION
Historically the SPL cached the system hostid the first time it
was accessed.  This was done to speed up subsequent accesses.
But in practice the system host id is rarely accessed and its
inconvenient that it doesn't promptly detect /etc/hostid
configuration changes.  Therefore, zone_get_hostid() has been
updated to always refresh the system hostid reported.