### PR TITLE
Module parameter to enable spl_panic() to panic the kernel

### DIFF
--- a/module/spl/spl-err.c
+++ b/module/spl/spl-err.c
@@ -29,6 +29,17 @@
 #include <linux/ratelimit.h>
 
 /*
+ * It is often useful to actually have the panic crash the node so you
+ * can then get notified of the event, get the crashdump for later
+ * analysis and other such goodies.
+ * But we would still default to the current default of not to do that.
+ */
+unsigned int spl_panic_halt;
+module_param(spl_panic_halt, uint, 0644);
+MODULE_PARM_DESC(spl_panic_halt,
+		 "Cause kernel panic on assertion failures");
+
+/*
  * Limit the number of stack traces dumped to not more than 5 every
  * 60 seconds to prevent denial-of-service attacks from debug code.
  */
@@ -62,6 +73,9 @@ spl_panic(const char *file, const char *func, int line, const char *fmt, ...) {
 
 	printk(KERN_EMERG "%s", msg);
 	printk(KERN_EMERG "PANIC at %s:%d:%s()\n", newfile, line, func);
+	if (spl_panic_halt)
+		panic("%s", msg);
+
 	spl_dumpstack();
 
 	/* Halt the thread to facilitate further debugging */


### PR DESCRIPTION
In unattended operations it's often more useful to have node
panic and reboot when it encounters problems as opposed to
sit there indefinitely waiting for somebody to discover it.

This implements an spl_panic_crash module parameter, set it
to nonzero to cause spl_panic() to call panic().

Signed-off-by: Oleg Drokin <green@linuxhacker.ru>