### PR TITLE
Fix aarch64 build

### DIFF
--- a/rpm/generic/spl-kmod.spec.in
+++ b/rpm/generic/spl-kmod.spec.in
@@ -53,8 +53,8 @@ BuildRequires:  %{_bindir}/kmodtool
 %endif
 %endif
 
-# LDFLAGS are not sanitized by arch/powerpc/Makefile (unlike other arches)
-%ifarch ppc ppc64 ppc64le
+# LDFLAGS are not sanitized by arch/*/Makefile for these architectures.
+%ifarch ppc ppc64 ppc64le aarch64
 %global __global_ldflags %{nil}
 %endif
 

--- a/rpm/redhat/spl-kmod.spec.in
+++ b/rpm/redhat/spl-kmod.spec.in
@@ -22,8 +22,8 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       @PACKAGE@ = %{version}\n\
 Conflicts:      @PACKAGE@-dkms\n\n" > %{_sourcedir}/kmod-preamble)
 
-# LDFLAGS are not sanitized by arch/powerpc/Makefile (unlike other arches)
-%ifarch ppc ppc64 ppc64le
+# LDFLAGS are not sanitized by arch/*/Makefile for these architectures.
+%ifarch ppc ppc64 ppc64le aarch64
 %global __global_ldflags %{nil}
 %endif
 


### PR DESCRIPTION
Add aarch64 to the list of architecture which do not sanitize the
LDFLAGS from the environment.  See e0aacd9b for details.
