### PR TITLE
spl-module-parameters.5 manpage: fix macro

### DIFF
--- a/man/man5/spl-module-parameters.5
+++ b/man/man5/spl-module-parameters.5
@@ -153,7 +153,7 @@ function takes a single global lock over the entire virtual address range
 which serializes all allocations.  Using slightly different allocation
 functions for small and large objects allows us to handle a wide range of
 object sizes.
-.sh
+.sp
 The \fBspl_kmem_cache_kmem_limit\fR value is used to determine this cutoff
 size.  One quarter the PAGE_SIZE is used as the default value because
 \fBspl_kmem_cache_obj_per_slab\fR defaults to 16.  This means that at


### PR DESCRIPTION
there is no '.sh' macro in troff/groff/man, only '.SH' for section headers. I assume .sp for a line break was intended here like in the rest of the man page.