### PR TITLE
Fix build on kernel 4.13 onwards

### DIFF
--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -402,11 +402,11 @@ static struct ctl_table spl_kmem_table[] = {
                 .mode     = 0444,
                 .proc_handler = &proc_doslab,
         },
-	{0},
+	{},
 };
 
 static struct ctl_table spl_kstat_table[] = {
-	{0},
+	{},
 };
 
 static struct ctl_table spl_table[] = {
@@ -437,7 +437,7 @@ static struct ctl_table spl_table[] = {
 		.mode     = 0555,
 		.child    = spl_kstat_table,
 	},
-        { 0 },
+        {},
 };
 
 static struct ctl_table spl_dir[] = {
@@ -446,7 +446,7 @@ static struct ctl_table spl_dir[] = {
                 .mode     = 0555,
                 .child    = spl_table,
         },
-        { 0 }
+        {}
 };
 
 static struct ctl_table spl_root[] = {
@@ -458,7 +458,7 @@ static struct ctl_table spl_root[] = {
 	.mode = 0555,
 	.child = spl_dir,
 	},
-	{ 0 }
+	{}
 };
 
 int


### PR DESCRIPTION
Build fails on kernels 4.13 onwards, which enable struct randomisation (https://github.com/torvalds/linux/commit/3859a271a003aba01e45b85c9d8b355eb7bf25f9) invalidating positional struct accesses

The spl-proc.c file has a couple of positional struct accesses, removed in v0.7. This PR cherry-picks commit 120faefed90aa4c276a3db45525dc5c804cb1a00 into the spl-0.6.5-release branch to remove them here too and fix the build :)