### PR TITLE
Enable building the DKMS package on Debian-based distributions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,5 +50,6 @@ etags:
 tags: ctags etags
 
 pkg: @DEFAULT_PACKAGE@
+pkg-dkms: @DEFAULT_PACKAGE@-dkms
 pkg-kmod: @DEFAULT_PACKAGE@-kmod
 pkg-utils: @DEFAULT_PACKAGE@-utils

--- a/config/deb.am
+++ b/config/deb.am
@@ -29,33 +29,27 @@ deb-local:
 	fi)
 
 deb-kmod: deb-local rpm-kmod
-if CONFIG_KERNEL
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-kmod-$${version}.src.rpm --qf %{arch} | tail -1`; \
 	pkg1=kmod-$${name}*$${version}.$${arch}.rpm; \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
 	$(RM) $$pkg1
-endif
 
 deb-dkms: deb-local rpm-dkms
-if CONFIG_KERNEL
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-dkms-$${version}.src.rpm --qf %{arch} | tail -1`; \
 	pkg1=$${name}-dkms-$${version}.$${arch}.rpm; \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
 	$(RM) $$pkg1
-endif
 
 deb-utils: deb-local rpm-utils
-if CONFIG_USER
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-$${version}.src.rpm --qf %{arch} | tail -1`; \
 	pkg1=$${name}-$${version}.$${arch}.rpm; \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
 	$(RM) $$pkg1
-endif
 
 deb: deb-kmod deb-dkms deb-utils

--- a/config/deb.am
+++ b/config/deb.am
@@ -38,6 +38,16 @@ if CONFIG_KERNEL
 	$(RM) $$pkg1
 endif
 
+deb-dkms: deb-local rpm-dkms
+if CONFIG_KERNEL
+	name=${PACKAGE}; \
+	version=${VERSION}-${RELEASE}; \
+	arch=`$(RPM) -qp $${name}-dkms-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	pkg1=$${name}-dkms-$${version}.$${arch}.rpm; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
+	$(RM) $$pkg1
+endif
+
 deb-utils: deb-local rpm-utils
 if CONFIG_USER
 	name=${PACKAGE}; \
@@ -48,4 +58,4 @@ if CONFIG_USER
 	$(RM) $$pkg1
 endif
 
-deb: deb-kmod deb-utils
+deb: deb-kmod deb-dkms deb-utils

--- a/rpm/generic/spl-dkms.spec.in
+++ b/rpm/generic/spl-dkms.spec.in
@@ -1,5 +1,9 @@
 %{?!packager: %define packager Brian Behlendorf <behlendorf1@llnl.gov>}
 
+%if ! 0%{?rhel}%{?fedora}%{?mageia}%{?suse_version}
+%define not_rpm 1
+%endif
+
 %define module  @PACKAGE@
 %define mkconf  scripts/dkms.mkconf
 
@@ -18,7 +22,9 @@ BuildArch:      noarch
 
 Requires:       dkms >= 2.2.0.2
 Requires:       gcc, make, perl
+%if 0%{?rhel}%{?fedora}%{?mageia}%{?suse_version}
 Requires:       kernel-devel
+%endif
 Provides:       %{module}-kmod = %{version}
 
 %description
@@ -69,7 +75,7 @@ DKMS_META_ALIAS=`cat $CONFIG_H 2>/dev/null |
 if [ "$SPEC_META_ALIAS" = "$DKMS_META_ALIAS" ]; then
     echo -e
     echo -e "Uninstall of %{module} module ($SPEC_META_ALIAS) beginning:"
-    dkms remove -m %{module} -v %{version} --all --rpm_safe_upgrade
+    dkms remove -m %{module} -v %{version} --all %{!?not_rpm:--rpm_safe_upgrade}
 fi
 exit 0
 


### PR DESCRIPTION
This pull request adds the ability to generate DKMS packages that are compatible and installable for Debian and derivatives.

Required for: zfsonlinux/zfs/issues/6044
Required by: zfsonlinux/zfs/pull/6731