### PR TITLE
Add cv_timedwait_io()

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -52,6 +52,7 @@ AC_DEFUN([SPL_AC_CONFIG_KERNEL], [
 	SPL_AC_KMEM_CACHE_CREATE_USERCOPY
 	SPL_AC_WAIT_QUEUE_ENTRY_T
 	SPL_AC_WAIT_QUEUE_HEAD_ENTRY
+	SPL_AC_IO_SCHEDULE_TIMEOUT
 	SPL_AC_KERNEL_WRITE
 	SPL_AC_KERNEL_READ
 	SPL_AC_KERNEL_TIMER_FUNCTION_TIMER_LIST
@@ -1593,6 +1594,26 @@ AC_DEFUN([SPL_AC_WAIT_QUEUE_HEAD_ENTRY], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_WAIT_QUEUE_HEAD_ENTRY, 1,
 		    [wq_head->head and wq_entry->entry exist])
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
+dnl # 3.19 API change
+dnl # The io_schedule_timeout() function is present in all 2.6.32 kernels
+dnl # but it was not exported until Linux 3.19.  The RHEL 7.x kernels which
+dnl # are based on a 3.10 kernel do export this symbol.
+dnl #
+AC_DEFUN([SPL_AC_IO_SCHEDULE_TIMEOUT], [
+	AC_MSG_CHECKING([whether io_schedule_timeout() is available])
+	SPL_LINUX_TRY_COMPILE_SYMBOL([
+		#include <linux/sched.h>
+	], [
+		(void) io_schedule_timeout(1);
+	], [io_schedule_timeout], [], [
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_IO_SCHEDULE_TIMEOUT, 1, [yes])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/include/sys/condvar.h
+++ b/include/sys/condvar.h
@@ -56,6 +56,7 @@ extern void __cv_wait(kcondvar_t *, kmutex_t *);
 extern void __cv_wait_io(kcondvar_t *, kmutex_t *);
 extern void __cv_wait_sig(kcondvar_t *, kmutex_t *);
 extern clock_t __cv_timedwait(kcondvar_t *, kmutex_t *, clock_t);
+extern clock_t __cv_timedwait_io(kcondvar_t *, kmutex_t *, clock_t);
 extern clock_t __cv_timedwait_sig(kcondvar_t *, kmutex_t *, clock_t);
 extern clock_t cv_timedwait_hires(kcondvar_t *, kmutex_t *, hrtime_t,
     hrtime_t res, int flag);
@@ -71,6 +72,7 @@ extern void __cv_broadcast(kcondvar_t *c);
 #define	cv_wait_sig(cvp, mp)			__cv_wait_sig(cvp, mp)
 #define	cv_wait_interruptible(cvp, mp)		cv_wait_sig(cvp, mp)
 #define	cv_timedwait(cvp, mp, t)		__cv_timedwait(cvp, mp, t)
+#define	cv_timedwait_io(cvp, mp, t)		__cv_timedwait_io(cvp, mp, t)
 #define	cv_timedwait_sig(cvp, mp, t)		__cv_timedwait_sig(cvp, mp, t)
 #define	cv_timedwait_interruptible(cvp, mp, t)	cv_timedwait_sig(cvp, mp, t)
 #define	cv_signal(cvp)				__cv_signal(cvp)


### PR DESCRIPTION
Add missing helper function cv_timedwait_io() which should be used
when waiting on IO with a specified timeout.