### PR TITLE
Fix Debian packaging on ARMv7/ARM64

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -32,24 +32,27 @@ deb-kmod: deb-local rpm-kmod
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-kmod-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=kmod-$${name}*$${version}.$${arch}.rpm; \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1; \
 	$(RM) $$pkg1
 
 deb-dkms: deb-local rpm-dkms
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-dkms-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=$${name}-dkms-$${version}.$${arch}.rpm; \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1; \
 	$(RM) $$pkg1
 
 deb-utils: deb-local rpm-utils
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=$${name}-$${version}.$${arch}.rpm; \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1; \
 	$(RM) $$pkg1
 
 deb: deb-kmod deb-dkms deb-utils


### PR DESCRIPTION
When building packages on Debian-based systems specify the target architecture used by `alien` to convert .rpm packages into .deb: this avoids detecting an incorrect value which results in the following errors:

```
<package>.aarch64.rpm is for architecture aarch64 ; the package cannot be built on this system
<package>.armv7l.rpm is for architecture armel ; the package cannot be built on this system
```

This change is intended to fix https://github.com/zfsonlinux/zfs/issues/7046.