### PR TITLE
Remove all spin_is_locked calls

### DIFF
--- a/module/spl/spl-kmem-cache.c
+++ b/module/spl/spl-kmem-cache.c
@@ -382,7 +382,6 @@ spl_slab_free(spl_kmem_slab_t *sks,
 
 	skc = sks->sks_cache;
 	ASSERT(skc->skc_magic == SKC_MAGIC);
-	ASSERT(spin_is_locked(&skc->skc_lock));
 
 	/*
 	 * Update slab/objects counters in the cache, then remove the
@@ -583,7 +582,6 @@ __spl_cache_flush(spl_kmem_cache_t *skc, spl_kmem_magazine_t *skm, int flush)
 
 	ASSERT(skc->skc_magic == SKC_MAGIC);
 	ASSERT(skm->skm_magic == SKM_MAGIC);
-	ASSERT(spin_is_locked(&skc->skc_lock));
 
 	for (i = 0; i < count; i++)
 		spl_cache_shrink(skc, skm->skm_objs[i]);
@@ -1125,7 +1123,6 @@ spl_cache_obj(spl_kmem_cache_t *skc, spl_kmem_slab_t *sks)
 
 	ASSERT(skc->skc_magic == SKC_MAGIC);
 	ASSERT(sks->sks_magic == SKS_MAGIC);
-	ASSERT(spin_is_locked(&skc->skc_lock));
 
 	sko = list_entry(sks->sks_free_list.next, spl_kmem_obj_t, sko_list);
 	ASSERT(sko->sko_magic == SKO_MAGIC);
@@ -1396,7 +1393,6 @@ spl_cache_shrink(spl_kmem_cache_t *skc, void *obj)
 	spl_kmem_obj_t *sko = NULL;
 
 	ASSERT(skc->skc_magic == SKC_MAGIC);
-	ASSERT(spin_is_locked(&skc->skc_lock));
 
 	sko = spl_sko_from_obj(skc, obj);
 	ASSERT(sko->sko_magic == SKO_MAGIC);

--- a/module/spl/spl-tsd.c
+++ b/module/spl/spl-tsd.c
@@ -315,7 +315,6 @@ tsd_hash_add_pid(tsd_hash_table_t *table, pid_t pid)
 static void
 tsd_hash_del(tsd_hash_table_t *table, tsd_hash_entry_t *entry)
 {
-	ASSERT(spin_is_locked(&table->ht_lock));
 	hlist_del(&entry->he_list);
 	list_del_init(&entry->he_key_list);
 	list_del_init(&entry->he_pid_list);

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -427,8 +427,6 @@ file_find(int fd, struct task_struct *task)
 {
         file_t *fp;
 
-	ASSERT(spin_is_locked(&vn_file_lock));
-
         list_for_each_entry(fp, &vn_file_list,  f_list) {
 		if (fd == fp->f_fd && fp->f_task == task) {
 			ASSERT(atomic_read(&fp->f_ref) != 0);


### PR DESCRIPTION
On systems with CONFIG_SMP turned off, spin_is_locked always returns false causing these assertions to fail. Remove them as suggested in zfsonlinux/zfs#6558