### PR TITLE
Fix reaping Linux kmem caches

### DIFF
--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -28,8 +28,8 @@
 #include <asm/page.h>
 
 /* Pages to bytes and back */
-#define ptob(pages)			(pages << PAGE_SHIFT)
-#define btop(bytes)			(bytes >> PAGE_SHIFT)
+#define ptob(pages)			((pages) << PAGE_SHIFT)
+#define btop(bytes)			((bytes) >> PAGE_SHIFT)
 
 #define MAXUID				UINT32_MAX
 

--- a/module/spl/spl-kmem-cache.c
+++ b/module/spl/spl-kmem-cache.c
@@ -1671,6 +1671,8 @@ spl_kmem_cache_reap_now(spl_kmem_cache_t *skc, int count)
 	if (skc->skc_flags & KMC_SLAB) {
 		if (skc->skc_reclaim)
 			skc->skc_reclaim(skc->skc_private);
+
+		(void) kmem_cache_shrink(skc->skc_linux_cache);
 		goto out;
 	}
 


### PR DESCRIPTION
When the kmem cache is backed by a Linux slab cache requests
to reap from the cache should be passed along.

Add missing parenthisis around btop and ptob macros to ensure
operation ordering is preserved after expandsion.