### PR TITLE
Add parenthesis to btop and ptob macros

### DIFF
--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -28,8 +28,8 @@
 #include <asm/page.h>
 
 /* Pages to bytes and back */
-#define ptob(pages)			(pages << PAGE_SHIFT)
-#define btop(bytes)			(bytes >> PAGE_SHIFT)
+#define ptob(pages)			((pages) << PAGE_SHIFT)
+#define btop(bytes)			((bytes) >> PAGE_SHIFT)
 
 #define MAXUID				UINT32_MAX
 


### PR DESCRIPTION
Add missing parenthesis around btop and ptob macros to ensure
operation ordering is preserved after expansion.