### PR TITLE
Multi-buffer sha256 support in SPL to ZFS

### DIFF
--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -54,6 +54,10 @@ KERNEL_H = \
 	$(top_srcdir)/include/sys/modctl.h \
 	$(top_srcdir)/include/sys/mode.h \
 	$(top_srcdir)/include/sys/mount.h \
+	$(top_srcdir)/include/sys/multi_buffer.h \
+	$(top_srcdir)/include/sys/mulbuf_queue_sha256.h \
+	$(top_srcdir)/include/sys/mulbuf_queue.h \
+	$(top_srcdir)/include/sys/mulbuf_thdpool.h \
 	$(top_srcdir)/include/sys/mutex.h \
 	$(top_srcdir)/include/sys/note.h \
 	$(top_srcdir)/include/sys/open.h \
@@ -70,6 +74,7 @@ KERNEL_H = \
 	$(top_srcdir)/include/sys/resource.h \
 	$(top_srcdir)/include/sys/rwlock.h \
 	$(top_srcdir)/include/sys/sdt.h \
+	$(top_srcdir)/include/sys/sha256_mb.h \
 	$(top_srcdir)/include/sys/sid.h \
 	$(top_srcdir)/include/sys/signal.h \
 	$(top_srcdir)/include/sys/stat.h \

--- a/include/sys/mulbuf_queue.h
+++ b/include/sys/mulbuf_queue.h
@@ -1,0 +1,95 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+\*****************************************************************************/
+
+#ifndef _SPL_MULBUF_QUEUE_H
+#define	_SPL_MULBUF_QUEUE_H
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+#include <linux/module.h>
+#include <linux/gfp.h>
+#include <linux/slab.h>
+#include <linux/interrupt.h>
+#include <linux/kthread.h>
+#include <sys/types.h>
+#include <sys/thread.h>
+#include <sys/rwlock.h>
+
+#include "mulbuf_thdpool.h"
+
+/* taskjob's callback function */
+typedef struct mbtp_task mbtp_task_t;
+typedef void (*mbtp_task_cb)(mbtp_task_t *mb_task, void *arg);
+
+
+struct mbtp_task {
+	void *buffer;
+	size_t size;
+	unsigned char *digest;
+
+	mbtp_task_cb cb_fn; /* callback after task is completed or cancelled */
+	void *cb_arg;
+	int processsed; /* 1 if processed by hash fn, 2 if cancelled by queue's close */
+
+	struct list_head queue_entry;
+};
+
+struct mbtp_queue{
+	char *queue_name;		/* queue name */
+	struct list_head plthread_list;
+	int curr_threadcnt; /* current thread count attached to this queue */
+	int idle_threadcnt; /* thread in queue, but not running hash-mb-proc-fn */
+	int max_threadcnt; /* max thread count doing jobs */
+	int min_threadcnt; /* min thread count waiting to do job */
+
+	struct list_head task_list;
+	int curr_taskcnt; /* task count attached to this queue, waiting to be processed */
+	int proc_taskcnt; /* task count in processing */
+	int total_taskcnt; /* task count processed */
+
+	mulbuf_thdpool_t *pool;
+	int leave; /* 1 means this queue is going to leave */
+
+	threadp_func_t thread_fn; /* which function queue's thread should run */
+
+	spinlock_t queue_lock;
+	wait_queue_head_t queue_waitq;
+};
+
+int mbtp_queue_create(mbtp_queue_t **queue_r, const char *name, mulbuf_thdpool_t *pool,
+		int min_threadcnt, int max_threadcnt, threadp_func_t hash_mb_fn);
+void mbtp_queue_destroy(mbtp_queue_t *queue);
+
+int mbtp_queue_assign_taskjobcnt(mbtp_queue_t *queue, int process_num, int concurrent_num);
+
+int mbtp_queue_add_thread(mbtp_queue_t *queue);
+void mbtp_queue_shrink_thread(mbtp_queue_t *queue, mbtp_thread_t *tpt);
+int mbtp_queue_check_add_thread(mbtp_queue_t *queue, int concurrent_num);
+int mbtp_queue_check_shrink_thread(mbtp_queue_t *queue, int concurrent_num);
+
+void mbtp_queue_submit_job(mbtp_task_t *mb_task, mbtp_queue_t *queue);
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */
+
+#endif  /* _SPL_MULBUF_QUEUE_H */

--- a/include/sys/mulbuf_queue_sha256.h
+++ b/include/sys/mulbuf_queue_sha256.h
@@ -1,0 +1,57 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+\*****************************************************************************/
+
+#ifndef MULBUF_QUEUE_SHA256_H_
+#define MULBUF_QUEUE_SHA256_H_
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+#include <linux/interrupt.h>
+#include <linux/kthread.h>
+#include <sys/kmem.h>
+#include <sys/mulbuf_queue.h>
+
+void mulbuf_sha256_fn(void *args);
+
+int mulbuf_suite_sha256_init(void);
+void mulbuf_suite_sha256_fini(void);
+
+int mulbuf_sha256_queue_choose(void *buffer, size_t size,
+		unsigned char *digest, mbtp_queue_t *queue);
+int mulbuf_sha256(void *buffer, size_t size, unsigned char *digest);
+
+#else
+
+static inline int mulbuf_suite_sha256_init(void)
+{
+	return 0;
+}
+static inline void mulbuf_suite_sha256_fini(void)
+{
+	return;
+}
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */
+
+#endif /* MULBUF_QUEUE_SHA256_H_ */

--- a/include/sys/mulbuf_thdpool.h
+++ b/include/sys/mulbuf_thdpool.h
@@ -1,0 +1,105 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+\*****************************************************************************/
+
+#ifndef _SPL_MULBUF_THDPOOL_H
+#define	_SPL_MULBUF_THDPOOL_H
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+#include <linux/module.h>
+#include <linux/gfp.h>
+#include <linux/slab.h>
+#include <linux/interrupt.h>
+#include <linux/kthread.h>
+#include <linux/mutex.h>
+#include <sys/types.h>
+#include <sys/thread.h>
+#include <sys/rwlock.h>
+
+
+typedef void (*threadp_func_t)(void *);
+typedef struct mulbuf_thdpool mulbuf_thdpool_t;	/* thread pool for multi-buffer crypto */
+typedef struct mbtp_thread mbtp_thread_t;	/* thread for multi-buffer thread pool */
+typedef struct mbtp_queue mbtp_queue_t;		/* task queue for mb thread pool */
+
+typedef enum mbtp_thd_state {
+	THREAD_SETUP,
+	THREAD_READY,
+	THREAD_RUNNING,
+	THREAD_EXIT
+} mbtp_thd_state_t;
+
+
+struct mbtp_thread {
+	struct list_head pool_entry;
+	mulbuf_thdpool_t *pool;
+	struct list_head queue_entry;
+	mbtp_queue_t *queue;
+
+	spinlock_t thd_lock;
+	wait_queue_head_t thread_waitq;
+
+	struct task_struct	*tp_thread;
+	mbtp_thd_state_t curr_state;
+	mbtp_thd_state_t next_state;
+
+	threadp_func_t fn;
+	void *arg;
+};
+
+struct mulbuf_thdpool {
+	char *pool_name;	/* thread pool name */
+	int curr_threadcnt;	/* current thread count */
+	int max_threadcnt;	/* max thread count, if 0, then unlimited */
+	int idle_threadcnt;	/* idle thread count */
+
+	spinlock_t pool_lock;
+	unsigned long pool_lock_flags; /* interrupt state */
+	wait_queue_head_t pool_waitq;
+
+	struct list_head plthread_idle_list; /* idle thread not attached to any queue */
+	struct list_head plthread_busy_list; /* busy thread attached to one queue */
+};
+
+/* Initialize thread pool */
+int mulbuf_thdpool_create(mulbuf_thdpool_t **pool_r, const char *name, int threadcnt, int max_threadcnt);
+
+/* Destroy thread pool */
+void mulbuf_thdpool_destroy(mulbuf_thdpool_t *pool);
+
+/*
+ * Get a valid thread from pool
+ * return 0 if success
+ */
+int mulbuf_thdpool_get_thread(mulbuf_thdpool_t *pool, mbtp_thread_t **tpt_r);
+
+/* Get a valid thread from pool */
+void mbtp_thread_run_fn(mbtp_thread_t *tpt, threadp_func_t fn, void *arg);
+
+/* Return a valid thread to its pool */
+void mulbuf_thdpool_put_thread(mbtp_thread_t *tpt);
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */
+
+#endif  /* _SPL_MULBUF_THDPOOL_H */

--- a/include/sys/multi_buffer.h
+++ b/include/sys/multi_buffer.h
@@ -1,0 +1,119 @@
+/**********************************************************************
+  Copyright(c) 2011-2016 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#ifndef _MULTI_BUFFER_H_
+#define _MULTI_BUFFER_H_
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+/**
+ *  @file  multi_buffer.h
+ *  @brief Multi-buffer common fields
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+# define DECLARE_ALIGNED(decl, alignval) decl __attribute__((aligned(alignval)))
+
+/**
+ *  @enum JOB_STS
+ *  @brief Job return codes
+ */
+
+typedef enum {STS_UNKNOWN = 0,	//!< STS_UNKNOWN
+	STS_BEING_PROCESSED = 1,//!< STS_BEING_PROCESSED
+	STS_COMPLETED = 2,	//!< STS_COMPLETED
+	STS_INTERNAL_ERROR,	//!< STS_INTERNAL_ERROR
+	STS_ERROR		//!< STS_ERROR
+} JOB_STS;
+
+#define HASH_MB_NO_FLAGS 0
+#define HASH_MB_FIRST	1
+#define HASH_MB_LAST	2
+
+/* Common flags for the new API only
+ *  */
+
+/**
+ *  @enum HASH_CTX_FLAG
+ *  @brief CTX job type
+ */
+typedef enum {
+	HASH_UPDATE	= 0x00, //!< HASH_UPDATE
+	HASH_FIRST	= 0x01, //!< HASH_FIRST
+	HASH_LAST	= 0x02, //!< HASH_LAST
+	HASH_ENTIRE	= 0x03, //!< HASH_ENTIRE
+} HASH_CTX_FLAG;
+
+/**
+ *  @enum HASH_CTX_STS
+ *  @brief CTX status flags
+ */
+typedef enum {
+	HASH_CTX_STS_IDLE	= 0x00, //!< HASH_CTX_STS_IDLE
+	HASH_CTX_STS_PROCESSING	= 0x01, //!< HASH_CTX_STS_PROCESSING
+	HASH_CTX_STS_LAST	= 0x02, //!< HASH_CTX_STS_LAST
+	HASH_CTX_STS_COMPLETE	= 0x04, //!< HASH_CTX_STS_COMPLETE
+} HASH_CTX_STS;
+
+/**
+ *  @enum HASH_CTX_ERROR
+ *  @brief CTX error flags
+ */
+typedef enum {
+	HASH_CTX_ERROR_NONE			=  0, //!< HASH_CTX_ERROR_NONE
+	HASH_CTX_ERROR_INVALID_FLAGS		= -1, //!< HASH_CTX_ERROR_INVALID_FLAGS
+	HASH_CTX_ERROR_ALREADY_PROCESSING	= -2, //!< HASH_CTX_ERROR_ALREADY_PROCESSING
+	HASH_CTX_ERROR_ALREADY_COMPLETED	= -3, //!< HASH_CTX_ERROR_ALREADY_COMPLETED
+} HASH_CTX_ERROR;
+
+
+#define hash_ctx_user_data(ctx)  ((ctx)->user_data)
+#define hash_ctx_digest(ctx)     ((ctx)->job.result_digest)
+#define hash_ctx_processing(ctx) ((ctx)->status & HASH_CTX_STS_PROCESSING)
+#define hash_ctx_complete(ctx)   ((ctx)->status == HASH_CTX_STS_COMPLETE)
+#define hash_ctx_status(ctx)     ((ctx)->status)
+#define hash_ctx_error(ctx)      ((ctx)->error)
+#define hash_ctx_init(ctx) \
+	do { \
+		(ctx)->error = HASH_CTX_ERROR_NONE; \
+		(ctx)->status = HASH_CTX_STS_COMPLETE; \
+	} while(0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */
+
+#endif // _MULTI_BUFFER_H_

--- a/include/sys/sha256_mb.h
+++ b/include/sys/sha256_mb.h
@@ -1,0 +1,449 @@
+/**********************************************************************
+  Copyright(c) 2011-2016 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#ifndef _SHA256_MB_H_
+#define _SHA256_MB_H_
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+/**
+ *  @file sha256_mb.h
+ *  @brief Multi-buffer CTX API SHA256 function prototypes and structures
+ *
+ * Interface for multi-buffer SHA256 functions
+ *
+ * <b> Multi-buffer SHA256  Entire or First-Update..Update-Last </b>
+ *
+ * The interface to this multi-buffer hashing code is carried out through the
+ * context-level (CTX) init, submit and flush functions and the SHA256_HASH_CTX_MGR and
+ * SHA256_HASH_CTX objects. Numerous SHA256_HASH_CTX objects may be instantiated by the
+ * application for use with a single SHA256_HASH_CTX_MGR.
+ *
+ * The CTX interface functions carry out the initialization and padding of the jobs
+ * entered by the user and add them to the multi-buffer manager. The lower level "scheduler"
+ * layer then processes the jobs in an out-of-order manner. The scheduler layer functions
+ * are internal and are not intended to be invoked directly. Jobs can be submitted
+ * to a CTX as a complete buffer to be hashed, using the HASH_ENTIRE flag, or as partial
+ * jobs which can be started using the HASH_FIRST flag, and later resumed or finished
+ * using the HASH_UPDATE and HASH_LAST flags respectively.
+ *
+ * <b>Note:</b> The submit function does not require data buffers to be block sized.
+ *
+ * The SHA256 CTX interface functions are available for 4 architectures: SSE, AVX, AVX2 and
+ * AVX512. In addition, a multibinary interface is provided, which selects the appropriate
+ * architecture-specific function at runtime.
+ *
+ * <b>Usage:</b> The application creates a SHA256_HASH_CTX_MGR object and initializes it
+ * with a call to sha256_ctx_mgr_init*() function, where henceforth "*" stands for the
+ * relevant suffix for each architecture; _sse, _avx, _avx2, _avx512(or no suffix for the
+ * multibinary version). The SHA256_HASH_CTX_MGR object will be used to schedule processor
+ * resources, with up to 4 SHA256_HASH_CTX objects (or 8 in the AVX2 case, 16 in the AVX512)
+ * being processed at a time.
+ *
+ * Each SHA256_HASH_CTX must be initialized before first use by the hash_ctx_init macro
+ * defined in multi_buffer.h. After initialization, the application may begin computing
+ * a hash by giving the SHA256_HASH_CTX to a SHA256_HASH_CTX_MGR using the submit functions
+ * sha256_ctx_mgr_submit*() with the HASH_FIRST flag set. When the SHA256_HASH_CTX is
+ * returned to the application (via this or a later call to sha256_ctx_mgr_submit*() or
+ * sha256_ctx_mgr_flush*()), the application can then re-submit it with another call to
+ * sha256_ctx_mgr_submit*(), but without the HASH_FIRST flag set.
+ *
+ * Ideally, on the last buffer for that hash, sha256_ctx_mgr_submit_sse is called with
+ * HASH_LAST, although it is also possible to submit the hash with HASH_LAST and a zero
+ * length if necessary. When a SHA256_HASH_CTX is returned after having been submitted with
+ * HASH_LAST, it will contain a valid hash. The SHA256_HASH_CTX can be reused immediately
+ * by submitting with HASH_FIRST.
+ *
+ * For example, you would submit hashes with the following flags for the following numbers
+ * of buffers:
+ * <ul>
+ *  <li> one buffer: HASH_FIRST | HASH_LAST  (or, equivalently, HASH_ENTIRE)
+ *  <li> two buffers: HASH_FIRST, HASH_LAST
+ *  <li> three buffers: HASH_FIRST, HASH_UPDATE, HASH_LAST
+ * etc.
+ * </ul>
+ *
+ * The order in which SHA256_CTX objects are returned is in general different from the order
+ * in which they are submitted.
+ *
+ * A few possible error conditions exist:
+ * <ul>
+ *  <li> Submitting flags other than the allowed entire/first/update/last values
+ *  <li> Submitting a context that is currently being managed by a SHA256_HASH_CTX_MGR.
+ *  <li> Submitting a context after HASH_LAST is used but before HASH_FIRST is set.
+ * </ul>
+ *
+ *  These error conditions are reported by returning the SHA256_HASH_CTX immediately after
+ *  a submit with its error member set to a non-zero error code (defined in
+ *  multi_buffer.h). No changes are made to the SHA256_HASH_CTX_MGR in the case of an
+ *  error; no processing is done for other hashes.
+ *
+ */
+
+#include "multi_buffer.h"
+#include "types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Hash Constants and Typedefs
+#define SHA256_DIGEST_NWORDS		8
+#define SHA256_MAX_LANES		16
+#define SHA256_X8_LANES			8
+#define SHA256_MIN_LANES		4
+#define SHA256_BLOCK_SIZE		64
+#define SHA256_LOG2_BLOCK_SIZE		6
+#define SHA256_PADLENGTHFIELD_SIZE	8
+#define SHA256_INITIAL_DIGEST		\
+	0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, \
+	0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+
+typedef uint32_t sha256_digest_array[SHA256_DIGEST_NWORDS][SHA256_MAX_LANES];
+typedef uint32_t SHA256_WORD_T;
+
+/** @brief Scheduler layer - Holds info describing a single SHA256 job for the multi-buffer manager */
+
+typedef struct {
+	uint8_t*  buffer;	//!< pointer to data buffer for this job
+	uint64_t  len;		//!< length of buffer for this job in blocks.
+	DECLARE_ALIGNED(uint32_t result_digest[SHA256_DIGEST_NWORDS], 64);
+	JOB_STS status;		//!< output job status
+	void*   user_data;	//!< pointer for user's job-related data
+} SHA256_JOB;
+
+/** @brief Scheduler layer -  Holds arguments for submitted SHA256 job */
+
+typedef struct {
+	sha256_digest_array digest;
+	uint8_t* data_ptr[SHA256_MAX_LANES];
+} SHA256_MB_ARGS_X16;
+
+/** @brief Scheduler layer - Lane data */
+
+typedef struct {
+	SHA256_JOB *job_in_lane;
+} SHA256_LANE_DATA;
+
+/** @brief Scheduler layer - Holds state for multi-buffer SHA256 jobs */
+
+typedef struct {
+	SHA256_MB_ARGS_X16 args;
+	uint32_t lens[SHA256_MAX_LANES];
+	uint64_t unused_lanes; //!< each nibble is index (0...3 or 0...7) of unused lanes, nibble 4 or 8 is set to F as a flag
+	SHA256_LANE_DATA ldata[SHA256_MAX_LANES];
+	uint32_t num_lanes_inuse;
+} SHA256_MB_JOB_MGR;
+
+/** @brief Context layer - Holds state for multi-buffer SHA256 jobs */
+
+typedef struct {
+	SHA256_MB_JOB_MGR mgr;
+} SHA256_HASH_CTX_MGR;
+
+/** @brief Context layer - Holds info describing a single SHA256 job for the multi-buffer CTX manager */
+
+typedef struct {
+	SHA256_JOB	job; // Must be at struct offset 0.
+	HASH_CTX_STS	status;		//!< Context status flag
+	HASH_CTX_ERROR	error;		//!< Context error flag
+	uint32_t	total_length;	//!< Running counter of length processed for this CTX's job
+	const void*	incoming_buffer; //!< pointer to data input buffer for this CTX's job
+	uint32_t	incoming_buffer_length; //!< length of buffer for this job in bytes.
+	uint8_t		partial_block_buffer[SHA256_BLOCK_SIZE * 2]; //!< CTX partial blocks
+	uint32_t	partial_block_buffer_length;
+	void*		user_data;	//!< pointer for user to keep any job-related data
+} SHA256_HASH_CTX;
+
+/******************** multibinary function prototypes **********************/
+
+/**
+ * @brief Initialize the SHA256 multi-buffer manager structure.
+ * @requires SSE4.1 or AVX or AVX2
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns void
+ */
+void      sha256_ctx_mgr_init   (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief  Submit a new SHA256 job to the multi-buffer manager.
+ * @requires SSE4.1 or AVX or AVX2
+ *
+ * @param  mgr Structure holding context level state info
+ * @param  ctx Structure holding ctx job info
+ * @param  buffer Pointer to buffer to be processed
+ * @param  len Length of buffer (in bytes) to be processed
+ * @param  flags Input flag specifying job type (first, update, last or entire)
+ * @returns NULL if no jobs complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_submit (SHA256_HASH_CTX_MGR* mgr, SHA256_HASH_CTX* ctx,
+					const void* buffer, uint32_t len, HASH_CTX_FLAG flags);
+
+/**
+ * @brief Finish all submitted SHA256 jobs and return when complete.
+ * @requires SSE4.1 or AVX or AVX2
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns NULL if no jobs to complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_flush  (SHA256_HASH_CTX_MGR* mgr);
+
+
+/*******************************************************************
+ * CTX level API function prototypes
+ ******************************************************************/
+
+/**
+ * @brief Initialize the context level SHA256 multi-buffer manager structure.
+ * @requires SSE4.1
+ *
+ * @param mgr Structure holding context level state info
+ * @returns void
+ */
+void      sha256_ctx_mgr_init_sse   (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief  Submit a new SHA256 job to the context level multi-buffer manager.
+ * @requires SSE4.1
+ *
+ * @param  mgr Structure holding context level state info
+ * @param  ctx Structure holding ctx job info
+ * @param  buffer Pointer to buffer to be processed
+ * @param  len Length of buffer (in bytes) to be processed
+ * @param  flags Input flag specifying job type (first, update, last or entire)
+ * @returns NULL if no jobs complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_submit_sse (SHA256_HASH_CTX_MGR* mgr, SHA256_HASH_CTX* ctx,
+					const void* buffer, uint32_t len, HASH_CTX_FLAG flags);
+
+/**
+ * @brief Finish all submitted SHA256 jobs and return when complete.
+ * @requires SSE4.1
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns NULL if no jobs to complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_flush_sse  (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief Initialize the context level SHA256 multi-buffer manager structure.
+ * @requires SSE4.1 and SHANI
+ *
+ * @param mgr Structure holding context level state info
+ * @returns void
+ */
+void      sha256_ctx_mgr_init_sse_ni (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief  Submit a new SHA256 job to the context level multi-buffer manager.
+ * @requires SSE4.1 and SHANI
+ *
+ * @param  mgr Structure holding context level state info
+ * @param  ctx Structure holding ctx job info
+ * @param  buffer Pointer to buffer to be processed
+ * @param  len Length of buffer (in bytes) to be processed
+ * @param  flags Input flag specifying job type (first, update, last or entire)
+ * @returns NULL if no jobs complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_submit_sse_ni (SHA256_HASH_CTX_MGR* mgr, SHA256_HASH_CTX* ctx,
+				const void* buffer, uint32_t len, HASH_CTX_FLAG flags);
+
+/**
+ * @brief Finish all submitted SHA256 jobs and return when complete.
+ * @requires SSE4.1 and SHANI
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns NULL if no jobs to complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_flush_sse_ni (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief Initialize the SHA256 multi-buffer manager structure.
+ * @requires AVX
+ *
+ * @param mgr Structure holding context level state info
+ * @returns void
+ */
+void      sha256_ctx_mgr_init_avx   (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief  Submit a new SHA256 job to the multi-buffer manager.
+ * @requires AVX
+ *
+ * @param  mgr Structure holding context level state info
+ * @param  ctx Structure holding ctx job info
+ * @param  buffer Pointer to buffer to be processed
+ * @param  len Length of buffer (in bytes) to be processed
+ * @param  flags Input flag specifying job type (first, update, last or entire)
+ * @returns NULL if no jobs complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_submit_avx (SHA256_HASH_CTX_MGR* mgr, SHA256_HASH_CTX* ctx,
+					const void* buffer, uint32_t len, HASH_CTX_FLAG flags);
+
+/**
+ * @brief Finish all submitted SHA256 jobs and return when complete.
+ * @requires AVX
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns NULL if no jobs to complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_flush_avx  (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief Initialize the SHA256 multi-buffer manager structure.
+ * @requires AVX2
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns void
+ */
+void      sha256_ctx_mgr_init_avx2   (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief  Submit a new SHA256 job to the multi-buffer manager.
+ * @requires AVX2
+ *
+ * @param  mgr Structure holding context level state info
+ * @param  ctx Structure holding ctx job info
+ * @param  buffer Pointer to buffer to be processed
+ * @param  len Length of buffer (in bytes) to be processed
+ * @param  flags Input flag specifying job type (first, update, last or entire)
+ * @returns NULL if no jobs complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_submit_avx2 (SHA256_HASH_CTX_MGR* mgr, SHA256_HASH_CTX* ctx,
+					const void* buffer, uint32_t len, HASH_CTX_FLAG flags);
+
+/**
+ * @brief Finish all submitted SHA256 jobs and return when complete.
+ * @requires AVX2
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns NULL if no jobs to complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_flush_avx2  (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief Initialize the SHA256 multi-buffer manager structure.
+ * @requires AVX512
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns void
+ */
+void      sha256_ctx_mgr_init_avx512   (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief  Submit a new SHA256 job to the multi-buffer manager.
+ * @requires AVX512
+ *
+ * @param  mgr Structure holding context level state info
+ * @param  ctx Structure holding ctx job info
+ * @param  buffer Pointer to buffer to be processed
+ * @param  len Length of buffer (in bytes) to be processed
+ * @param  flags Input flag specifying job type (first, update, last or entire)
+ * @returns NULL if no jobs complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_submit_avx512 (SHA256_HASH_CTX_MGR* mgr, SHA256_HASH_CTX* ctx,
+					const void* buffer, uint32_t len, HASH_CTX_FLAG flags);
+
+/**
+ * @brief Finish all submitted SHA256 jobs and return when complete.
+ * @requires AVX512
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns NULL if no jobs to complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_flush_avx512  (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief Initialize the SHA256 multi-buffer manager structure.
+ * @requires AVX512 and SHANI
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns void
+ */
+void      sha256_ctx_mgr_init_avx512_ni (SHA256_HASH_CTX_MGR* mgr);
+
+/**
+ * @brief  Submit a new SHA256 job to the multi-buffer manager.
+ * @requires AVX512 and SHANI
+ *
+ * @param  mgr Structure holding context level state info
+ * @param  ctx Structure holding ctx job info
+ * @param  buffer Pointer to buffer to be processed
+ * @param  len Length of buffer (in bytes) to be processed
+ * @param  flags Input flag specifying job type (first, update, last or entire)
+ * @returns NULL if no jobs complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_submit_avx512_ni (SHA256_HASH_CTX_MGR* mgr, SHA256_HASH_CTX* ctx,
+				const void* buffer, uint32_t len, HASH_CTX_FLAG flags);
+
+/**
+ * @brief Finish all submitted SHA256 jobs and return when complete.
+ * @requires AVX512 and SHANI
+ *
+ * @param mgr	Structure holding context level state info
+ * @returns NULL if no jobs to complete or pointer to jobs structure.
+ */
+SHA256_HASH_CTX* sha256_ctx_mgr_flush_avx512_ni (SHA256_HASH_CTX_MGR* mgr);
+
+
+/*******************************************************************
+ * Scheduler (internal) level out-of-order function prototypes
+ ******************************************************************/
+
+void        sha256_mb_mgr_init_sse   (SHA256_MB_JOB_MGR *state);
+SHA256_JOB* sha256_mb_mgr_submit_sse (SHA256_MB_JOB_MGR *state, SHA256_JOB* job);
+SHA256_JOB* sha256_mb_mgr_flush_sse  (SHA256_MB_JOB_MGR *state);
+
+#define     sha256_mb_mgr_init_avx   sha256_mb_mgr_init_sse
+SHA256_JOB* sha256_mb_mgr_submit_avx (SHA256_MB_JOB_MGR *state, SHA256_JOB* job);
+SHA256_JOB* sha256_mb_mgr_flush_avx  (SHA256_MB_JOB_MGR *state);
+
+void        sha256_mb_mgr_init_avx2   (SHA256_MB_JOB_MGR *state);
+SHA256_JOB* sha256_mb_mgr_submit_avx2 (SHA256_MB_JOB_MGR *state, SHA256_JOB* job);
+SHA256_JOB* sha256_mb_mgr_flush_avx2  (SHA256_MB_JOB_MGR *state);
+
+void        sha256_mb_mgr_init_avx512   (SHA256_MB_JOB_MGR *state);
+SHA256_JOB* sha256_mb_mgr_submit_avx512 (SHA256_MB_JOB_MGR *state, SHA256_JOB* job);
+SHA256_JOB* sha256_mb_mgr_flush_avx512  (SHA256_MB_JOB_MGR *state);
+
+void        sha256_mb_mgr_init_sse_ni    (SHA256_MB_JOB_MGR *state);
+SHA256_JOB* sha256_mb_mgr_submit_sse_ni  (SHA256_MB_JOB_MGR *state, SHA256_JOB* job);
+SHA256_JOB* sha256_mb_mgr_flush_sse_ni   (SHA256_MB_JOB_MGR *state);
+
+void        sha256_mb_mgr_init_avx512_ni    (SHA256_MB_JOB_MGR *state);
+SHA256_JOB* sha256_mb_mgr_submit_avx512_ni  (SHA256_MB_JOB_MGR *state, SHA256_JOB* job);
+SHA256_JOB* sha256_mb_mgr_flush_avx512_ni   (SHA256_MB_JOB_MGR *state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */
+
+#endif // _SHA256_MB_H_

--- a/module/spl/Makefile.in
+++ b/module/spl/Makefile.in
@@ -28,3 +28,40 @@ $(MODULE)-objs += spl-xdr.o
 $(MODULE)-objs += spl-cred.o
 $(MODULE)-objs += spl-tsd.o
 $(MODULE)-objs += spl-zlib.o
+$(MODULE)-objs += spl-mulbuf-thdpool.o
+$(MODULE)-objs += spl-mulbuf-queue.o
+$(MODULE)-objs += spl-mulbuf-queue-sha256.o
+$(MODULE)-objs += spl-mulbuf-suite-sha256.o
+#$(MODULE)-objs += spl-mulbuf-test.o
+
+@CONFIG_HASH_MB_TRUE@hash_mb = 1
+ifdef hash_mb
+$(MODULE)-objs += isa-l.o_shipped
+$(obj)/isa-l.o_shipped:
+	@# add Makefile to compile kernel space object
+	@echo 'include Makefile.unx' > @HASH_MB_SRC@/Makefile.kern
+	@echo 'product = isa-l' >> @HASH_MB_SRC@/Makefile.kern
+	@echo 'kernobj: $$(product).o_shipped' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '$$(product).o_shipped: CFLAGS+= -fno-common \' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '-mcmodel=kernel -fno-stack-protector \' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '$$(product).o_shipped: D+=ALIGN_STACK REL_TEXT' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '$$(product).o_shipped: DEFINES+=-D NDEBUG' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '$$(product).o_shipped: DEBUG_$$(AS)=' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '$$(product).o_shipped: DEBUG=' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '$$(product).o_shipped: $$(objs)' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '	@echo "  ---> Creating bin $$@"' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '	@$$(AR) $$(ARFLAGS) $$^' >> @HASH_MB_SRC@/Makefile.kern
+	@echo '	@$$(STRIP_$$(CC))' >> @HASH_MB_SRC@/Makefile.kern
+	@# compile kernel space object from isa-l crypto
+	@echo "Get multi-buffer hash object from isa-l crypto"
+	@if [ -f @HASH_MB_SRC@/isa-l.o_shipped ]; then \
+	mv @HASH_MB_SRC@/isa-l.o_shipped $(obj); \
+	else echo "Please run: $(MAKE) -C @HASH_MB_SRC@ -f Makefile.kern kernobj"; \
+	echo "then continue run: make"; exit 1; fi
+endif
+
+ $(product).o_shipped: DEBUG_$(AS)=    # Don't put debug symbols in the lib
+ $(product).o_shipped: DEBUG=
+ $(product).o_shipped: DEFINES+=-D NDEBUG
+	

--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -34,6 +34,7 @@
 #include <sys/mutex.h>
 #include <sys/rwlock.h>
 #include <sys/taskq.h>
+#include <sys/mulbuf_queue_sha256.h>
 #include <sys/tsd.h>
 #include <sys/zmod.h>
 #include <sys/debug.h>
@@ -703,10 +704,15 @@ spl_init(void)
 	if ((rc = spl_zlib_init()))
 		goto out10;
 
+	if ((rc = mulbuf_suite_sha256_init()))
+		goto out11;
+
 	printk(KERN_NOTICE "SPL: Loaded module v%s-%s%s\n", SPL_META_VERSION,
 	       SPL_META_RELEASE, SPL_DEBUG_STR);
 	return (rc);
 
+out11:
+	mulbuf_suite_sha256_fini();
 out10:
 	spl_kstat_fini();
 out9:
@@ -738,6 +744,7 @@ spl_fini(void)
 {
 	printk(KERN_NOTICE "SPL: Unloaded module v%s-%s%s\n",
 	       SPL_META_VERSION, SPL_META_RELEASE, SPL_DEBUG_STR);
+	mulbuf_suite_sha256_fini();
 	spl_zlib_fini();
 	spl_kstat_fini();
 	spl_proc_fini();

--- a/module/spl/spl-mulbuf-queue-sha256.c
+++ b/module/spl/spl-mulbuf-queue-sha256.c
@@ -1,0 +1,549 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************
+ *  Solaris Porting Layer (SPL) Multi-Buffer Hash Queue SHA256 Implementation.
+\*****************************************************************************/
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+#include <sys/sha256_mb.h>
+#include <sys/mulbuf_queue_sha256.h>
+
+#ifdef HAVE_FPU_HEADER
+# include <asm/fpu/api.h>
+#else
+# include <asm/i387.h>
+#endif
+
+/*
+ * align stack before calling multi-buffer hash functions
+ */
+#define STACK_ALIGNCALL16(x)  \
+{ \
+    asm("push %rdi"); \
+    asm("mov %rsp, %rdi"); \
+    asm("and $0xfffffffffffffff0, %rsp"); \
+    asm("push %rdi"); \
+    asm("sub $8, %rsp"); \
+    asm("mov (%rdi), %rdi"); \
+    x; \
+    asm("add $8, %rsp"); \
+    asm("pop %rsp"); \
+    asm("add $8, %rsp"); \
+}
+
+/*
+ * Get number of concurrent lanes this platform supports
+ */
+int sha256_mb_concurrent_lanes(void)
+{
+	static int cc_num = 0;
+
+	SHA256_HASH_CTX_MGR *mgr;
+
+	if (cc_num == 0) {
+		mgr = kmem_alloc(sizeof(*mgr), KM_SLEEP);
+
+		sha256_ctx_mgr_init(mgr);
+
+		if (mgr->mgr.unused_lanes == 0xf76543210)
+			cc_num = 8;
+		else if (mgr->mgr.unused_lanes == 0xf3210)
+			cc_num = 4;
+		else
+			cc_num = 16;
+
+		kmem_free(mgr, sizeof(*mgr));
+	}
+
+	return cc_num;
+}
+
+int spl_mulbuf_snoop_size_threshold = 128 * 1024;
+module_param(spl_mulbuf_snoop_size_threshold, int, 0644);
+MODULE_PARM_DESC(spl_mulbuf_snoop_size_threshold,
+		 "Size threshold for sha256_mb to snoop new tasks");
+
+/*
+ * Get first usable ctx from a ctx array
+ *
+ * sidx: start index for this search
+ * return 0 if the index we find in this ctx array
+ * return 1 if not found
+ */
+static int get_unused_hash_ctx(SHA256_HASH_CTX ctxpool[], int sidx, int concurrent_num)
+{
+	int i;
+	for (i = sidx; i < concurrent_num; i++) {
+		if (hash_ctx_complete(&ctxpool[i]))
+			return i;
+	}
+
+	return -1;
+}
+
+static int get_used_hash_ctx(SHA256_HASH_CTX ctxpool[], int sidx, int concurrent_num)
+{
+	int i;
+	for (i = sidx; i < concurrent_num; i++) {
+		/* completed ctx has user_data */
+		if (ctxpool[i].user_data && hash_ctx_complete(&ctxpool[i]))
+			return i;
+	}
+
+	return -1;
+}
+
+static int get_using_hash_ctx(SHA256_HASH_CTX ctxpool[], int sidx, int concurrent_num)
+{
+	int i;
+	for (i = sidx; i < concurrent_num; i++) {
+		if (!hash_ctx_complete(&ctxpool[i]))
+			return i;
+	}
+
+	return -1;
+}
+
+/*
+ * Snoop mb-hash function by length threshold
+ */
+void sha256_mb_length_thd(SHA256_HASH_CTX_MGR * mgr, SHA256_HASH_CTX ctxpool[],
+			  mbtp_task_t * ta[], int take_num, int concurrent_num, int thd)
+{
+	int i;
+	int sidx;
+	unsigned char *buffer;
+	size_t gap, size;
+	mbtp_task_t *job;
+	SHA256_HASH_CTX *tmp;
+
+	kernel_fpu_begin();
+
+	/* process previous processing jobs */
+	sidx = -1;
+	while ((sidx = get_using_hash_ctx(ctxpool, sidx + 1, concurrent_num)) != -1) {
+		job = (mbtp_task_t *) ctxpool[sidx].user_data;
+
+		buffer = (unsigned char *)job->buffer + ctxpool[sidx].total_length;
+		gap = job->size - ctxpool[sidx].total_length;
+		/* check whether this is last round */
+		if (thd <= gap) {
+			size = thd;
+			STACK_ALIGNCALL16(sha256_ctx_mgr_submit(mgr, &ctxpool[sidx],
+								(void *)buffer, size,
+								HASH_UPDATE));
+		} else {
+			size = gap;
+			STACK_ALIGNCALL16(sha256_ctx_mgr_submit(mgr, &ctxpool[sidx],
+								(void *)buffer, size,
+								HASH_LAST));
+		}
+	}
+
+	/* process new taken jobs */
+	sidx = -1;
+	if (take_num > 0) {
+		for (i = 0; i < take_num; i++) {
+			sidx = get_unused_hash_ctx(ctxpool, sidx + 1, concurrent_num);
+			job = ta[i];
+			/* link job with ctx */
+			ctxpool[sidx].user_data = (void *)job;
+			if (ta[i]->size <= thd) {
+				STACK_ALIGNCALL16(sha256_ctx_mgr_submit(mgr, &ctxpool[sidx],
+									ta[i]->buffer,
+									ta[i]->size,
+									HASH_ENTIRE));
+			} else {
+				STACK_ALIGNCALL16(sha256_ctx_mgr_submit(mgr, &ctxpool[sidx],
+									ta[i]->buffer, thd,
+									HASH_FIRST));
+			}
+		}
+	}
+
+	STACK_ALIGNCALL16(tmp = sha256_ctx_mgr_flush(mgr));
+	while (tmp)
+		STACK_ALIGNCALL16(tmp = sha256_ctx_mgr_flush(mgr));
+
+	kernel_fpu_end();
+
+	return;
+}
+
+/*
+ * Full mb-hash function by origin length
+ */
+void sha256_mb_length_full(SHA256_HASH_CTX_MGR * mgr, SHA256_HASH_CTX ctxpool[],
+			   mbtp_task_t * ta[], int take_num, int concurrent_num)
+{
+	int i;
+	int sidx;
+	unsigned char *buffer;
+	size_t gap;
+	mbtp_task_t *job;
+	SHA256_HASH_CTX *tmp;
+
+	kernel_fpu_begin();
+
+	/* process previous processing jobs */
+	sidx = -1;
+	while ((sidx = get_using_hash_ctx(ctxpool, sidx + 1, concurrent_num)) != -1) {
+		job = (mbtp_task_t *) ctxpool[sidx].user_data;
+
+		buffer = (unsigned char *)job->buffer + ctxpool[sidx].total_length;
+		gap = job->size - ctxpool[sidx].total_length;
+		STACK_ALIGNCALL16(sha256_ctx_mgr_submit(mgr, &ctxpool[sidx],
+							(void *)buffer, gap, HASH_LAST));
+	}
+
+	/* process new taken jobs */
+	sidx = -1;
+	if (take_num > 0) {
+		for (i = 0; i < take_num; i++) {
+			sidx = get_unused_hash_ctx(ctxpool, sidx + 1, concurrent_num);
+			/* link job with ctx */
+			ctxpool[sidx].user_data = (void *)ta[i];
+
+			STACK_ALIGNCALL16(sha256_ctx_mgr_submit(mgr, &ctxpool[sidx],
+								ta[i]->buffer, ta[i]->size,
+								HASH_ENTIRE));
+		}
+	}
+
+	STACK_ALIGNCALL16(tmp = sha256_ctx_mgr_flush(mgr));
+	while (tmp)
+		STACK_ALIGNCALL16(tmp = sha256_ctx_mgr_flush(mgr));
+
+	kernel_fpu_end();
+
+	return;
+}
+
+inline uint32_t byteswap32(uint32_t x)
+{
+	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
+}
+
+/*
+ * Process completed jobs
+ *
+ * return number of completed jobs
+ */
+int sha256_mb_count_complete(SHA256_HASH_CTX ctxpool[], int concurrent_num)
+{
+	int sidx;
+	int count = 0;
+	mbtp_task_t *job;
+	uint32_t *H;
+
+	/* completed ctx */
+	sidx = -1;
+	while ((sidx = get_used_hash_ctx(ctxpool, sidx + 1, concurrent_num)) != -1) {
+		job = (mbtp_task_t *) ctxpool[sidx].user_data;
+
+		/*
+		 * sha256 digest: sha256-mb is A62F007C C6848756 ...                                                                                                                                        V..Æ|./¦
+		 *                            sha256-zfs is C6848756 A62F007C ...
+		 *                            sha256-ossl is 7C002FA6 568784C6 ...
+		 */
+#ifndef OPENSSL_SHA256
+		// change sha256-mb to sha256-zfs
+		H = (uint32_t *) ctxpool[sidx].job.result_digest;
+		*(uint64_t *) & job->digest[0] = (uint64_t) H[0] << 32 | H[1];
+		*(uint64_t *) & job->digest[8] = (uint64_t) H[2] << 32 | H[3];
+		*(uint64_t *) & job->digest[16] = (uint64_t) H[4] << 32 | H[5];
+		*(uint64_t *) & job->digest[24] = (uint64_t) H[6] << 32 | H[7];
+
+#else
+		// change sha256-mb to sha256-ossl
+		H = (uint32_t *) ctxpool[sidx].job.result_digest;
+		*(uint32_t *) & job->digest[0] = byteswap32(H[0]);
+		*(uint32_t *) & job->digest[4] = byteswap32(H[1]);
+		*(uint32_t *) & job->digest[8] = byteswap32(H[2]);
+		*(uint32_t *) & job->digest[12] = byteswap32(H[3]);
+		*(uint32_t *) & job->digest[16] = byteswap32(H[4]);
+		*(uint32_t *) & job->digest[20] = byteswap32(H[5]);
+		*(uint32_t *) & job->digest[24] = byteswap32(H[6]);
+		*(uint32_t *) & job->digest[28] = byteswap32(H[7]);
+#endif
+
+		job->processsed = 1;
+		if (job->cb_fn)
+			job->cb_fn(job, job->cb_arg);
+
+		hash_ctx_init(&ctxpool[sidx]);
+
+		/* user_data is used to judge just now completed ctxpool */
+		ctxpool[sidx].user_data = NULL;
+		count++;
+	}
+
+	return count;
+}
+
+/*
+ * auxiliary structure and functions
+ */
+typedef struct sha256_aux {
+	SHA256_HASH_CTX_MGR *mgr;
+	SHA256_HASH_CTX ctxpool[16];
+	int concurrent_num;
+} sha256_aux_t;
+
+int sha256_mb_auxiliary_init(sha256_aux_t ** aux_r)
+{
+	sha256_aux_t *aux;
+	SHA256_HASH_CTX_MGR *mgr;
+	int i;
+
+	aux = (sha256_aux_t *) kmem_alloc(sizeof(*aux), KM_PUSHPAGE | KM_ZERO);
+	*aux_r = aux;
+	if (aux == NULL)
+		return 1;
+
+	mgr = (SHA256_HASH_CTX_MGR *) kmem_alloc(sizeof(*mgr), KM_PUSHPAGE | KM_ZERO);
+	aux->mgr = mgr;
+	sha256_ctx_mgr_init(mgr);
+
+	aux->concurrent_num = sha256_mb_concurrent_lanes();
+	for (i = 0; i < aux->concurrent_num; i++) {
+		hash_ctx_init(&aux->ctxpool[i]);
+	}
+
+	return 0;
+}
+
+void sha256_mb_auxiliary_fini(sha256_aux_t * aux)
+{
+	kmem_free(aux->mgr, sizeof(*aux->mgr));
+	kmem_free(aux, sizeof(*aux));
+
+	return;
+}
+
+unsigned long sha256_mb_snoop_proc(mbtp_thread_t * tqt, sha256_aux_t * aux, int thd,
+				   unsigned long flags)
+{
+	mbtp_queue_t *queue = tqt->queue;
+	mbtp_task_t *jobs[32];
+	mbtp_task_t *job;
+
+	SHA256_HASH_CTX_MGR *mgr = aux->mgr;
+	SHA256_HASH_CTX *ctxpool = aux->ctxpool;
+	int concurrent_num = aux->concurrent_num;
+
+	int take_num, complete_num, process_num;
+	int i;
+	int snoop = 0;
+	int rc;
+
+	ASSERT(queue->idle_threadcnt > 0);
+	/* get tasks from queue's job list */
+	process_num = complete_num = 0;
+	while ((take_num = mbtp_queue_assign_taskjobcnt(queue, process_num, concurrent_num))
+	       || process_num) {
+		queue->curr_taskcnt -= take_num;
+		queue->proc_taskcnt += take_num;
+		queue->idle_threadcnt--;
+		// take tasks out
+		for (i = 0; i < take_num && !list_empty(&queue->task_list); i++) {
+			job = list_entry(queue->task_list.next, mbtp_task_t, queue_entry);
+			list_del(&job->queue_entry);
+			jobs[i] = job;
+		}
+
+		ASSERT(i == take_num);
+
+		/* start snoop loop */
+		if (queue->idle_threadcnt == 0) {
+			/* Last idle thread should do snoop operations */
+			if (take_num + process_num < concurrent_num) {
+				/* snoop if this thread is not full */
+				snoop = 1;
+			} else if (queue->max_threadcnt == queue->curr_threadcnt) {
+				/* all threads are working, not snoop since this thread is full of jobs */
+				snoop = 0;
+			} else {
+				/* release lock before add thread */
+				spin_unlock_irqrestore(&queue->queue_lock, flags);
+
+				/* no snoop if this thread is full and can add an extra thread into queue */
+				rc = mbtp_queue_add_thread(queue);
+
+				spin_lock_irqsave(&queue->queue_lock, flags);
+
+				/* check whether need to signal next thread */
+				if (queue->curr_taskcnt > 0 && queue->idle_threadcnt > 0)
+					wake_up(&queue->queue_waitq);
+				snoop = 0;
+			}
+		} else {
+			/* extra idle thread needn't do snoop operations */
+			/* check whether need to signal next thread */
+			if (queue->curr_taskcnt > 0 && queue->idle_threadcnt > 0)
+				wake_up(&queue->queue_waitq);
+			snoop = 0;
+		}
+
+		spin_unlock_irqrestore(&queue->queue_lock, flags);
+		if (snoop) {
+			sha256_mb_length_thd(mgr, ctxpool, jobs, take_num, concurrent_num,
+					     thd);
+		} else {
+			sha256_mb_length_full(mgr, ctxpool, jobs, take_num, concurrent_num);
+		}
+		complete_num = sha256_mb_count_complete(ctxpool, concurrent_num);
+		process_num = take_num + process_num - complete_num;
+
+		spin_lock_irqsave(&queue->queue_lock, flags);
+
+		queue->idle_threadcnt++;
+		queue->proc_taskcnt -= complete_num;
+
+		if (snoop) {
+			continue;	/* continue snoop loop */
+		} else {
+			break;	/* leave snoop loop */
+		}
+	}
+
+	return flags;
+}
+
+/*
+ * Taskqueue function in which thread will run
+ */
+typedef enum hash_fn_state {
+	HASH_WAIT,
+	HASH_PROCESS,
+	HASH_EXIT
+} hash_fn_state_t;
+
+void mulbuf_sha256_fn(void *arg)
+{
+	DECLARE_WAITQUEUE(thd_wait, current);
+	hash_fn_state_t state;
+	mbtp_thread_t *tpt = (mbtp_thread_t *) arg;
+	mbtp_queue_t *queue = tpt->queue;
+
+	unsigned long flags;
+
+	int concurrent_num;
+
+	sha256_aux_t *aux;
+
+	sha256_mb_auxiliary_init(&aux);
+	concurrent_num = aux->concurrent_num;
+
+	state = HASH_WAIT;
+
+	spin_lock_irqsave(&queue->queue_lock, flags);
+
+	while (state != HASH_EXIT) {
+
+		switch (state) {
+		case HASH_WAIT:
+			/* if queue is leaving, start to leave at first */
+			if (queue->leave > 0) {
+				state = HASH_EXIT;
+				break;
+			}
+			/* shrink thread */
+			if (mbtp_queue_check_shrink_thread(queue, concurrent_num) == 0) {
+				state = HASH_EXIT;
+				break;
+			}
+			/* if there are tasks, directly process them */
+			if (queue->curr_taskcnt > 0) {
+				state = HASH_PROCESS;
+				break;
+			}
+
+			/* wait for task coming or exit notice */
+			add_wait_queue_exclusive(&queue->queue_waitq, &thd_wait);
+			set_current_state(TASK_INTERRUPTIBLE);
+
+			spin_unlock_irqrestore(&queue->queue_lock, flags);
+
+			schedule();
+
+			spin_lock_irqsave(&queue->queue_lock, flags);
+			__set_current_state(TASK_RUNNING);
+
+			remove_wait_queue(&queue->queue_waitq, &thd_wait);
+
+			if (queue->curr_taskcnt == 0) {
+				state = HASH_EXIT;
+			} else {
+				state = HASH_PROCESS;
+			}
+
+			break;
+		case HASH_PROCESS:
+			/* get tasks from queue's job list */
+			flags =
+			    sha256_mb_snoop_proc(tpt, aux, spl_mulbuf_snoop_size_threshold,
+						 flags);
+
+			state = HASH_WAIT;
+			break;
+
+		case HASH_EXIT:
+		default:
+			break;
+		}
+	}
+
+	if (queue->leave) {
+		/* queue is leaving, queue will detach them */
+
+		spin_unlock_irqrestore(&queue->queue_lock, flags);
+
+		/* let queue know, this thread is left now */
+		spin_lock_irqsave(&tpt->thd_lock, flags);
+		tpt->next_state = THREAD_READY;
+		wake_up(&tpt->thread_waitq);
+		spin_unlock_irqrestore(&tpt->thd_lock, flags);
+	} else {
+		/* queue is not leaving, thread detaches itself from queue */
+		/* after shrink, this thread has no relationship with queue, its owner becomes pool */
+		spin_unlock_irqrestore(&queue->queue_lock, flags);
+
+		/* let queue know, this thread is left now */
+		spin_lock_irqsave(&tpt->thd_lock, flags);
+		tpt->next_state = THREAD_READY;
+		wake_up(&tpt->thread_waitq);
+		spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+		spin_lock_irqsave(&queue->queue_lock, flags);
+		mbtp_queue_shrink_thread(queue, tpt);
+		spin_unlock_irqrestore(&queue->queue_lock, flags);
+	}
+
+	sha256_mb_auxiliary_fini(aux);
+
+	return;
+}
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */

--- a/module/spl/spl-mulbuf-queue.c
+++ b/module/spl/spl-mulbuf-queue.c
@@ -1,0 +1,314 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************
+ *  Solaris Porting Layer (SPL) Multi-Buffer Hash Queue Basic Implementation.
+\*****************************************************************************/
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+#include <linux/interrupt.h>
+#include <linux/kthread.h>
+#include <sys/kmem.h>
+#include <sys/mulbuf_queue.h>
+
+int mbtp_queue_create(mbtp_queue_t ** queue_r, const char *name, mulbuf_thdpool_t * pool,
+		      int min_threadcnt, int max_threadcnt, threadp_func_t hash_mb_fn)
+{
+	int i;
+	mbtp_thread_t *tpt;
+	mbtp_queue_t *queue;
+
+	queue = kmem_alloc(sizeof(*queue), KM_PUSHPAGE);
+	*queue_r = queue;
+	if (queue == NULL)
+		return 1;
+
+	queue->queue_name = strdup(name);
+	queue->curr_threadcnt = 0;
+	queue->idle_threadcnt = 0;
+	queue->max_threadcnt = max_threadcnt;
+	queue->min_threadcnt = min_threadcnt;
+
+	queue->pool = pool;
+	queue->leave = 0;
+	queue->thread_fn = hash_mb_fn;
+
+	INIT_LIST_HEAD(&queue->plthread_list);
+	INIT_LIST_HEAD(&queue->task_list);
+
+	queue->curr_taskcnt = 0;
+	queue->proc_taskcnt = 0;
+	queue->total_taskcnt = 0;
+
+	init_waitqueue_head(&queue->queue_waitq);
+	spin_lock_init(&queue->queue_lock);
+
+	for (i = 0; i < queue->min_threadcnt; i++) {
+		/* get thread and attach it to list */
+		if (!mulbuf_thdpool_get_thread(queue->pool, &tpt)) {
+			list_add_tail(&tpt->queue_entry, &queue->plthread_list);
+			tpt->queue = queue;
+			mbtp_thread_run_fn(tpt, queue->thread_fn, (void *)tpt);
+			queue->curr_threadcnt++;
+			queue->idle_threadcnt++;
+		}
+	}
+
+	if (queue->curr_threadcnt == 0)
+		return 1;
+
+	return 0;
+}
+
+void mbtp_queue_destroy(mbtp_queue_t * queue)
+{
+	DECLARE_WAITQUEUE(queue_wait, current);
+	mbtp_thread_t *tpt;
+	mbtp_task_t *tj;
+	unsigned long flags;
+
+	struct list_head *l, *l_tmp;
+
+	spin_lock_irqsave(&queue->queue_lock, flags);
+	queue->leave = 1;
+
+	/* cancel unassigned taskjobs */
+	while (!list_empty(&queue->task_list)) {
+		tj = list_entry(queue->task_list.next, mbtp_task_t, queue_entry);
+		list_del(&tj->queue_entry);
+		/* tag this task as cancelled */
+		tj->processsed = 2;
+		tj->cb_fn(tj, tj->cb_arg);
+		queue->curr_taskcnt--;
+	}
+
+	/* validate thread state */
+	list_for_each(l, &queue->plthread_list) {
+		tpt = list_entry(l, mbtp_thread_t, queue_entry);
+		ASSERT(tpt->next_state == THREAD_RUNNING);
+	}
+
+	/* wake waiting threads to leave */
+	wake_up_all(&queue->queue_waitq);
+
+	spin_unlock_irqrestore(&queue->queue_lock, flags);
+
+	/*
+	 * Detach threads from queue
+	 * since threads will not operate queue elements, there is no need to lock queue
+	 */
+	list_for_each_safe(l, l_tmp, &queue->plthread_list) {
+
+		/* check and wait whether this tqt is left */
+		tpt = list_entry(l, mbtp_thread_t, queue_entry);
+
+		spin_lock_irqsave(&tpt->thd_lock, flags);
+
+		/* thread may be going ready or running */
+		if (tpt->next_state != THREAD_READY) {
+			add_wait_queue_exclusive(&tpt->thread_waitq, &queue_wait);
+
+			set_current_state(TASK_INTERRUPTIBLE);
+			spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+			schedule();
+
+			spin_lock_irqsave(&tpt->thd_lock, flags);
+			__set_current_state(TASK_RUNNING);
+			remove_wait_queue(&tpt->thread_waitq, &queue_wait);
+		}
+
+		spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+		mbtp_queue_shrink_thread(queue, tpt);
+	}
+
+	strfree(queue->queue_name);
+	kmem_free(queue, sizeof(*queue));
+
+	return;
+}
+
+/*
+ * Assign tasks to thread
+ *
+ * process_num process_num number of jobs thread is processing
+ * concurrent_num thread's concurrent capability of maximum jobs
+ * return how many tasks should be taken
+ */
+int mbtp_queue_assign_taskjobcnt(mbtp_queue_t * queue, int process_num, int concurrent_num)
+{
+	int idle_threadcnt = queue->idle_threadcnt;
+	int curr_taskjobcnt = queue->curr_taskcnt;
+	int take_num;
+
+	if (curr_taskjobcnt == 0) {
+		/* take 0 if no task */
+		take_num = 0;
+	} else if (curr_taskjobcnt + process_num >= idle_threadcnt - 1 + concurrent_num) {
+		/* take Concurrent_num if other idle thread can take at least one task job */
+		take_num = concurrent_num - process_num;
+	} else if (idle_threadcnt > 1) {
+		/* not the last thread, take 1 task */
+		take_num = 1;
+	} else {
+		/* the last one idle thread */
+		if (curr_taskjobcnt + process_num >= concurrent_num) {
+			take_num = concurrent_num - process_num;
+		} else {
+			take_num = curr_taskjobcnt;
+		}
+	}
+
+	return take_num;
+}
+
+/*
+ * Add thread into queue
+ * requires under lock of queue
+ * returns	0 add thread successfully; 1 failed to add
+ */
+int mbtp_queue_add_thread(mbtp_queue_t * queue)
+{
+	mbtp_thread_t *new_tpt;
+	unsigned long flags;
+
+	if (!mulbuf_thdpool_get_thread(queue->pool, &new_tpt)) {
+		/* add threadcnt before run thread */
+		spin_lock_irqsave(&queue->queue_lock, flags);
+		list_add_tail(&new_tpt->queue_entry, &queue->plthread_list);
+		new_tpt->queue = queue;
+		queue->curr_threadcnt++;
+		queue->idle_threadcnt++;
+		spin_unlock_irqrestore(&queue->queue_lock, flags);
+
+		mbtp_thread_run_fn(new_tpt, queue->thread_fn, (void *)new_tpt);
+
+		return 0;
+	}
+	return 1;
+}
+
+/*
+ * Shrink thread into queue
+ * Requires under lock of queue;
+ * Called by thread itself if thread is running hash_mb_fn
+ */
+void mbtp_queue_shrink_thread(mbtp_queue_t * queue, mbtp_thread_t * tpt)
+{
+	queue->curr_threadcnt--;
+	queue->idle_threadcnt--;
+
+	tpt->queue = NULL;
+	list_del(&tpt->queue_entry);
+	mulbuf_thdpool_put_thread(tpt);
+}
+
+/*
+ * Check and add thread if needed
+ *
+ * return 0 if need to add thread
+ * return 1 if no need
+ */
+int mbtp_queue_check_add_thread(mbtp_queue_t * queue, int concurrent_num)
+{
+	int curr_threadcnt = queue->curr_threadcnt;
+	int idle_threadcnt = queue->idle_threadcnt;
+	int max_threadcnt = queue->max_threadcnt;
+	int proc_taskjobcnt = queue->proc_taskcnt;
+
+	/*
+	 * add_by_proc is 1 if thread need to add from processing job's view
+	 * add_by_thread is 1 if adding is not limited by max_threadcnt
+	 */
+	int add_by_proc = 0, add_by_thread = 0;
+
+	if (curr_threadcnt < max_threadcnt && idle_threadcnt == 0) {
+		add_by_thread = 1;
+	}
+
+	if (proc_taskjobcnt == (curr_threadcnt - idle_threadcnt) * concurrent_num) {
+		add_by_proc = 1;
+	}
+
+	if (add_by_proc && add_by_thread) {
+		return 0;
+	}
+
+	return 1;
+}
+
+/*
+ * Check and shrink thread if needed
+ *
+ * return 0 if need to shrink thread
+ * return 1 if no need
+ */
+int mbtp_queue_check_shrink_thread(mbtp_queue_t * queue, int concurrent_num)
+{
+	int idle_threadcnt = queue->idle_threadcnt;
+	int proc_taskjobcnt = queue->proc_taskcnt;
+	int curr_threadcnt = queue->curr_threadcnt;
+	int min_threadcnt = queue->min_threadcnt;
+
+	/*
+	 * shrink_by_proc is 1 if thread need to shrink from processing job's view
+	 * shrink_by_thread is 1 if shrinking is not limited by min_threadcnt
+	 */
+	int shrink_by_proc = 0, shrink_by_thread = 0;
+
+	/* current threadcnt should be at least equal to min_threadcnt */
+	if (curr_threadcnt > min_threadcnt)
+		shrink_by_thread = 1;
+
+	/* at least, there is one thread doing snoop */
+	if (proc_taskjobcnt < (curr_threadcnt - idle_threadcnt) * concurrent_num)
+		shrink_by_proc = 1;
+
+	if (shrink_by_proc && shrink_by_thread) {
+		return 0;
+	}
+
+	return 1;
+}
+
+void mbtp_queue_submit_job(mbtp_task_t * mb_task, mbtp_queue_t * queue)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&queue->queue_lock, flags);
+
+	queue->curr_taskcnt++;
+	queue->total_taskcnt++;
+	list_add_tail(&mb_task->queue_entry, &queue->task_list);
+
+	/* signal queue to wake thread if before there is no other jobs in queue */
+	if (queue->curr_taskcnt == 1)
+		wake_up(&queue->queue_waitq);
+
+	spin_unlock_irqrestore(&queue->queue_lock, flags);
+
+	return;
+}
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */

--- a/module/spl/spl-mulbuf-suite-sha256.c
+++ b/module/spl/spl-mulbuf-suite-sha256.c
@@ -1,0 +1,201 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************
+ *  Solaris Porting Layer (SPL) Multi-Buffer Hash SHA256 Suite Implementation.
+\*****************************************************************************/
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+#include <sys/mulbuf_queue_sha256.h>
+
+/*
+ * Different queues for different hash length
+ * For ZFS sha256, 7 is a proper queue number for length: 16KB and below, 32KB
+ * 64KB, 128KB, 256KB, 512KB, 1MB and above.
+ */
+#define MULBUF_NQUEUE	7
+
+int spl_mulbuf_queues_max_threadcnt = -50;
+module_param(spl_mulbuf_queues_max_threadcnt, int, 0644);
+MODULE_PARM_DESC(spl_mulbuf_queues_max_threadcnt,
+		 "Maximum number of threads in each queue. (minus means percentage)");
+
+int spl_mulbuf_queues_min_threadcnt = -25;
+module_param(spl_mulbuf_queues_min_threadcnt, int, 0644);
+MODULE_PARM_DESC(spl_mulbuf_queues_min_threadcnt,
+		 "Maximum number of threads in each queue. (minus means percentage)");
+
+typedef struct mulbuf_sha256_suite {
+	mulbuf_thdpool_t *pool;
+	mbtp_queue_t **queues_array;
+	int queue_count;
+} mulbuf_sha256_suite_t;
+
+mulbuf_sha256_suite_t suite;
+
+static int threadcnt_analyze(int ncpu, int threadcnt_param)
+{
+	int threadcnt;
+
+	if (threadcnt_param < 0)
+		threadcnt = ncpu * (0 - threadcnt_param) / 100;
+	else
+		threadcnt = threadcnt_param;
+
+	if (threadcnt < 1)
+		threadcnt = 1;
+
+	if (threadcnt > ncpu)
+		threadcnt = ncpu;
+
+	return threadcnt;
+}
+
+int mulbuf_suite_sha256_init(void)
+{
+	int min_poolthreadcnt;
+	int max_poolthreadcnt;
+	int max_threadcnt;
+	int min_threadcnt;
+	int ncpu;
+	char namep[] = "spl-sha256mb-pool";
+	char nameq[] = "spl-sha256mb-queue";
+	int rc, i;
+
+	mulbuf_thdpool_t *pool;
+	int nqueue = MULBUF_NQUEUE;
+	mbtp_queue_t **queue_array;
+
+	ncpu = num_online_cpus();
+
+	min_threadcnt = threadcnt_analyze(ncpu, spl_mulbuf_queues_min_threadcnt);
+	max_threadcnt = threadcnt_analyze(ncpu, spl_mulbuf_queues_max_threadcnt);
+	min_poolthreadcnt = min_threadcnt * nqueue;
+	max_poolthreadcnt = min_poolthreadcnt + max_threadcnt - min_threadcnt;
+
+	queue_array = kmem_alloc(sizeof(mbtp_queue_t *) * nqueue, KM_PUSHPAGE);
+
+	rc = mulbuf_thdpool_create(&pool, namep, min_poolthreadcnt, max_poolthreadcnt);
+
+	for (i = 0; i < nqueue; i++) {
+		rc += mbtp_queue_create(&queue_array[i], nameq, pool,
+					min_threadcnt, max_threadcnt, mulbuf_sha256_fn);
+	}
+
+	suite.pool = pool;
+	suite.queue_count = nqueue;
+	suite.queues_array = queue_array;
+
+	if (rc > 0)
+		rc = 1;
+
+	return rc;
+}
+
+void mulbuf_suite_sha256_fini(void)
+{
+	int i;
+
+	mulbuf_thdpool_t *pool;
+	int nqueue;
+	mbtp_queue_t **queue_array;
+
+	pool = suite.pool;
+	nqueue = suite.queue_count;
+	queue_array = suite.queues_array;
+
+	for (i = 0; i < nqueue; i++) {
+		if (queue_array[i])
+			mbtp_queue_destroy(queue_array[i]);
+	}
+
+	kmem_free(queue_array, sizeof(mbtp_queue_t *) * nqueue);
+
+	if (pool)
+		mulbuf_thdpool_destroy(pool);
+
+	return;
+}
+
+static void mulbuf_sha256_cb(mbtp_task_t * mb_task, void *arg)
+{
+	struct completion *cmp = (struct completion *)arg;
+	complete(cmp);
+}
+
+int mulbuf_sha256_queue_choose(void *buffer, size_t size, unsigned char *digest,
+			       mbtp_queue_t * queue)
+{
+	mbtp_task_t task;
+
+	struct completion cmpt;
+	init_completion(&cmpt);
+
+	task.buffer = buffer;
+	task.size = size;
+	task.digest = digest;
+
+	task.cb_fn = mulbuf_sha256_cb;
+	task.cb_arg = &cmpt;
+	task.processsed = 0;
+
+	mbtp_queue_submit_job(&task, queue);
+
+	wait_for_completion(&cmpt);
+
+	if (task.processsed == 1) {
+		return 0;
+	} else {
+		return 1;
+	}
+}
+
+/*
+ * mulbuf_sha256 is the API exported out for ZFS to compute sha256 digest
+ */
+int mulbuf_sha256(void *buffer, size_t size, unsigned char *digest)
+{
+	int rc;
+	int index;
+	uint64_t mask;
+
+	/*
+	 * Find queue index for specific buffer size.
+	 * queues are set for lengths 16K ~ 1M. 16K is 0x1 << 14
+	 */
+	for (index = -1, mask = (0x1 << 14); size >= mask; mask <<= 1)
+		index++;
+
+	if (index == -1)
+		index = 0;
+	if (index >= MULBUF_NQUEUE)
+		index = MULBUF_NQUEUE - 1;
+
+	rc = mulbuf_sha256_queue_choose(buffer, size, digest, suite.queues_array[index]);
+
+	return rc;
+}
+
+EXPORT_SYMBOL(mulbuf_sha256);
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */

--- a/module/spl/spl-mulbuf-thdpool.c
+++ b/module/spl/spl-mulbuf-thdpool.c
@@ -1,0 +1,359 @@
+/*****************************************************************************\
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2007 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
+ *  UCRL-CODE-235197
+ *
+ *  This file is part of the SPL, Solaris Porting Layer.
+ *  For details, see <http://zfsonlinux.org/>.
+ *
+ *  The SPL is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation; either version 2 of the License, or (at your
+ *  option) any later version.
+ *
+ *  The SPL is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************
+ *  Solaris Porting Layer (SPL) Multi-Buffer Hash Thread Pool Implementation.
+\*****************************************************************************/
+
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+
+#include <linux/interrupt.h>
+#include <linux/kthread.h>
+#include <sys/kmem.h>
+#include <sys/mulbuf_thdpool.h>
+
+static int mbtp_thread_routine(void *args)
+{
+	DECLARE_WAITQUEUE(wait, current);
+
+	mbtp_thread_t *tpt = (mbtp_thread_t *) args;
+	sigset_t blocked;
+	unsigned long flags;
+
+	current->flags |= PF_NOFREEZE;
+
+	sigfillset(&blocked);
+	sigprocmask(SIG_BLOCK, &blocked, NULL);
+	flush_signals(current);
+
+	spin_lock_irqsave(&tpt->thd_lock, flags);
+	tpt->next_state = THREAD_SETUP;
+
+	while (!kthread_should_stop()) {
+		tpt->curr_state = tpt->next_state;
+
+		switch (tpt->next_state) {
+		case THREAD_SETUP:
+			tpt->next_state = THREAD_READY;
+
+			/* Inform thread pool, thead is going to be ready */
+			wake_up(&tpt->thread_waitq);
+			break;
+
+		case THREAD_READY:
+			/* tqt->next_state is determined by queue or pool during wait */
+			add_wait_queue_exclusive(&tpt->thread_waitq, &wait);
+			set_current_state(TASK_INTERRUPTIBLE);
+			spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+			schedule();
+
+			spin_lock_irqsave(&tpt->thd_lock, flags);
+			__set_current_state(TASK_RUNNING);
+			remove_wait_queue(&tpt->thread_waitq, &wait);
+
+			break;
+
+		case THREAD_RUNNING:
+			/* hash mb will change it after its end */
+			tpt->next_state = THREAD_RUNNING;
+			spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+			tpt->fn(tpt->arg);
+
+			spin_lock_irqsave(&tpt->thd_lock, flags);
+			break;
+
+		case THREAD_EXIT:
+		default:
+			/* Exit notice to destroy function */
+			wake_up(&tpt->thread_waitq);
+			spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+			return 0;
+		}
+	}
+
+	/* Exit notice to destroy function */
+	tpt->curr_state = THREAD_EXIT;
+	wake_up(&tpt->thread_waitq);
+	spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+	return 0;
+
+}
+
+static int mbtp_thread_create(mbtp_thread_t ** tpt_r, mulbuf_thdpool_t * pool)
+{
+	mbtp_thread_t *tpt;
+
+	tpt = kmem_alloc(sizeof(*tpt), KM_PUSHPAGE | KM_ZERO);
+	*tpt_r = tpt;
+
+	if (!tpt)
+		return 1;
+
+	tpt->fn = NULL;
+	tpt->curr_state = THREAD_SETUP;
+	tpt->queue = NULL;
+	tpt->pool = pool;
+
+	/* tpt facilities initialize */
+	spin_lock_init(&tpt->thd_lock);
+	init_waitqueue_head(&tpt->thread_waitq);
+
+	tpt->tp_thread = spl_kthread_create(mbtp_thread_routine, tpt, "%s", pool->pool_name);
+	if (tpt->tp_thread == NULL) {
+		kmem_free(tpt, sizeof(mbtp_thread_t));
+		*tpt_r = NULL;
+		return 1;
+	}
+
+	wake_up_process(tpt->tp_thread);
+
+	return 0;
+}
+
+static void mbtp_thread_destroy(mbtp_thread_t * tpt)
+{
+	DECLARE_WAITQUEUE(wait, current);
+	unsigned long flags;
+
+	/* wait for thread's exit */
+	spin_lock_irqsave(&tpt->thd_lock, flags);
+	if (tpt->curr_state != THREAD_EXIT) {
+		add_wait_queue_exclusive(&tpt->thread_waitq, &wait);
+		set_current_state(TASK_INTERRUPTIBLE);
+		spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+		schedule();
+
+		spin_lock_irqsave(&tpt->thd_lock, flags);
+		__set_current_state(TASK_RUNNING);
+		remove_wait_queue(&tpt->thread_waitq, &wait);
+	}
+	spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+	kmem_free(tpt, sizeof(*tpt));
+
+	return;
+}
+
+int mulbuf_thdpool_create(mulbuf_thdpool_t ** pool_r, const char *name, int threadcnt,
+			  int max_threadcnt)
+{
+	DECLARE_WAITQUEUE(pool_wait, current);
+	unsigned long flags;
+	int i;
+	mbtp_thread_t *tpt;
+	mulbuf_thdpool_t *pool;
+
+	pool = kmem_alloc(sizeof(*pool), KM_PUSHPAGE);
+	*pool_r = pool;
+
+	/* element initialize */
+	pool->pool_name = strdup(name);
+	pool->curr_threadcnt = threadcnt;
+	pool->idle_threadcnt = 0;
+	pool->max_threadcnt = max_threadcnt;
+
+	/* pool facilities initialize */
+	init_waitqueue_head(&pool->pool_waitq);
+	spin_lock_init(&pool->pool_lock);
+
+	INIT_LIST_HEAD(&pool->plthread_idle_list);
+	INIT_LIST_HEAD(&pool->plthread_busy_list);
+
+	/* threads create and run */
+	for (i = 0; i < pool->curr_threadcnt; i++) {
+		if (mbtp_thread_create(&tpt, pool))
+			continue;	/* if failed, continue to generate next one */
+
+		/* wait for thread's ready */
+		spin_lock_irqsave(&tpt->thd_lock, flags);
+		if (tpt->curr_state == THREAD_SETUP) {
+			add_wait_queue_exclusive(&tpt->thread_waitq, &pool_wait);
+			set_current_state(TASK_INTERRUPTIBLE);
+			spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+			schedule();
+
+			spin_lock_irqsave(&tpt->thd_lock, flags);
+			__set_current_state(TASK_RUNNING);
+			remove_wait_queue(&tpt->thread_waitq, &pool_wait);
+		}
+		spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+		/* new thread is attached to idle list */
+		list_add_tail(&tpt->pool_entry, &pool->plthread_idle_list);
+		pool->idle_threadcnt++;
+	}
+
+	/* adjust based on thread creation */
+	pool->curr_threadcnt = pool->idle_threadcnt;
+	if (pool->curr_threadcnt == 0) {
+		kmem_free(pool, sizeof(*pool));
+		*pool_r = NULL;
+		return 1;
+
+	}
+	return 0;
+}
+
+void mulbuf_thdpool_destroy(mulbuf_thdpool_t * pool)
+{
+	mbtp_thread_t *tpt;
+	unsigned long flags;
+
+	/* if not empty, there is error */
+	ASSERT(list_empty(&pool->plthread_busy_list));
+
+	/* notify threads to leave */
+	while (!list_empty(&pool->plthread_idle_list)) {
+		tpt = list_entry(pool->plthread_idle_list.next, mbtp_thread_t, pool_entry);
+		list_del(&tpt->pool_entry);
+		/* check and wait whether this tpt is left */
+		spin_lock_irqsave(&tpt->thd_lock, flags);
+		if (tpt->next_state != THREAD_EXIT) {
+			tpt->next_state = THREAD_EXIT;
+			wake_up(&tpt->thread_waitq);
+		}
+		spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+		mbtp_thread_destroy(tpt);
+		pool->curr_threadcnt--;
+		pool->idle_threadcnt--;
+	}
+
+	/* free pool */
+	strfree(pool->pool_name);
+	kmem_free(pool, sizeof(pool));
+
+	return;
+}
+
+/*
+ * Get a valid thread from pool; return 0 if success
+ */
+int mulbuf_thdpool_get_thread(mulbuf_thdpool_t * pool, mbtp_thread_t ** tpt_r)
+{
+	DECLARE_WAITQUEUE(pool_wait, current);
+	mbtp_thread_t *tpt;
+	unsigned long flags;
+
+	spin_lock_irqsave(&pool->pool_lock, flags);
+	/* check whether need to add a thread */
+	if (pool->idle_threadcnt == 0) {
+
+		/* there is no idle thread */
+		if (pool->curr_threadcnt < pool->max_threadcnt) {
+			spin_unlock_irqrestore(&pool->pool_lock, flags);
+
+			/* create one new thread */
+			if (!mbtp_thread_create(&tpt, pool)) {
+				/* wait for thread's ready */
+				spin_lock_irqsave(&tpt->thd_lock, flags);
+				if (tpt->curr_state == THREAD_SETUP) {
+					add_wait_queue_exclusive(&tpt->thread_waitq,
+								 &pool_wait);
+					set_current_state(TASK_INTERRUPTIBLE);
+					spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+					schedule();
+
+					spin_lock_irqsave(&tpt->thd_lock, flags);
+					__set_current_state(TASK_RUNNING);
+					remove_wait_queue(&tpt->thread_waitq, &pool_wait);
+				}
+				spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+				spin_lock_irqsave(&pool->pool_lock, flags);
+
+				list_add_tail(&tpt->pool_entry, &pool->plthread_idle_list);
+				pool->idle_threadcnt++;
+				pool->curr_threadcnt++;
+				spin_unlock_irqrestore(&pool->pool_lock, flags);
+			}
+
+			spin_lock_irqsave(&pool->pool_lock, flags);
+		}
+	}
+
+	/* there is at least one idle thread */
+	if (pool->idle_threadcnt > 0) {
+		pool->idle_threadcnt--;
+
+		tpt = list_entry(pool->plthread_idle_list.next, mbtp_thread_t, pool_entry);
+		list_del(&tpt->pool_entry);
+		list_add_tail(&tpt->pool_entry, &pool->plthread_busy_list);
+		spin_unlock_irqrestore(&pool->pool_lock, flags);
+
+		*tpt_r = tpt;
+		return 0;
+	} else {
+		/* there no idle thread */
+		spin_unlock_irqrestore(&pool->pool_lock, flags);
+
+		*tpt_r = NULL;
+		return 1;
+	}
+
+}
+
+/*
+ * Return a valid thread to its pool
+ */
+void mulbuf_thdpool_put_thread(mbtp_thread_t * tpt)
+{
+	mulbuf_thdpool_t *pool = tpt->pool;
+	unsigned long flags;
+
+	spin_lock_irqsave(&pool->pool_lock, flags);
+	pool->idle_threadcnt++;
+	list_del(&tpt->pool_entry);
+	list_add_tail(&tpt->pool_entry, &pool->plthread_idle_list);
+	spin_unlock_irqrestore(&pool->pool_lock, flags);
+
+	return;
+}
+
+/*
+ * Get a valid thread from pool
+ */
+void mbtp_thread_run_fn(mbtp_thread_t * tpt, threadp_func_t fn, void *arg)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&tpt->thd_lock, flags);
+
+	tpt->fn = fn;
+	tpt->arg = arg;
+	tpt->next_state = THREAD_RUNNING;
+	/* trigger tpt to run fn */
+	wake_up(&tpt->thread_waitq);
+
+	spin_unlock_irqrestore(&tpt->thd_lock, flags);
+
+	return;
+}
+
+#endif /* __KERNEL__ && __x86_64 && HAVE_HASH_MB */

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -1025,10 +1025,18 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 
 	/* Scale the number of threads using nthreads as a percentage */
 	if (flags & TASKQ_THREADS_CPU_PCT) {
+#if defined(__x86_64) && defined(__KERNEL__) && defined(HAVE_HASH_MB)
+		/* Eightfold threads maximum percentage of cpu */
+		ASSERT(nthreads <= 100 * 8);
+		ASSERT(nthreads >= 0);
+		nthreads = MIN(nthreads, 100 * 8);
+		nthreads = MAX(nthreads, 0);
+#else
 		ASSERT(nthreads <= 100);
 		ASSERT(nthreads >= 0);
 		nthreads = MIN(nthreads, 100);
 		nthreads = MAX(nthreads, 0);
+#endif
 		nthreads = MAX((num_online_cpus() * nthreads) / 100, 1);
 	}
 


### PR DESCRIPTION
This patch implements multi-buffer hash facilities to export a general
SHA256 api to ZFS. When multibuffer hash is configured in SPL, its
SHA256 api for ZFS will automaticlly transfer SHA256 compute task to
multi-buffer hash facilities which will increase SHA256 performance
2~7 times.

ISA-L multi-buffer hash provides software acceleration for SHA256:
https://github.com/01org/isa-l_crypto
* To enable multi-buffer hash acceleration, you need to download ISA-L
crypto lib source code from above link and checkout master branch.
* Configure multi-buffer hash in SPL, e.g.:
 ./configure --with-hash-mb=<isa-l-crypto-code-path>
 make
  Following make notice, run:
 make -C <isa-l-crypto-code-path> -f Makefile.kern kernobj
 Then, continue run:
 make
* After that, a C predefine marco HAVE_HASH_MB and C api mulbuf_sha256
will be exported out to ZFS module

If ZFS is also patched with multi-buffer sha256, then.
Set sha256 checksum in ZFS dataset: "checksum = sha256"
Data written to ZFS pool will be checksumed by multi-buffer sha256.
Run write workload, on Intel Xeon of Haswell type, cpu consumption of
sha256 will be decreased to be previous 1/2~1/5.

Multibuffer sha256 follows standard sha256 format. With SIMD instruction
set, it can process 4/8/16 sha256 tasks simutaneously. So it has a much
better compute throughput.
Here are Isa-L's performance data sheets about multi-buffer hash.

Intel®   Xeon® E5-2600v3 (Haswell) |   |  
-- | -- | --
Hash functions | ISA-L multi-buffer version | OpenSSL single version
SHA-1 | 1.9 GB/s | 542 MB/s
SHA-256 | 881 MB/s | 183 MB/s
SHA-512 | 689 MB/s | 286 MB/s
MD5 | 3.7 GB/s | 465 MB/s




Intel® Xeon® Platinum 8180 (Skylake) |   |  
-- | -- | --
Hash functions | ISA-L multi-buffer version | OpenSSL single version
SHA-1 | 5.4 GB/s | 605 MB/s |  
SHA-256 | 2.7 GB/s | 216 MB/s |  
SHA-512 | 2.2 GB/s | 334 MB/s |  
MD5 | 9.7 GB/s | 401 MB/s |  

