### PR TITLE
Make SPL code conform to ZFS style

### DIFF
--- a/cmd/splat/splat.c
+++ b/cmd/splat/splat.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) User Space Interface.
-\*****************************************************************************/
+ */
 
 #include <stdlib.h>
 #include <stddef.h>

--- a/cmd/splat/splat.h
+++ b/cmd/splat/splat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPLAT_H
 #define _SPLAT_H

--- a/include/fs/fs_subr.h
+++ b/include/fs/fs_subr.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_FS_FS_SUBR_H
 #define _SPL_FS_FS_SUBR_H

--- a/include/linux/bitops_compat.h
+++ b/include/linux/bitops_compat.h
@@ -23,9 +23,8 @@
  */
 
 #ifndef _SPL_BITOPS_COMPAT_H
-#define _SPL_BITOPS_COMPAT_H
+#define	_SPL_BITOPS_COMPAT_H
 
 #include <linux/bitops.h>
 
 #endif /* _SPL_BITOPS_COMPAT_H */
-

--- a/include/linux/bitops_compat.h
+++ b/include/linux/bitops_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_BITOPS_COMPAT_H
 #define _SPL_BITOPS_COMPAT_H

--- a/include/linux/compiler_compat.h
+++ b/include/linux/compiler_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_COMPILER_COMPAT_H
 #define _SPL_COMPILER_COMPAT_H

--- a/include/linux/compiler_compat.h
+++ b/include/linux/compiler_compat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_COMPILER_COMPAT_H
-#define _SPL_COMPILER_COMPAT_H
+#define	_SPL_COMPILER_COMPAT_H
 
 #include <linux/compiler.h>
 
@@ -41,7 +41,7 @@
  * handlers, all running on the same CPU.
  */
 /* Taken from 2.6.33.2 */
-# define ACCESS_ONCE(x) (*(volatile typeof(x) *)&(x))
+#define	ACCESS_ONCE(x) (*(volatile typeof(x) *)&(x))
 #endif
 
 #endif /* _SPL_COMPILER_COMPAT_H */

--- a/include/linux/delay_compat.h
+++ b/include/linux/delay_compat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_DELAY_COMPAT_H
-#define _SPL_DELAY_COMPAT_H
+#define	_SPL_DELAY_COMPAT_H
 
 #include <linux/delay.h>
 #include <linux/time.h>

--- a/include/linux/delay_compat.h
+++ b/include/linux/delay_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2013 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DELAY_COMPAT_H
 #define _SPL_DELAY_COMPAT_H

--- a/include/linux/file_compat.h
+++ b/include/linux/file_compat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_FILE_COMPAT_H
-#define _SPL_FILE_COMPAT_H
+#define	_SPL_FILE_COMPAT_H
 
 #include <linux/fs.h>
 #ifdef HAVE_FDTABLE_HEADER
@@ -33,22 +33,22 @@
 static inline struct file *
 spl_filp_open(const char *name, int flags, int mode, int *err)
 {
-        struct file *filp = NULL;
-        int rc;
+	struct file *filp = NULL;
+	int rc;
 
-        filp = filp_open(name, flags, mode);
-        if (IS_ERR(filp)) {
-                rc = PTR_ERR(filp);
-                if (err)
-                        *err = rc;
-                filp = NULL;
-        }
-        return filp;
+	filp = filp_open(name, flags, mode);
+	if (IS_ERR(filp)) {
+		rc = PTR_ERR(filp);
+		if (err)
+			*err = rc;
+		filp = NULL;
+	}
+	return (filp);
 }
 
-#define spl_filp_close(f)		filp_close(f, NULL)
-#define spl_filp_poff(f)		(&(f)->f_pos)
-#define spl_filp_write(fp, b, s, p)	(fp)->f_op->write((fp), (b), (s), p)
+#define	spl_filp_close(f)		filp_close(f, NULL)
+#define	spl_filp_poff(f)		(&(f)->f_pos)
+#define	spl_filp_write(fp, b, s, p)	(fp)->f_op->write((fp), (b), (s), p)
 
 static inline int
 spl_filp_fallocate(struct file *fp, int mode, loff_t offset, loff_t len)
@@ -65,7 +65,7 @@ spl_filp_fallocate(struct file *fp, int mode, loff_t offset, loff_t len)
 		error = fp->f_dentry->d_inode->i_op->fallocate(
 		    fp->f_dentry->d_inode, mode, offset, len);
 #endif /* HAVE_INODE_FALLOCATE */
-#endif /*HAVE_FILE_FALLOCATE */
+#endif /* HAVE_FILE_FALLOCATE */
 
 	return (error);
 }
@@ -97,4 +97,3 @@ spl_filp_fallocate(struct file *fp, int mode, loff_t offset, loff_t len)
 #endif
 
 #endif /* SPL_FILE_COMPAT_H */
-

--- a/include/linux/file_compat.h
+++ b/include/linux/file_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_FILE_COMPAT_H
 #define _SPL_FILE_COMPAT_H

--- a/include/linux/list_compat.h
+++ b/include/linux/list_compat.h
@@ -23,29 +23,28 @@
  */
 
 #ifndef _SPL_LIST_COMPAT_H
-#define _SPL_LIST_COMPAT_H
+#define	_SPL_LIST_COMPAT_H
 
 #include <linux/list.h>
 
 #ifndef list_for_each_entry_safe_reverse
 
-/**
+/*
  * list_for_each_entry_safe_reverse
- * @pos:        the type * to use as a loop cursor.
- * @n:          another type * to use as temporary storage
- * @head:       the head for your list.
- * @member:     the name of the list_struct within the struct.
+ * @pos:	the type * to use as a loop cursor.
+ * @n:		another type * to use as temporary storage
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
  *
  * Iterate backwards over list of given type, safe against removal
  * of list entry.
  */
-#define list_for_each_entry_safe_reverse(pos, n, head, member)          \
-        for (pos = list_entry((head)->prev, typeof(*pos), member),      \
-                n = list_entry(pos->member.prev, typeof(*pos), member); \
-             &pos->member != (head);                                    \
-             pos = n, n = list_entry(n->member.prev, typeof(*n), member))
+#define	list_for_each_entry_safe_reverse(pos, n, head, member)		\
+	for (pos = list_entry((head)->prev, typeof(*pos), member),	\
+	    n = list_entry(pos->member.prev, typeof(*pos), member); 	\
+	    &pos->member != (head);					\
+	    pos = n, n = list_entry(n->member.prev, typeof(*n), member))
 
 #endif /* list_for_each_entry_safe_reverse */
 
 #endif /* SPL_LIST_COMPAT_H */
-

--- a/include/linux/list_compat.h
+++ b/include/linux/list_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_LIST_COMPAT_H
 #define _SPL_LIST_COMPAT_H

--- a/include/linux/math64_compat.h
+++ b/include/linux/math64_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_MATH64_COMPAT_H
 #define _SPL_MATH64_COMPAT_H

--- a/include/linux/math64_compat.h
+++ b/include/linux/math64_compat.h
@@ -23,10 +23,10 @@
  */
 
 #ifndef _SPL_MATH64_COMPAT_H
-#define _SPL_MATH64_COMPAT_H
+#define	_SPL_MATH64_COMPAT_H
 
 #ifndef abs64
-#define abs64(x)	({ uint64_t t = (x) >> 63; ((x) ^ t) - t; })
+#define	abs64(x)	({ uint64_t t = (x) >> 63; ((x) ^ t) - t; })
 #endif
 
 #endif /* _SPL_MATH64_COMPAT_H */

--- a/include/linux/mm_compat.h
+++ b/include/linux/mm_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_MM_COMPAT_H
 #define _SPL_MM_COMPAT_H

--- a/include/linux/mm_compat.h
+++ b/include/linux/mm_compat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_MM_COMPAT_H
-#define _SPL_MM_COMPAT_H
+#define	_SPL_MM_COMPAT_H
 
 #include <linux/mm.h>
 #include <linux/fs.h>

--- a/include/linux/proc_compat.h
+++ b/include/linux/proc_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_PROC_COMPAT_H
 #define _SPL_PROC_COMPAT_H

--- a/include/linux/proc_compat.h
+++ b/include/linux/proc_compat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_PROC_COMPAT_H
-#define _SPL_PROC_COMPAT_H
+#define	_SPL_PROC_COMPAT_H
 
 #include <linux/proc_fs.h>
 

--- a/include/linux/rwsem_compat.h
+++ b/include/linux/rwsem_compat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_RWSEM_COMPAT_H
-#define _SPL_RWSEM_COMPAT_H
+#define	_SPL_RWSEM_COMPAT_H
 
 #include <linux/rwsem.h>
 
@@ -53,15 +53,16 @@
 int rwsem_tryupgrade(struct rw_semaphore *rwsem);
 
 #if defined(RWSEM_SPINLOCK_IS_RAW)
-#define spl_rwsem_lock_irqsave(lk, fl)       raw_spin_lock_irqsave(lk, fl)
-#define spl_rwsem_unlock_irqrestore(lk, fl)  raw_spin_unlock_irqrestore(lk, fl)
-#define spl_rwsem_trylock_irqsave(lk, fl)    raw_spin_trylock_irqsave(lk, fl)
+#define	spl_rwsem_lock_irqsave(lk, fl)		raw_spin_lock_irqsave(lk, fl)
+#define	spl_rwsem_unlock_irqrestore(lk, fl)	\
+    raw_spin_unlock_irqrestore(lk, fl)
+#define	spl_rwsem_trylock_irqsave(lk, fl)	raw_spin_trylock_irqsave(lk, fl)
 #else
-#define spl_rwsem_lock_irqsave(lk, fl)       spin_lock_irqsave(lk, fl)
-#define spl_rwsem_unlock_irqrestore(lk, fl)  spin_unlock_irqrestore(lk, fl)
-#define spl_rwsem_trylock_irqsave(lk, fl)    spin_trylock_irqsave(lk, fl)
+#define	spl_rwsem_lock_irqsave(lk, fl)		spin_lock_irqsave(lk, fl)
+#define	spl_rwsem_unlock_irqrestore(lk, fl)	spin_unlock_irqrestore(lk, fl)
+#define	spl_rwsem_trylock_irqsave(lk, fl)	spin_trylock_irqsave(lk, fl)
 #endif /* RWSEM_SPINLOCK_IS_RAW */
 
-#define spl_rwsem_is_locked(rwsem)           rwsem_is_locked(rwsem)
+#define	spl_rwsem_is_locked(rwsem)		rwsem_is_locked(rwsem)
 
 #endif /* _SPL_RWSEM_COMPAT_H */

--- a/include/linux/rwsem_compat.h
+++ b/include/linux/rwsem_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_RWSEM_COMPAT_H
 #define _SPL_RWSEM_COMPAT_H

--- a/include/linux/wait_compat.h
+++ b/include/linux/wait_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2014 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_WAIT_COMPAT_H
 #define _SPL_WAIT_COMPAT_H

--- a/include/linux/wait_compat.h
+++ b/include/linux/wait_compat.h
@@ -23,23 +23,23 @@
  */
 
 #ifndef _SPL_WAIT_COMPAT_H
-#define _SPL_WAIT_COMPAT_H
+#define	_SPL_WAIT_COMPAT_H
 
 #include <linux/sched.h>
 #include <linux/wait.h>
 
 #ifndef HAVE_WAIT_ON_BIT_ACTION
-#  define spl_wait_on_bit(word, bit, mode) wait_on_bit(word, bit, mode)
+#define	spl_wait_on_bit(word, bit, mode)	wait_on_bit(word, bit, mode)
 #else
 
 static inline int
 spl_bit_wait(void *word)
 {
-        schedule();
-        return 0;
+	schedule();
+	return (0);
 }
 
-#define spl_wait_on_bit(word, bit, mode)			\
+#define	spl_wait_on_bit(word, bit, mode)		\
 	wait_on_bit(word, bit, spl_bit_wait, mode)
 
 #endif /* HAVE_WAIT_ON_BIT_ACTION */

--- a/include/linux/zlib_compat.h
+++ b/include/linux/zlib_compat.h
@@ -22,15 +22,15 @@
  */
 
 #ifndef _SPL_ZLIB_COMPAT_H
-#define _SPL_ZLIB_COMPAT_H
+#define	_SPL_ZLIB_COMPAT_H
 
 #include <linux/zlib.h>
 
 #ifdef HAVE_2ARGS_ZLIB_DEFLATE_WORKSPACESIZE
-#define spl_zlib_deflate_workspacesize(wb, ml) \
+#define	spl_zlib_deflate_workspacesize(wb, ml) \
 	zlib_deflate_workspacesize(wb, ml)
 #else
-#define spl_zlib_deflate_workspacesize(wb, ml) \
+#define	spl_zlib_deflate_workspacesize(wb, ml) \
 	zlib_deflate_workspacesize()
 #endif /* HAVE_2ARGS_ZLIB_DEFLATE_WORKSPACESIZE */
 

--- a/include/linux/zlib_compat.h
+++ b/include/linux/zlib_compat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2011 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
@@ -19,7 +19,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ZLIB_COMPAT_H
 #define _SPL_ZLIB_COMPAT_H

--- a/include/rpc/types.h
+++ b/include/rpc/types.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_RPC_TYPES_H
 #define _SPL_RPC_TYPES_H

--- a/include/rpc/xdr.h
+++ b/include/rpc/xdr.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (c) 2008 Sun Microsystems, Inc.
  *  Written by Ricardo Correia <Ricardo.M.Correia@Sun.COM>
  *
@@ -17,7 +17,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_RPC_XDR_H
 #define _SPL_RPC_XDR_H

--- a/include/sharefs/share.h
+++ b/include/sharefs/share.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SHARE_H
 #define _SPL_SHARE_H

--- a/include/spl-ctl.h
+++ b/include/spl-ctl.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _DEBUG_CTL_H
 #define _DEBUG_CTL_H

--- a/include/splat-ctl.h
+++ b/include/splat-ctl.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPLAT_CTL_H
 #define _SPLAT_CTL_H

--- a/include/strings.h
+++ b/include/strings.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_STRINGS_H
 #define _SPL_STRINGS_H

--- a/include/sys/acl.h
+++ b/include/sys/acl.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ACL_H
 #define _SPL_ACL_H

--- a/include/sys/acl_impl.h
+++ b/include/sys/acl_impl.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ACL_IMPL_H
 #define _SPL_ACL_IMPL_H

--- a/include/sys/atomic.h
+++ b/include/sys/atomic.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ATOMIC_H
 #define _SPL_ATOMIC_H

--- a/include/sys/attr.h
+++ b/include/sys/attr.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ATTR_H
 #define _SPL_ATTR_H

--- a/include/sys/bitmap.h
+++ b/include/sys/bitmap.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_BITMAP_H
 #define _SPL_BITMAP_H

--- a/include/sys/bootconf.h
+++ b/include/sys/bootconf.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_BOOTCONF_H
 #define _SPL_BOOTCONF_H

--- a/include/sys/bootprops.h
+++ b/include/sys/bootprops.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_BOOTPROPS_H
 #define _SPL_BOOTPROPS_H

--- a/include/sys/buf.h
+++ b/include/sys/buf.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_BUF_H
 #define _SPL_BUF_H

--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_BYTEORDER_H
 #define _SPL_BYTEORDER_H

--- a/include/sys/callb.h
+++ b/include/sys/callb.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CALLB_H
 #define _SPL_CALLB_H

--- a/include/sys/callo.h
+++ b/include/sys/callo.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2013 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
@@ -19,7 +19,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CALLO_H
 #define _SPL_CALLO_H

--- a/include/sys/cmn_err.h
+++ b/include/sys/cmn_err.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CMN_ERR_H
 #define _SPL_CMN_ERR_H

--- a/include/sys/compress.h
+++ b/include/sys/compress.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_COMPRESS_H
 #define _SPL_COMPRESS_H

--- a/include/sys/conf.h
+++ b/include/sys/conf.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CONF_H
 #define _SPL_CONF_H

--- a/include/sys/console.h
+++ b/include/sys/console.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_CONSOLE_H
 #define	_SPL_CONSOLE_H

--- a/include/sys/cpupart.h
+++ b/include/sys/cpupart.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CPUPART_H
 #define _SPL_CPUPART_H

--- a/include/sys/cpuvar.h
+++ b/include/sys/cpuvar.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CPUVAR_H
 #define _SPL_CPUVAR_H

--- a/include/sys/crc32.h
+++ b/include/sys/crc32.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CRC32_H
 #define _SPL_CRC32_H

--- a/include/sys/cred.h
+++ b/include/sys/cred.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CRED_H
 #define _SPL_CRED_H

--- a/include/sys/ctype.h
+++ b/include/sys/ctype.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_CTYPE_H
 #define _SPL_CTYPE_H

--- a/include/sys/ddi.h
+++ b/include/sys/ddi.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DDI_H
 #define _SPL_DDI_H

--- a/include/sys/debug.h
+++ b/include/sys/debug.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 /*
  * Available Solaris debug functions.  All of the ASSERT() macros will be

--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DIRENT_H
 #define _SPL_DIRENT_H

--- a/include/sys/disp.h
+++ b/include/sys/disp.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DISP_H
 #define _SPL_DISP_H

--- a/include/sys/dkio.h
+++ b/include/sys/dkio.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DKIO_H
 #define	_SPL_DKIO_H

--- a/include/sys/dkioc_free_util.h
+++ b/include/sys/dkioc_free_util.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DKIOC_UTIL_H
 #define	_SPL_DKIOC_UTIL_H

--- a/include/sys/dklabel.h
+++ b/include/sys/dklabel.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DKLABEL_H
 #define	_SPL_DKLABEL_H

--- a/include/sys/dnlc.h
+++ b/include/sys/dnlc.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DNLC_H
 #define _SPL_DNLC_H

--- a/include/sys/dumphdr.h
+++ b/include/sys/dumphdr.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_DUMPHDR_H
 #define _SPL_DUMPHDR_H

--- a/include/sys/efi_partition.h
+++ b/include/sys/efi_partition.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_EFI_PARTITION_H
 #define _SPL_EFI_PARTITION_H

--- a/include/sys/errno.h
+++ b/include/sys/errno.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ERRNO_H
 #define _SPL_ERRNO_H

--- a/include/sys/extdirent.h
+++ b/include/sys/extdirent.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
@@ -19,7 +19,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_EXTDIRENT_H
 #define	_SPL_EXTDIRENT_H

--- a/include/sys/fcntl.h
+++ b/include/sys/fcntl.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
@@ -19,7 +19,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_FCNTL_H
 #define _SPL_FCNTL_H

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_FILE_H
 #define _SPL_FILE_H

--- a/include/sys/fm/protocol.h
+++ b/include/sys/fm/protocol.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_FM_PROTOCOL_H
 #define	_SPL_FM_PROTOCOL_H

--- a/include/sys/fm/util.h
+++ b/include/sys/fm/util.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_FM_UTIL_H
 #define	_SPL_FM_UTIL_H

--- a/include/sys/fs/swapnode.h
+++ b/include/sys/fs/swapnode.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SWAPNODE_H
 #define _SPL_SWAPNODE_H

--- a/include/sys/idmap.h
+++ b/include/sys/idmap.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
@@ -19,7 +19,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_IDMAP_H
 #define _SPL_IDMAP_H

--- a/include/sys/int_limits.h
+++ b/include/sys/int_limits.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_INT_LIMITS_H
 #define _SPL_INT_LIMITS_H

--- a/include/sys/int_types.h
+++ b/include/sys/int_types.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_INT_TYPES_H
 #define _SPL_INT_TYPES_H

--- a/include/sys/inttypes.h
+++ b/include/sys/inttypes.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_INTTYPES_H
 #define _SPL_INTTYPES_H

--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_ISA_DEFS_H
 #define	_SPL_ISA_DEFS_H

--- a/include/sys/kidmap.h
+++ b/include/sys/kidmap.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_KIDMAP_H
 #define _SPL_KIDMAP_H

--- a/include/sys/kobj.h
+++ b/include/sys/kobj.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_KOBJ_H
 #define _SPL_KOBJ_H

--- a/include/sys/kstat.h
+++ b/include/sys/kstat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_KSTAT_H
 #define _SPL_KSTAT_H

--- a/include/sys/list.h
+++ b/include/sys/list.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_LIST_H
 #define _SPL_LIST_H

--- a/include/sys/mkdev.h
+++ b/include/sys/mkdev.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_MKDEV_H
 #define _SPL_MKDEV_H

--- a/include/sys/mntent.h
+++ b/include/sys/mntent.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_MNTENT_H
 #define _SPL_MNTENT_H

--- a/include/sys/modctl.h
+++ b/include/sys/modctl.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_MODCTL_H
 #define _SPL_MODCTL_H

--- a/include/sys/mode.h
+++ b/include/sys/mode.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_MODE_H
 #define _SPL_MODE_H

--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_MOUNT_H
 #define _SPL_MOUNT_H

--- a/include/sys/note.h
+++ b/include/sys/note.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_NOTE_H
 #define _SPL_NOTE_H

--- a/include/sys/open.h
+++ b/include/sys/open.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_OPEN_H
 #define _SPL_OPEN_H

--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_PARAM_H
 #define _SPL_PARAM_H

--- a/include/sys/pathname.h
+++ b/include/sys/pathname.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_PATHNAME_H
 #define _SPL_PATHNAME_H

--- a/include/sys/policy.h
+++ b/include/sys/policy.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_POLICY_H
 #define _SPL_POLICY_H

--- a/include/sys/pool.h
+++ b/include/sys/pool.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_POOL_H
 #define _SPL_POOL_H

--- a/include/sys/priv_impl.h
+++ b/include/sys/priv_impl.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_PRIV_IMPL_H
 #define _SPL_PRIV_IMPL_H

--- a/include/sys/proc.h
+++ b/include/sys/proc.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_PROC_H
 #define _SPL_PROC_H

--- a/include/sys/processor.h
+++ b/include/sys/processor.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_PROCESSOR_H
 #define	_SPL_PROCESSOR_H

--- a/include/sys/pset.h
+++ b/include/sys/pset.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_PSET_H
 #define _SPL_PSET_H

--- a/include/sys/random.h
+++ b/include/sys/random.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_RANDOM_H
 #define	_SPL_RANDOM_H

--- a/include/sys/refstr.h
+++ b/include/sys/refstr.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_REFSTR_H
 #define _SPL_REFSTR_H

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_RESOURCE_H
 #define _SPL_RESOURCE_H

--- a/include/sys/rwlock.h
+++ b/include/sys/rwlock.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_RWLOCK_H
 #define _SPL_RWLOCK_H

--- a/include/sys/sdt.h
+++ b/include/sys/sdt.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SDT_H
 #define _SPL_SDT_H

--- a/include/sys/sid.h
+++ b/include/sys/sid.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SID_H
 #define _SPL_SID_H

--- a/include/sys/signal.h
+++ b/include/sys/signal.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SIGNAL_H
 #define _SPL_SIGNAL_H

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_STAT_H
 #define _SPL_STAT_H

--- a/include/sys/stropts.h
+++ b/include/sys/stropts.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_STROPTS_H
 #define _SPL_STROPTS_H

--- a/include/sys/sunddi.h
+++ b/include/sys/sunddi.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SUNDDI_H
 #define _SPL_SUNDDI_H

--- a/include/sys/sunldi.h
+++ b/include/sys/sunldi.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SUNLDI_H
 #define _SPL_SUNLDI_H

--- a/include/sys/sysdc.h
+++ b/include/sys/sysdc.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SYSDC_H
 #define _SPL_SYSDC_H

--- a/include/sys/sysevent.h
+++ b/include/sys/sysevent.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_SYSEVENT_H
 #define	_SPL_SYSEVENT_H

--- a/include/sys/sysevent/eventdefs.h
+++ b/include/sys/sysevent/eventdefs.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef	_SPL_SYSEVENT_EVENTDEFS_H
 #define	_SPL_SYSEVENT_EVENTDEFS_H

--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SYSMACROS_H
 #define _SPL_SYSMACROS_H

--- a/include/sys/systeminfo.h
+++ b/include/sys/systeminfo.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SYSTEMINFO_H
 #define _SPL_SYSTEMINFO_H

--- a/include/sys/systm.h
+++ b/include/sys/systm.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SYSTM_H
 #define _SPL_SYSTM_H

--- a/include/sys/t_lock.h
+++ b/include/sys/t_lock.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_T_LOCK_H
 #define _SPL_T_LOCK_H

--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_THREAD_H
 #define _SPL_THREAD_H

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_TIME_H
 #define	_SPL_TIME_H

--- a/include/sys/timer.h
+++ b/include/sys/timer.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_TIMER_H
 #define _SPL_TIMER_H

--- a/include/sys/tsd.h
+++ b/include/sys/tsd.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
@@ -19,7 +19,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_TSD_H
 #define _SPL_TSD_H

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_TYPES_H
 #define	_SPL_TYPES_H

--- a/include/sys/types32.h
+++ b/include/sys/types32.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_TYPES32_H
 #define	_SPL_TYPES32_H

--- a/include/sys/u8_textprep.h
+++ b/include/sys/u8_textprep.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_U8_TEXTPREP_H
 #define _SPL_U8_TEXTPREP_H

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Copyright (c) 2015 by Chunwei Chen. All rights reserved.
@@ -21,7 +21,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_UIO_H
 #define _SPL_UIO_H

--- a/include/sys/unistd.h
+++ b/include/sys/unistd.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_UNISTD_H
 #define _SPL_UNISTD_H

--- a/include/sys/user.h
+++ b/include/sys/user.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2015 Cluster Inc.
  *  Produced at ClusterHQ Inc (cf, DISCLAIMER).
  *  Written by Richard Yao <richard.yao@clusterhq.com>.
@@ -18,7 +18,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_USER_H
 #define _SPL_USER_H

--- a/include/sys/va_list.h
+++ b/include/sys/va_list.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_VA_LIST_H
 #define _SPL_VA_LIST_H

--- a/include/sys/varargs.h
+++ b/include/sys/varargs.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_VARARGS_H
 #define _SPL_VARARGS_H

--- a/include/sys/vfs.h
+++ b/include/sys/vfs.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ZFS_H
 #define _SPL_ZFS_H

--- a/include/sys/vfs_opreg.h
+++ b/include/sys/vfs_opreg.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_OPREG_H
 #define _SPL_OPREG_H

--- a/include/sys/vmsystm.h
+++ b/include/sys/vmsystm.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_VMSYSTM_H
 #define _SPL_VMSYSTM_H

--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_VNODE_H
 #define _SPL_VNODE_H

--- a/include/sys/zmod.h
+++ b/include/sys/zmod.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -50,7 +50,7 @@
  *
  *  Jean-loup Gailly
  *  Mark Adler
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ZMOD_H
 #define _SPL_ZMOD_H

--- a/include/sys/zone.h
+++ b/include/sys/zone.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_ZONE_H
 #define _SPL_ZONE_H

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_UNISTD_H
 #define _SPL_UNISTD_H

--- a/include/util/qsort.h
+++ b/include/util/qsort.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_QSORT_H
 #define _SPL_QSORT_H

--- a/include/util/sscanf.h
+++ b/include/util/sscanf.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_UTIL_SSCANF_H
 #define _SPL_UTIL_SSCANF_H

--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_VM_ANON_H
 #define _SPL_VM_ANON_H

--- a/include/vm/pvn.h
+++ b/include/vm/pvn.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_VM_PVN_H
 #define _SPL_VM_PVN_H

--- a/include/vm/seg_kmem.h
+++ b/include/vm/seg_kmem.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPL_SEG_KMEM_H
 #define _SPL_SEG_KMEM_H

--- a/module/spl/spl-atomic.c
+++ b/module/spl/spl-atomic.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Atomic Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/atomic.h>
 

--- a/module/spl/spl-cred.c
+++ b/module/spl/spl-cred.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Credential Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/cred.h>
 

--- a/module/spl/spl-err.c
+++ b/module/spl/spl-err.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Error Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/sysmacros.h>
 #include <sys/cmn_err.h>

--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Generic Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/sysmacros.h>
 #include <sys/systeminfo.h>

--- a/module/spl/spl-kobj.c
+++ b/module/spl/spl-kobj.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Kobj Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/kobj.h>
 

--- a/module/spl/spl-kstat.c
+++ b/module/spl/spl-kstat.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Kstat Implementation.
-\*****************************************************************************/
+ */
 
 #include <linux/seq_file.h>
 #include <sys/kstat.h>

--- a/module/spl/spl-mutex.c
+++ b/module/spl/spl-mutex.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Mutex Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/mutex.h>
 

--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Proc Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/systeminfo.h>
 #include <sys/kstat.h>

--- a/module/spl/spl-rwlock.c
+++ b/module/spl/spl-rwlock.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Reader/Writer Lock Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/rwlock.h>
 

--- a/module/spl/spl-thread.c
+++ b/module/spl/spl-thread.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Thread Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/thread.h>
 #include <sys/kmem.h>

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) Vnode Implementation.
-\*****************************************************************************/
+ */
 
 #include <sys/cred.h>
 #include <sys/vnode.h>

--- a/module/spl/spl-xdr.c
+++ b/module/spl/spl-xdr.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (c) 2008-2010 Sun Microsystems, Inc.
  *  Written by Ricardo Correia <Ricardo.M.Correia@Sun.COM>
  *
@@ -19,7 +19,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting Layer (SPL) XDR Implementation.
-\*****************************************************************************/
+ */
 
 #include <linux/string.h>
 #include <sys/kmem.h>

--- a/module/spl/spl-zlib.c
+++ b/module/spl/spl-zlib.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -50,7 +50,7 @@
  *
  *  Jean-loup Gailly
  *  Mark Adler
-\*****************************************************************************/
+ */
 
 
 #include <sys/kmem.h>

--- a/module/splat/splat-atomic.c
+++ b/module/splat/splat-atomic.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Atomic Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/atomic.h>
 #include <sys/thread.h>

--- a/module/splat/splat-condvar.c
+++ b/module/splat/splat-condvar.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Condition Variable Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/condvar.h>
 #include <sys/timer.h>

--- a/module/splat/splat-cred.c
+++ b/module/splat/splat-cred.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Credential Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/cred.h>
 #include <sys/random.h>

--- a/module/splat/splat-ctl.c
+++ b/module/splat/splat-ctl.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -41,7 +41,7 @@
  *  splat command line tool can be used to display all available
  *  subsystems and tests.  It can also be used to run the full suite
  *  of regression tests or particular tests.
-\*****************************************************************************/
+ */
 
 #include <sys/debug.h>
 #include <sys/mutex.h>

--- a/module/splat/splat-generic.c
+++ b/module/splat/splat-generic.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Generic Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/sunddi.h>
 #include <linux/math64_compat.h>

--- a/module/splat/splat-internal.h
+++ b/module/splat/splat-internal.h
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
-\*****************************************************************************/
+ */
 
 #ifndef _SPLAT_INTERNAL_H
 #define _SPLAT_INTERNAL_H

--- a/module/splat/splat-kmem.c
+++ b/module/splat/splat-kmem.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Kmem Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/kmem.h>
 #include <sys/kmem_cache.h>

--- a/module/splat/splat-kobj.c
+++ b/module/splat/splat-kobj.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Kobj Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/kobj.h>
 #include "splat-internal.h"

--- a/module/splat/splat-linux.c
+++ b/module/splat/splat-linux.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2011 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Brian Behlendorf <behlendorf1@llnl.gov>.
@@ -21,7 +21,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Kernel Compatibility Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/kmem.h>
 #include <linux/mm_compat.h>

--- a/module/splat/splat-list.c
+++ b/module/splat/splat-list.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) List Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/list.h>
 #include <sys/kmem.h>

--- a/module/splat/splat-mutex.c
+++ b/module/splat/splat-mutex.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Mutex Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/mutex.h>
 #include <sys/taskq.h>

--- a/module/splat/splat-random.c
+++ b/module/splat/splat-random.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Random Number Generator Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/random.h>
 #include <sys/kmem.h>

--- a/module/splat/splat-rwlock.c
+++ b/module/splat/splat-rwlock.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Read/Writer Lock Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/random.h>
 #include <sys/rwlock.h>

--- a/module/splat/splat-taskq.c
+++ b/module/splat/splat-taskq.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Task Queue Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/kmem.h>
 #include <sys/vmem.h>

--- a/module/splat/splat-thread.c
+++ b/module/splat/splat-thread.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Thread Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/thread.h>
 #include <sys/random.h>

--- a/module/splat/splat-time.c
+++ b/module/splat/splat-time.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Time Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/time.h>
 #include <linux/mm_compat.h>

--- a/module/splat/splat-vnode.c
+++ b/module/splat/splat-vnode.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Vnode Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/vnode.h>
 #include "splat-internal.h"

--- a/module/splat/splat-zlib.c
+++ b/module/splat/splat-zlib.c
@@ -1,4 +1,4 @@
-/*****************************************************************************\
+/*
  *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
  *  Copyright (C) 2007 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
@@ -22,7 +22,7 @@
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Solaris Porting LAyer Tests (SPLAT) Zlib Compression Tests.
-\*****************************************************************************/
+ */
 
 #include <sys/zmod.h>
 #include <sys/random.h>


### PR DESCRIPTION
In preparation for merging the SPL into ZFS, make the SPL conform to ZFS style conventions.

These patches do not make any semantic changes (or if they do, it's a mistake).

The vast majority of the changes are white space - spaces to tabs, or the wrong number of spaces for a continuation line.

The first patch that changes file headers will be the only one that I expect to change very large numbers of files.  The remaining patches are planned to fix whatever style issues exist in some small subtree.

Tested by locally building both SPL and ZFS, and running zloop.  Running through automated testing via https://github.com/zfsonlinux/zfs/pull/6726