### PR TITLE
Fix cstyle warnings

### DIFF
--- a/include/fs/fs_subr.h
+++ b/include/fs/fs_subr.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_FS_FS_SUBR_H
-#define _SPL_FS_FS_SUBR_H
+#define	_SPL_FS_FS_SUBR_H
 
 #endif /* SPL_FS_FS_SUBR_H */

--- a/include/linux/math64_compat.h
+++ b/include/linux/math64_compat.h
@@ -26,6 +26,7 @@
 #define	_SPL_MATH64_COMPAT_H
 
 #ifndef abs64
+/* CSTYLED */
 #define	abs64(x)	({ uint64_t t = (x) >> 63; ((x) ^ t) - t; })
 #endif
 

--- a/include/rpc/types.h
+++ b/include/rpc/types.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_RPC_TYPES_H
-#define _SPL_RPC_TYPES_H
+#define	_SPL_RPC_TYPES_H
 
 typedef int bool_t;
 

--- a/include/rpc/xdr.h
+++ b/include/rpc/xdr.h
@@ -20,7 +20,7 @@
  */
 
 #ifndef _SPL_RPC_XDR_H
-#define _SPL_RPC_XDR_H
+#define	_SPL_RPC_XDR_H
 
 #include <sys/types.h>
 #include <rpc/types.h>
@@ -36,11 +36,10 @@ enum xdr_op {
 struct xdr_ops;
 
 typedef struct {
-	struct xdr_ops *x_ops;      /* Also used to let caller know if
-	                               xdrmem_create() succeeds (sigh..) */
-	caddr_t         x_addr;     /* Current buffer addr */
-	caddr_t         x_addr_end; /* End of the buffer */
-	enum xdr_op     x_op;       /* Stream direction */
+	struct xdr_ops	*x_ops;	/* Let caller know xdrmem_create() succeeds */
+	caddr_t		x_addr;	/* Current buffer addr */
+	caddr_t		x_addr_end;	/* End of the buffer */
+	enum xdr_op	x_op;	/* Stream direction */
 } XDR;
 
 typedef bool_t (*xdrproc_t)(XDR *xdrs, void *ptr);
@@ -56,13 +55,13 @@ struct xdr_ops {
 	bool_t (*xdr_opaque)(XDR *, caddr_t, const uint_t);
 	bool_t (*xdr_string)(XDR *, char **, const uint_t);
 	bool_t (*xdr_array)(XDR *, caddr_t *, uint_t *, const uint_t,
-	                    const uint_t, const xdrproc_t);
+	    const uint_t, const xdrproc_t);
 };
 
 /*
  * XDR control operator.
  */
-#define XDR_GET_BYTES_AVAIL 1
+#define	XDR_GET_BYTES_AVAIL 1
 
 struct xdr_bytesrec {
 	bool_t xc_is_last_record;
@@ -74,11 +73,12 @@ struct xdr_bytesrec {
  */
 void xdrmem_create(XDR *xdrs, const caddr_t addr, const uint_t size,
     const enum xdr_op op);
-#define xdr_destroy(xdrs) ((void) 0) /* Currently not needed. If needed later,
-                                        we'll add it to struct xdr_ops */
 
-#define xdr_control(xdrs, req, info) (xdrs)->x_ops->xdr_control((xdrs),        \
-                                         (req), (info))
+/* Currently not needed. If needed later, we'll add it to struct xdr_ops */
+#define	xdr_destroy(xdrs) ((void) 0)
+
+#define	xdr_control(xdrs, req, info) \
+	(xdrs)->x_ops->xdr_control((xdrs), (req), (info))
 
 /*
  * For precaution, the following are defined as static inlines instead of macros
@@ -89,40 +89,40 @@ void xdrmem_create(XDR *xdrs, const caddr_t addr, const uint_t size,
  */
 static inline bool_t xdr_char(XDR *xdrs, char *cp)
 {
-	return xdrs->x_ops->xdr_char(xdrs, cp);
+	return (xdrs->x_ops->xdr_char(xdrs, cp));
 }
 
 static inline bool_t xdr_u_short(XDR *xdrs, unsigned short *usp)
 {
-	return xdrs->x_ops->xdr_u_short(xdrs, usp);
+	return (xdrs->x_ops->xdr_u_short(xdrs, usp));
 }
 
 static inline bool_t xdr_short(XDR *xdrs, short *sp)
 {
-	BUILD_BUG_ON(sizeof(short) != 2);
-	return xdrs->x_ops->xdr_u_short(xdrs, (unsigned short *) sp);
+	BUILD_BUG_ON(sizeof (short) != 2);
+	return (xdrs->x_ops->xdr_u_short(xdrs, (unsigned short *) sp));
 }
 
 static inline bool_t xdr_u_int(XDR *xdrs, unsigned *up)
 {
-	return xdrs->x_ops->xdr_u_int(xdrs, up);
+	return (xdrs->x_ops->xdr_u_int(xdrs, up));
 }
 
 static inline bool_t xdr_int(XDR *xdrs, int *ip)
 {
-	BUILD_BUG_ON(sizeof(int) != 4);
-	return xdrs->x_ops->xdr_u_int(xdrs, (unsigned *) ip);
+	BUILD_BUG_ON(sizeof (int) != 4);
+	return (xdrs->x_ops->xdr_u_int(xdrs, (unsigned *)ip));
 }
 
 static inline bool_t xdr_u_longlong_t(XDR *xdrs, u_longlong_t *ullp)
 {
-	return xdrs->x_ops->xdr_u_longlong_t(xdrs, ullp);
+	return (xdrs->x_ops->xdr_u_longlong_t(xdrs, ullp));
 }
 
 static inline bool_t xdr_longlong_t(XDR *xdrs, longlong_t *llp)
 {
-	BUILD_BUG_ON(sizeof(longlong_t) != 8);
-	return xdrs->x_ops->xdr_u_longlong_t(xdrs, (u_longlong_t *) llp);
+	BUILD_BUG_ON(sizeof (longlong_t) != 8);
+	return (xdrs->x_ops->xdr_u_longlong_t(xdrs, (u_longlong_t *)llp));
 }
 
 /*
@@ -130,7 +130,7 @@ static inline bool_t xdr_longlong_t(XDR *xdrs, longlong_t *llp)
  */
 static inline bool_t xdr_opaque(XDR *xdrs, caddr_t cp, const uint_t cnt)
 {
-	return xdrs->x_ops->xdr_opaque(xdrs, cp, cnt);
+	return (xdrs->x_ops->xdr_opaque(xdrs, cp, cnt));
 }
 
 /*
@@ -139,7 +139,7 @@ static inline bool_t xdr_opaque(XDR *xdrs, caddr_t cp, const uint_t cnt)
  */
 static inline bool_t xdr_string(XDR *xdrs, char **sp, const uint_t maxsize)
 {
-	return xdrs->x_ops->xdr_string(xdrs, sp, maxsize);
+	return (xdrs->x_ops->xdr_string(xdrs, sp, maxsize));
 }
 
 /*

--- a/include/sharefs/share.h
+++ b/include/sharefs/share.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_SHARE_H
-#define _SPL_SHARE_H
+#define	_SPL_SHARE_H
 
 #endif /* SPL_SHARE_H */

--- a/include/spl-ctl.h
+++ b/include/spl-ctl.h
@@ -23,23 +23,23 @@
  */
 
 #ifndef _DEBUG_CTL_H
-#define _DEBUG_CTL_H
+#define	_DEBUG_CTL_H
 
 /*
  * Contains shared definitions which both the user space
  * and kernel space portions of splat must agree on.
  */
 typedef struct spl_debug_header {
-        int ph_len;
-        int ph_flags;
-        int ph_subsys;
-        int ph_mask;
-        int ph_cpu_id;
-        int ph_sec;
-        long ph_usec;
-        int ph_stack;
-        int ph_pid;
-        int ph_line_num;
+	int ph_len;
+	int ph_flags;
+	int ph_subsys;
+	int ph_mask;
+	int ph_cpu_id;
+	int ph_sec;
+	long ph_usec;
+	int ph_stack;
+	int ph_pid;
+	int ph_line_num;
 } spl_debug_header_t;
 
 #endif /* _DEBUG_CTL_H */

--- a/include/splat-ctl.h
+++ b/include/splat-ctl.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPLAT_CTL_H
-#define _SPLAT_CTL_H
+#define	_SPLAT_CTL_H
 
 #include <linux/types.h>
 
@@ -32,11 +32,11 @@
  * ensure 32-bit/64-bit interoperability over ioctl()'s only types with
  * fixed sizes can be used.
  */
-#define SPLAT_NAME			"splatctl"
-#define SPLAT_DEV			"/dev/splatctl"
+#define	SPLAT_NAME			"splatctl"
+#define	SPLAT_DEV			"/dev/splatctl"
 
-#define SPLAT_NAME_SIZE			20
-#define SPLAT_DESC_SIZE			60
+#define	SPLAT_NAME_SIZE			20
+#define	SPLAT_DESC_SIZE			60
 
 typedef struct splat_user {
 	char name[SPLAT_NAME_SIZE];	/* Short name */
@@ -72,38 +72,38 @@ typedef struct splat_cmd {
 } splat_cmd_t;
 
 /* Valid ioctls */
-#define SPLAT_CFG			_IOWR('f', 101, splat_cfg_t)
-#define SPLAT_CMD			_IOWR('f', 102, splat_cmd_t)
+#define	SPLAT_CFG			_IOWR('f', 101, splat_cfg_t)
+#define	SPLAT_CMD			_IOWR('f', 102, splat_cmd_t)
 
 /* Valid configuration commands */
-#define SPLAT_CFG_BUFFER_CLEAR		0x001	/* Clear text buffer */
-#define SPLAT_CFG_BUFFER_SIZE		0x002	/* Resize text buffer */
-#define SPLAT_CFG_SUBSYSTEM_COUNT	0x101	/* Number of subsystem */
-#define SPLAT_CFG_SUBSYSTEM_LIST	0x102	/* List of N subsystems */
-#define SPLAT_CFG_TEST_COUNT		0x201	/* Number of tests */
-#define SPLAT_CFG_TEST_LIST		0x202	/* List of N tests */
+#define	SPLAT_CFG_BUFFER_CLEAR		0x001	/* Clear text buffer */
+#define	SPLAT_CFG_BUFFER_SIZE		0x002	/* Resize text buffer */
+#define	SPLAT_CFG_SUBSYSTEM_COUNT	0x101	/* Number of subsystem */
+#define	SPLAT_CFG_SUBSYSTEM_LIST	0x102	/* List of N subsystems */
+#define	SPLAT_CFG_TEST_COUNT		0x201	/* Number of tests */
+#define	SPLAT_CFG_TEST_LIST		0x202	/* List of N tests */
 
 /*
  * Valid subsystem and test commands are defined in each subsystem as
  * SPLAT_SUBSYSTEM_*.  We do need to be careful to avoid collisions, the
  * currently defined subsystems are as follows:
  */
-#define SPLAT_SUBSYSTEM_KMEM		0x0100
-#define SPLAT_SUBSYSTEM_TASKQ		0x0200
-#define SPLAT_SUBSYSTEM_KRNG		0x0300
-#define SPLAT_SUBSYSTEM_MUTEX		0x0400
-#define SPLAT_SUBSYSTEM_CONDVAR		0x0500
-#define SPLAT_SUBSYSTEM_THREAD		0x0600
-#define SPLAT_SUBSYSTEM_RWLOCK		0x0700
-#define SPLAT_SUBSYSTEM_TIME		0x0800
-#define SPLAT_SUBSYSTEM_VNODE		0x0900
-#define SPLAT_SUBSYSTEM_KOBJ		0x0a00
-#define SPLAT_SUBSYSTEM_ATOMIC		0x0b00
-#define SPLAT_SUBSYSTEM_LIST		0x0c00
-#define SPLAT_SUBSYSTEM_GENERIC		0x0d00
-#define SPLAT_SUBSYSTEM_CRED		0x0e00
-#define SPLAT_SUBSYSTEM_ZLIB		0x0f00
-#define SPLAT_SUBSYSTEM_LINUX		0x1000
-#define SPLAT_SUBSYSTEM_UNKNOWN		0xff00
+#define	SPLAT_SUBSYSTEM_KMEM		0x0100
+#define	SPLAT_SUBSYSTEM_TASKQ		0x0200
+#define	SPLAT_SUBSYSTEM_KRNG		0x0300
+#define	SPLAT_SUBSYSTEM_MUTEX		0x0400
+#define	SPLAT_SUBSYSTEM_CONDVAR		0x0500
+#define	SPLAT_SUBSYSTEM_THREAD		0x0600
+#define	SPLAT_SUBSYSTEM_RWLOCK		0x0700
+#define	SPLAT_SUBSYSTEM_TIME		0x0800
+#define	SPLAT_SUBSYSTEM_VNODE		0x0900
+#define	SPLAT_SUBSYSTEM_KOBJ		0x0a00
+#define	SPLAT_SUBSYSTEM_ATOMIC		0x0b00
+#define	SPLAT_SUBSYSTEM_LIST		0x0c00
+#define	SPLAT_SUBSYSTEM_GENERIC		0x0d00
+#define	SPLAT_SUBSYSTEM_CRED		0x0e00
+#define	SPLAT_SUBSYSTEM_ZLIB		0x0f00
+#define	SPLAT_SUBSYSTEM_LINUX		0x1000
+#define	SPLAT_SUBSYSTEM_UNKNOWN		0xff00
 
 #endif /* _SPLAT_CTL_H */

--- a/include/strings.h
+++ b/include/strings.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_STRINGS_H
-#define _SPL_STRINGS_H
+#define	_SPL_STRINGS_H
 
 #endif /* SPL_STRINGS_H */

--- a/include/sys/acl.h
+++ b/include/sys/acl.h
@@ -23,95 +23,97 @@
  */
 
 #ifndef _SPL_ACL_H
-#define _SPL_ACL_H
+#define	_SPL_ACL_H
 
 #include <sys/types.h>
 
 typedef struct ace {
-        uid_t a_who;
-        uint32_t a_access_mask;
-        uint16_t a_flags;
-        uint16_t a_type;
+	uid_t a_who;
+	uint32_t a_access_mask;
+	uint16_t a_flags;
+	uint16_t a_type;
 } ace_t;
 
 typedef struct ace_object {
-        uid_t           a_who;          /* uid or gid */
-        uint32_t        a_access_mask;  /* read,write,... */
-        uint16_t        a_flags;        /* see below */
-        uint16_t        a_type;         /* allow or deny */
-        uint8_t         a_obj_type[16]; /* obj type */
-        uint8_t         a_inherit_obj_type[16];  /* inherit obj */
+	uid_t		a_who;		/* uid or gid */
+	uint32_t	a_access_mask;	/* read,write,... */
+	uint16_t	a_flags;	/* see below */
+	uint16_t	a_type;		/* allow or deny */
+	uint8_t		a_obj_type[16];	/* obj type */
+	uint8_t		a_inherit_obj_type[16];	/* inherit obj */
 } ace_object_t;
 
-#define MAX_ACL_ENTRIES					1024
+#define	MAX_ACL_ENTRIES					1024
 
-#define ACE_READ_DATA                                   0x00000001
-#define ACE_LIST_DIRECTORY                              0x00000001
-#define ACE_WRITE_DATA                                  0x00000002
-#define ACE_ADD_FILE                                    0x00000002
-#define ACE_APPEND_DATA                                 0x00000004
-#define ACE_ADD_SUBDIRECTORY                            0x00000004
-#define ACE_READ_NAMED_ATTRS                            0x00000008
-#define ACE_WRITE_NAMED_ATTRS                           0x00000010
-#define ACE_EXECUTE                                     0x00000020
-#define ACE_DELETE_CHILD                                0x00000040
-#define ACE_READ_ATTRIBUTES                             0x00000080
-#define ACE_WRITE_ATTRIBUTES                            0x00000100
-#define ACE_DELETE                                      0x00010000
-#define ACE_READ_ACL                                    0x00020000
-#define ACE_WRITE_ACL                                   0x00040000
-#define ACE_WRITE_OWNER                                 0x00080000
-#define ACE_SYNCHRONIZE                                 0x00100000
+#define	ACE_READ_DATA					0x00000001
+#define	ACE_LIST_DIRECTORY				0x00000001
+#define	ACE_WRITE_DATA					0x00000002
+#define	ACE_ADD_FILE					0x00000002
+#define	ACE_APPEND_DATA					0x00000004
+#define	ACE_ADD_SUBDIRECTORY				0x00000004
+#define	ACE_READ_NAMED_ATTRS				0x00000008
+#define	ACE_WRITE_NAMED_ATTRS				0x00000010
+#define	ACE_EXECUTE					0x00000020
+#define	ACE_DELETE_CHILD				0x00000040
+#define	ACE_READ_ATTRIBUTES				0x00000080
+#define	ACE_WRITE_ATTRIBUTES				0x00000100
+#define	ACE_DELETE					0x00010000
+#define	ACE_READ_ACL					0x00020000
+#define	ACE_WRITE_ACL					0x00040000
+#define	ACE_WRITE_OWNER					0x00080000
+#define	ACE_SYNCHRONIZE					0x00100000
 
-#define ACE_FILE_INHERIT_ACE                            0x0001
-#define ACE_DIRECTORY_INHERIT_ACE                       0x0002
-#define ACE_NO_PROPAGATE_INHERIT_ACE                    0x0004
-#define ACE_INHERIT_ONLY_ACE                            0x0008
-#define ACE_SUCCESSFUL_ACCESS_ACE_FLAG                  0x0010
-#define ACE_FAILED_ACCESS_ACE_FLAG                      0x0020
-#define ACE_IDENTIFIER_GROUP                            0x0040
-#define ACE_INHERITED_ACE                               0x0080
-#define ACE_OWNER                                       0x1000
-#define ACE_GROUP                                       0x2000
-#define ACE_EVERYONE                                    0x4000
+#define	ACE_FILE_INHERIT_ACE				0x0001
+#define	ACE_DIRECTORY_INHERIT_ACE			0x0002
+#define	ACE_NO_PROPAGATE_INHERIT_ACE			0x0004
+#define	ACE_INHERIT_ONLY_ACE				0x0008
+#define	ACE_SUCCESSFUL_ACCESS_ACE_FLAG			0x0010
+#define	ACE_FAILED_ACCESS_ACE_FLAG			0x0020
+#define	ACE_IDENTIFIER_GROUP				0x0040
+#define	ACE_INHERITED_ACE				0x0080
+#define	ACE_OWNER					0x1000
+#define	ACE_GROUP					0x2000
+#define	ACE_EVERYONE					0x4000
 
-#define ACE_ACCESS_ALLOWED_ACE_TYPE                     0x0000
-#define ACE_ACCESS_DENIED_ACE_TYPE                      0x0001
-#define ACE_SYSTEM_AUDIT_ACE_TYPE                       0x0002
-#define ACE_SYSTEM_ALARM_ACE_TYPE                       0x0003
+#define	ACE_ACCESS_ALLOWED_ACE_TYPE			0x0000
+#define	ACE_ACCESS_DENIED_ACE_TYPE			0x0001
+#define	ACE_SYSTEM_AUDIT_ACE_TYPE			0x0002
+#define	ACE_SYSTEM_ALARM_ACE_TYPE			0x0003
 
-#define ACL_AUTO_INHERIT                                0x0001
-#define ACL_PROTECTED                                   0x0002
-#define ACL_DEFAULTED                                   0x0004
-#define ACL_FLAGS_ALL (ACL_AUTO_INHERIT|ACL_PROTECTED|ACL_DEFAULTED)
+#define	ACL_AUTO_INHERIT				0x0001
+#define	ACL_PROTECTED					0x0002
+#define	ACL_DEFAULTED					0x0004
+#define	ACL_FLAGS_ALL	(ACL_AUTO_INHERIT|ACL_PROTECTED|ACL_DEFAULTED)
 
-#define ACE_ACCESS_ALLOWED_COMPOUND_ACE_TYPE            0x04
-#define ACE_ACCESS_ALLOWED_OBJECT_ACE_TYPE              0x05
-#define ACE_ACCESS_DENIED_OBJECT_ACE_TYPE               0x06
-#define ACE_SYSTEM_AUDIT_OBJECT_ACE_TYPE                0x07
-#define ACE_SYSTEM_ALARM_OBJECT_ACE_TYPE                0x08
-#define ACE_ACCESS_ALLOWED_CALLBACK_ACE_TYPE            0x09
-#define ACE_ACCESS_DENIED_CALLBACK_ACE_TYPE             0x0A
-#define ACE_ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE     0x0B
-#define ACE_ACCESS_DENIED_CALLBACK_OBJECT_ACE_TYPE      0x0C
-#define ACE_SYSTEM_AUDIT_CALLBACK_ACE_TYPE              0x0D
-#define ACE_SYSTEM_ALARM_CALLBACK_ACE_TYPE              0x0E
-#define ACE_SYSTEM_AUDIT_CALLBACK_OBJECT_ACE_TYPE       0x0F
-#define ACE_SYSTEM_ALARM_CALLBACK_OBJECT_ACE_TYPE       0x10
+#define	ACE_ACCESS_ALLOWED_COMPOUND_ACE_TYPE		0x04
+#define	ACE_ACCESS_ALLOWED_OBJECT_ACE_TYPE		0x05
+#define	ACE_ACCESS_DENIED_OBJECT_ACE_TYPE		0x06
+#define	ACE_SYSTEM_AUDIT_OBJECT_ACE_TYPE		0x07
+#define	ACE_SYSTEM_ALARM_OBJECT_ACE_TYPE		0x08
+#define	ACE_ACCESS_ALLOWED_CALLBACK_ACE_TYPE		0x09
+#define	ACE_ACCESS_DENIED_CALLBACK_ACE_TYPE		0x0A
+#define	ACE_ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE	0x0B
+#define	ACE_ACCESS_DENIED_CALLBACK_OBJECT_ACE_TYPE	0x0C
+#define	ACE_SYSTEM_AUDIT_CALLBACK_ACE_TYPE		0x0D
+#define	ACE_SYSTEM_ALARM_CALLBACK_ACE_TYPE		0x0E
+#define	ACE_SYSTEM_AUDIT_CALLBACK_OBJECT_ACE_TYPE	0x0F
+#define	ACE_SYSTEM_ALARM_CALLBACK_OBJECT_ACE_TYPE	0x10
 
-#define ACE_ALL_TYPES   0x001F
+#define	ACE_ALL_TYPES	0x001F
 
-#define ACE_TYPE_FLAGS (ACE_OWNER|ACE_GROUP|ACE_EVERYONE|ACE_IDENTIFIER_GROUP)
+#define	ACE_TYPE_FLAGS	(ACE_OWNER|ACE_GROUP|ACE_EVERYONE|ACE_IDENTIFIER_GROUP)
 
-#define ACE_ALL_PERMS   (ACE_READ_DATA|ACE_LIST_DIRECTORY|ACE_WRITE_DATA| \
+/* BEGIN CSTYLED */
+#define	ACE_ALL_PERMS	(ACE_READ_DATA|ACE_LIST_DIRECTORY|ACE_WRITE_DATA| \
      ACE_ADD_FILE|ACE_APPEND_DATA|ACE_ADD_SUBDIRECTORY|ACE_READ_NAMED_ATTRS| \
      ACE_WRITE_NAMED_ATTRS|ACE_EXECUTE|ACE_DELETE_CHILD|ACE_READ_ATTRIBUTES| \
      ACE_WRITE_ATTRIBUTES|ACE_DELETE|ACE_READ_ACL|ACE_WRITE_ACL| \
      ACE_WRITE_OWNER|ACE_SYNCHRONIZE)
+/* END CSTYLED */
 
-#define VSA_ACE                                         0x0010
-#define VSA_ACECNT                                      0x0020
-#define VSA_ACE_ALLTYPES                                0x0040
-#define VSA_ACE_ACLFLAGS                                0x0080
+#define	VSA_ACE						0x0010
+#define	VSA_ACECNT					0x0020
+#define	VSA_ACE_ALLTYPES				0x0040
+#define	VSA_ACE_ACLFLAGS				0x0080
 
 #endif /* _SPL_ACL_H */

--- a/include/sys/acl_impl.h
+++ b/include/sys/acl_impl.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_ACL_IMPL_H
-#define _SPL_ACL_IMPL_H
+#define	_SPL_ACL_IMPL_H
 
 #endif /* _SPL_ACL_IMPL_H */

--- a/include/sys/atomic.h
+++ b/include/sys/atomic.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_ATOMIC_H
-#define _SPL_ATOMIC_H
+#define	_SPL_ATOMIC_H
 
 #include <linux/module.h>
 #include <linux/spinlock.h>
@@ -91,7 +91,7 @@ atomic_inc_32_nv(volatile uint32_t *target)
 	nv = ++(*target);
 	spin_unlock(&atomic32_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint32_t
@@ -103,7 +103,7 @@ atomic_dec_32_nv(volatile uint32_t *target)
 	nv = --(*target);
 	spin_unlock(&atomic32_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint32_t
@@ -116,7 +116,7 @@ atomic_add_32_nv(volatile uint32_t *target, uint32_t delta)
 	nv = *target;
 	spin_unlock(&atomic32_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint32_t
@@ -129,12 +129,11 @@ atomic_sub_32_nv(volatile uint32_t *target, uint32_t delta)
 	nv = *target;
 	spin_unlock(&atomic32_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint32_t
-atomic_cas_32(volatile uint32_t *target,  uint32_t cmp,
-              uint32_t newval)
+atomic_cas_32(volatile uint32_t *target,  uint32_t cmp, uint32_t newval)
 {
 	uint32_t rc;
 
@@ -145,7 +144,7 @@ atomic_cas_32(volatile uint32_t *target,  uint32_t cmp,
 
 	spin_unlock(&atomic32_lock);
 
-	return rc;
+	return (rc);
 }
 
 static __inline__ uint32_t
@@ -158,7 +157,7 @@ atomic_swap_32(volatile uint32_t *target,  uint32_t newval)
 	*target = newval;
 	spin_unlock(&atomic32_lock);
 
-	return rc;
+	return (rc);
 }
 
 static __inline__ void
@@ -202,7 +201,7 @@ atomic_inc_64_nv(volatile uint64_t *target)
 	nv = ++(*target);
 	spin_unlock(&atomic64_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint64_t
@@ -214,7 +213,7 @@ atomic_dec_64_nv(volatile uint64_t *target)
 	nv = --(*target);
 	spin_unlock(&atomic64_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint64_t
@@ -227,7 +226,7 @@ atomic_add_64_nv(volatile uint64_t *target, uint64_t delta)
 	nv = *target;
 	spin_unlock(&atomic64_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint64_t
@@ -240,12 +239,11 @@ atomic_sub_64_nv(volatile uint64_t *target, uint64_t delta)
 	nv = *target;
 	spin_unlock(&atomic64_lock);
 
-	return nv;
+	return (nv);
 }
 
 static __inline__ uint64_t
-atomic_cas_64(volatile uint64_t *target,  uint64_t cmp,
-              uint64_t newval)
+atomic_cas_64(volatile uint64_t *target,  uint64_t cmp, uint64_t newval)
 {
 	uint64_t rc;
 
@@ -255,7 +253,7 @@ atomic_cas_64(volatile uint64_t *target,  uint64_t cmp,
 		*target = newval;
 	spin_unlock(&atomic64_lock);
 
-	return rc;
+	return (rc);
 }
 
 static __inline__ uint64_t
@@ -268,31 +266,31 @@ atomic_swap_64(volatile uint64_t *target,  uint64_t newval)
 	*target = newval;
 	spin_unlock(&atomic64_lock);
 
-	return rc;
+	return (rc);
 }
 
 #else /* ATOMIC_SPINLOCK */
 
-#define atomic_inc_32(v)	atomic_inc((atomic_t *)(v))
-#define atomic_dec_32(v)	atomic_dec((atomic_t *)(v))
-#define atomic_add_32(v, i)	atomic_add((i), (atomic_t *)(v))
-#define atomic_sub_32(v, i)	atomic_sub((i), (atomic_t *)(v))
-#define atomic_inc_32_nv(v)	atomic_inc_return((atomic_t *)(v))
-#define atomic_dec_32_nv(v)	atomic_dec_return((atomic_t *)(v))
-#define atomic_add_32_nv(v, i)	atomic_add_return((i), (atomic_t *)(v))
-#define atomic_sub_32_nv(v, i)	atomic_sub_return((i), (atomic_t *)(v))
-#define atomic_cas_32(v, x, y)	atomic_cmpxchg((atomic_t *)(v), x, y)
-#define atomic_swap_32(v, x)	atomic_xchg((atomic_t *)(v), x)
-#define atomic_inc_64(v)	atomic64_inc((atomic64_t *)(v))
-#define atomic_dec_64(v)	atomic64_dec((atomic64_t *)(v))
-#define atomic_add_64(v, i)	atomic64_add((i), (atomic64_t *)(v))
-#define atomic_sub_64(v, i)	atomic64_sub((i), (atomic64_t *)(v))
-#define atomic_inc_64_nv(v)	atomic64_inc_return((atomic64_t *)(v))
-#define atomic_dec_64_nv(v)	atomic64_dec_return((atomic64_t *)(v))
-#define atomic_add_64_nv(v, i)	atomic64_add_return((i), (atomic64_t *)(v))
-#define atomic_sub_64_nv(v, i)	atomic64_sub_return((i), (atomic64_t *)(v))
-#define atomic_cas_64(v, x, y)	atomic64_cmpxchg((atomic64_t *)(v), x, y)
-#define atomic_swap_64(v, x)	atomic64_xchg((atomic64_t *)(v), x)
+#define	atomic_inc_32(v)	atomic_inc((atomic_t *)(v))
+#define	atomic_dec_32(v)	atomic_dec((atomic_t *)(v))
+#define	atomic_add_32(v, i)	atomic_add((i), (atomic_t *)(v))
+#define	atomic_sub_32(v, i)	atomic_sub((i), (atomic_t *)(v))
+#define	atomic_inc_32_nv(v)	atomic_inc_return((atomic_t *)(v))
+#define	atomic_dec_32_nv(v)	atomic_dec_return((atomic_t *)(v))
+#define	atomic_add_32_nv(v, i)	atomic_add_return((i), (atomic_t *)(v))
+#define	atomic_sub_32_nv(v, i)	atomic_sub_return((i), (atomic_t *)(v))
+#define	atomic_cas_32(v, x, y)	atomic_cmpxchg((atomic_t *)(v), x, y)
+#define	atomic_swap_32(v, x)	atomic_xchg((atomic_t *)(v), x)
+#define	atomic_inc_64(v)	atomic64_inc((atomic64_t *)(v))
+#define	atomic_dec_64(v)	atomic64_dec((atomic64_t *)(v))
+#define	atomic_add_64(v, i)	atomic64_add((i), (atomic64_t *)(v))
+#define	atomic_sub_64(v, i)	atomic64_sub((i), (atomic64_t *)(v))
+#define	atomic_inc_64_nv(v)	atomic64_inc_return((atomic64_t *)(v))
+#define	atomic_dec_64_nv(v)	atomic64_dec_return((atomic64_t *)(v))
+#define	atomic_add_64_nv(v, i)	atomic64_add_return((i), (atomic64_t *)(v))
+#define	atomic_sub_64_nv(v, i)	atomic64_sub_return((i), (atomic64_t *)(v))
+#define	atomic_cas_64(v, x, y)	atomic64_cmpxchg((atomic64_t *)(v), x, y)
+#define	atomic_swap_64(v, x)	atomic64_xchg((atomic64_t *)(v), x)
 
 #endif /* ATOMIC_SPINLOCK */
 
@@ -300,15 +298,15 @@ atomic_swap_64(volatile uint64_t *target,  uint64_t newval)
 static __inline__ void *
 atomic_cas_ptr(volatile void *target,  void *cmp, void *newval)
 {
-	return (void *)atomic_cas_64((volatile uint64_t *)target,
-	                             (uint64_t)cmp, (uint64_t)newval);
+	return ((void *)atomic_cas_64((volatile uint64_t *)target,
+	    (uint64_t)cmp, (uint64_t)newval));
 }
 #else /* _LP64 */
 static __inline__ void *
 atomic_cas_ptr(volatile void *target,  void *cmp, void *newval)
 {
-	return (void *)atomic_cas_32((volatile uint32_t *)target,
-	                             (uint32_t)cmp, (uint32_t)newval);
+	return ((void *)atomic_cas_32((volatile uint32_t *)target,
+	    (uint32_t)cmp, (uint32_t)newval));
 }
 #endif /* _LP64 */
 

--- a/include/sys/attr.h
+++ b/include/sys/attr.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_ATTR_H
-#define _SPL_ATTR_H
+#define	_SPL_ATTR_H
 
 #endif /* SPL_ATTR_H */

--- a/include/sys/bitmap.h
+++ b/include/sys/bitmap.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_BITMAP_H
-#define _SPL_BITMAP_H
+#define	_SPL_BITMAP_H
 
 #endif /* SPL_BITMAP_H */

--- a/include/sys/bootconf.h
+++ b/include/sys/bootconf.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_BOOTCONF_H
-#define _SPL_BOOTCONF_H
+#define	_SPL_BOOTCONF_H
 
 #endif /* SPL_BOOTCONF_H */

--- a/include/sys/bootprops.h
+++ b/include/sys/bootprops.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_BOOTPROPS_H
-#define _SPL_BOOTPROPS_H
+#define	_SPL_BOOTPROPS_H
 
 #endif /* SPL_BOOTPROPS_H */

--- a/include/sys/buf.h
+++ b/include/sys/buf.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_BUF_H
-#define _SPL_BUF_H
+#define	_SPL_BUF_H
 
 #endif /* SPL_BUF_H */

--- a/include/sys/byteorder.h
+++ b/include/sys/byteorder.h
@@ -23,45 +23,49 @@
  */
 
 #ifndef _SPL_BYTEORDER_H
-#define _SPL_BYTEORDER_H
+#define	_SPL_BYTEORDER_H
 
 #include <asm/byteorder.h>
 #include <sys/isa_defs.h>
 
-#define LE_16(x)	cpu_to_le16(x)
-#define LE_32(x)	cpu_to_le32(x)
-#define LE_64(x)	cpu_to_le64(x)
-#define BE_16(x)	cpu_to_be16(x)
-#define BE_32(x)	cpu_to_be32(x)
-#define BE_64(x)	cpu_to_be64(x)
+#define	LE_16(x)	cpu_to_le16(x)
+#define	LE_32(x)	cpu_to_le32(x)
+#define	LE_64(x)	cpu_to_le64(x)
+#define	BE_16(x)	cpu_to_be16(x)
+#define	BE_32(x)	cpu_to_be32(x)
+#define	BE_64(x)	cpu_to_be64(x)
 
-#define BE_IN8(xa) \
+#define	BE_IN8(xa) \
 	*((uint8_t *)(xa))
 
-#define BE_IN16(xa) \
+#define	BE_IN16(xa) \
 	(((uint16_t)BE_IN8(xa) << 8) | BE_IN8((uint8_t *)(xa)+1))
 
-#define BE_IN32(xa) \
+#define	BE_IN32(xa) \
 	(((uint32_t)BE_IN16(xa) << 16) | BE_IN16((uint8_t *)(xa)+2))
 
 #ifdef _BIG_ENDIAN
 static __inline__ uint64_t
-htonll(uint64_t n) {
+htonll(uint64_t n)
+{
 	return (n);
 }
 
 static __inline__ uint64_t
-ntohll(uint64_t n) {
+ntohll(uint64_t n)
+{
 	return (n);
 }
 #else
 static __inline__ uint64_t
-htonll(uint64_t n) {
+htonll(uint64_t n)
+{
 	return ((((uint64_t)htonl(n)) << 32) + htonl(n >> 32));
 }
 
 static __inline__ uint64_t
-ntohll(uint64_t n) {
+ntohll(uint64_t n)
+{
 	return ((((uint64_t)ntohl(n)) << 32) + ntohl(n >> 32));
 }
 #endif

--- a/include/sys/callb.h
+++ b/include/sys/callb.h
@@ -23,33 +23,32 @@
  */
 
 #ifndef _SPL_CALLB_H
-#define _SPL_CALLB_H
+#define	_SPL_CALLB_H
 
 #include <linux/module.h>
 #include <sys/mutex.h>
 
-#define CALLB_CPR_ASSERT(cp)		ASSERT(MUTEX_HELD((cp)->cc_lockp));
+#define	CALLB_CPR_ASSERT(cp)		ASSERT(MUTEX_HELD((cp)->cc_lockp));
 
 typedef struct callb_cpr {
-        kmutex_t        *cc_lockp;
+	kmutex_t	*cc_lockp;
 } callb_cpr_t;
 
-#define CALLB_CPR_INIT(cp, lockp, func, name)   {               \
-        (cp)->cc_lockp = lockp;                                 \
+#define	CALLB_CPR_INIT(cp, lockp, func, name)   {               \
+	(cp)->cc_lockp = lockp;                                 \
 }
 
-#define CALLB_CPR_SAFE_BEGIN(cp) {                              \
+#define	CALLB_CPR_SAFE_BEGIN(cp) {                              \
 	CALLB_CPR_ASSERT(cp);					\
 }
 
-#define CALLB_CPR_SAFE_END(cp, lockp) {                         \
+#define	CALLB_CPR_SAFE_END(cp, lockp) {                         \
 	CALLB_CPR_ASSERT(cp);					\
 }
 
-#define CALLB_CPR_EXIT(cp) {                                    \
-        ASSERT(MUTEX_HELD((cp)->cc_lockp));                     \
-        mutex_exit((cp)->cc_lockp);                             \
+#define	CALLB_CPR_EXIT(cp) {                                    \
+	ASSERT(MUTEX_HELD((cp)->cc_lockp));                     \
+	mutex_exit((cp)->cc_lockp);                             \
 }
 
 #endif  /* _SPL_CALLB_H */
-

--- a/include/sys/callo.h
+++ b/include/sys/callo.h
@@ -22,7 +22,7 @@
  */
 
 #ifndef _SPL_CALLO_H
-#define _SPL_CALLO_H
+#define	_SPL_CALLO_H
 
 /*
  * Callout flags:
@@ -44,9 +44,9 @@
  *      Legacy interfaces timeout() and realtime_timeout() pass this flag
  *      to timeout_generic() to indicate that a 32-bit ID should be allocated.
  */
-#define CALLOUT_FLAG_ROUNDUP            0x1
-#define CALLOUT_FLAG_ABSOLUTE           0x2
-#define CALLOUT_FLAG_HRESTIME           0x4
-#define CALLOUT_FLAG_32BIT              0x8
+#define	CALLOUT_FLAG_ROUNDUP		0x1
+#define	CALLOUT_FLAG_ABSOLUTE		0x2
+#define	CALLOUT_FLAG_HRESTIME		0x4
+#define	CALLOUT_FLAG_32BIT		0x8
 
 #endif  /* _SPL_CALLB_H */

--- a/include/sys/cmn_err.h
+++ b/include/sys/cmn_err.h
@@ -23,20 +23,20 @@
  */
 
 #ifndef _SPL_CMN_ERR_H
-#define _SPL_CMN_ERR_H
+#define	_SPL_CMN_ERR_H
 
 #include <sys/varargs.h>
 
-#define CE_CONT         0       /* continuation         */
-#define CE_NOTE         1       /* notice               */
-#define CE_WARN         2       /* warning              */
-#define CE_PANIC        3       /* panic                */
-#define CE_IGNORE       4       /* print nothing        */
+#define	CE_CONT		0 /* continuation */
+#define	CE_NOTE		1 /* notice */
+#define	CE_WARN		2 /* warning */
+#define	CE_PANIC	3 /* panic */
+#define	CE_IGNORE	4 /* print nothing */
 
 extern void cmn_err(int, const char *, ...);
 extern void vcmn_err(int, const char *, __va_list);
 extern void vpanic(const char *, __va_list);
 
-#define fm_panic	panic
+#define	fm_panic	panic
 
 #endif /* SPL_CMN_ERR_H */

--- a/include/sys/compress.h
+++ b/include/sys/compress.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_COMPRESS_H
-#define _SPL_COMPRESS_H
+#define	_SPL_COMPRESS_H
 
 #endif /* SPL_COMPRESS_H */

--- a/include/sys/conf.h
+++ b/include/sys/conf.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_CONF_H
-#define _SPL_CONF_H
+#define	_SPL_CONF_H
 
 #endif /* SPL_CONF_H */

--- a/include/sys/console.h
+++ b/include/sys/console.h
@@ -28,17 +28,17 @@
 void
 console_vprintf(const char *fmt, va_list args)
 {
-        vprintk(fmt, args);
+	vprintk(fmt, args);
 }
 
 void
 console_printf(const char *fmt, ...)
 {
-        va_list args;
+	va_list args;
 
-        va_start(args, fmt);
-        console_vprintf(fmt, args);
-        va_end(args);
+	va_start(args, fmt);
+	console_vprintf(fmt, args);
+	va_end(args);
 }
 
 #endif /* _SPL_CONSOLE_H */

--- a/include/sys/cpupart.h
+++ b/include/sys/cpupart.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_CPUPART_H
-#define _SPL_CPUPART_H
+#define	_SPL_CPUPART_H
 
 #endif /* SPL_CPUPART_H */

--- a/include/sys/cpuvar.h
+++ b/include/sys/cpuvar.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_CPUVAR_H
-#define _SPL_CPUVAR_H
+#define	_SPL_CPUVAR_H
 
 #endif /* SPL_CPUVAR_H */

--- a/include/sys/crc32.h
+++ b/include/sys/crc32.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_CRC32_H
-#define _SPL_CRC32_H
+#define	_SPL_CRC32_H
 
 #endif /* SPL_CRC32_H */

--- a/include/sys/cred.h
+++ b/include/sys/cred.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_CRED_H
-#define _SPL_CRED_H
+#define	_SPL_CRED_H
 
 #include <linux/module.h>
 #include <sys/types.h>
@@ -68,7 +68,7 @@ extern gid_t crgetrgid(const cred_t *cr);
 extern gid_t crgetsgid(const cred_t *cr);
 extern gid_t crgetfsgid(const cred_t *cr);
 extern int crgetngroups(const cred_t *cr);
-extern gid_t * crgetgroups(const cred_t *cr);
+extern gid_t *crgetgroups(const cred_t *cr);
 extern int groupmember(gid_t gid, const cred_t *cr);
 
 #endif  /* _SPL_CRED_H */

--- a/include/sys/ctype.h
+++ b/include/sys/ctype.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_CTYPE_H
-#define _SPL_CTYPE_H
+#define	_SPL_CTYPE_H
 
 #include <linux/ctype.h>
 

--- a/include/sys/ddi.h
+++ b/include/sys/ddi.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_DDI_H
-#define _SPL_DDI_H
+#define	_SPL_DDI_H
 
 #endif /* SPL_DDI_H */

--- a/include/sys/debug.h
+++ b/include/sys/debug.h
@@ -54,16 +54,17 @@ int spl_panic(const char *file, const char *func, int line,
     const char *fmt, ...);
 void spl_dumpstack(void);
 
+/* BEGIN CSTYLED */
 #define	PANIC(fmt, a...)						\
 	spl_panic(__FILE__, __FUNCTION__, __LINE__, fmt, ## a)
 
 #define	VERIFY(cond)							\
-	(void)(unlikely(!(cond)) &&					\
+	(void) (unlikely(!(cond)) &&					\
 	    spl_panic(__FILE__, __FUNCTION__, __LINE__,			\
 	    "%s", "VERIFY(" #cond ") failed\n"))
 
 #define	VERIFY3_IMPL(LEFT, OP, RIGHT, TYPE, FMT, CAST)			\
-	(void)((!((TYPE)(LEFT) OP (TYPE)(RIGHT))) &&			\
+	(void) ((!((TYPE)(LEFT) OP (TYPE)(RIGHT))) &&			\
 	    spl_panic(__FILE__, __FUNCTION__, __LINE__,			\
 	    "VERIFY3(" #LEFT " " #OP " " #RIGHT ") "			\
 	    "failed (" FMT " " #OP " " FMT ")\n",			\
@@ -120,6 +121,7 @@ void spl_dumpstack(void);
 	((void)((!!(A) == !!(B)) || \
 	    spl_panic(__FILE__, __FUNCTION__, __LINE__, \
 	    "(" #A ") is equivalent to (" #B ")")))
+/* END CSTYLED */
 
 #endif /* NDEBUG */
 

--- a/include/sys/dirent.h
+++ b/include/sys/dirent.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_DIRENT_H
-#define _SPL_DIRENT_H
+#define	_SPL_DIRENT_H
 
 #endif /* SPL_DIRENT_H */

--- a/include/sys/disp.h
+++ b/include/sys/disp.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_DISP_H
-#define _SPL_DISP_H
+#define	_SPL_DISP_H
 
 #include <linux/preempt.h>
 

--- a/include/sys/dkioc_free_util.h
+++ b/include/sys/dkioc_free_util.h
@@ -52,7 +52,7 @@ static inline void dfl_free(dkioc_free_list_t *dfl) {
 }
 
 static inline dkioc_free_list_t *dfl_alloc(uint64_t dfl_num_exts, int flags) {
-	return vmem_zalloc(DFL_SZ(dfl_num_exts), flags);
+	return (vmem_zalloc(DFL_SZ(dfl_num_exts), flags));
 }
 
 #endif /* _SPL_DKIOC_UTIL_H */

--- a/include/sys/dnlc.h
+++ b/include/sys/dnlc.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_DNLC_H
-#define _SPL_DNLC_H
+#define	_SPL_DNLC_H
 
 #endif /* SPL_DNLC_H */

--- a/include/sys/dumphdr.h
+++ b/include/sys/dumphdr.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_DUMPHDR_H
-#define _SPL_DUMPHDR_H
+#define	_SPL_DUMPHDR_H
 
 #endif /* SPL_DUMPHDR_H */

--- a/include/sys/efi_partition.h
+++ b/include/sys/efi_partition.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_EFI_PARTITION_H
-#define _SPL_EFI_PARTITION_H
+#define	_SPL_EFI_PARTITION_H
 
 #endif /* SPL_EFI_PARTITION_H */

--- a/include/sys/errno.h
+++ b/include/sys/errno.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_ERRNO_H
-#define _SPL_ERRNO_H
+#define	_SPL_ERRNO_H
 
 #endif /* SPL_ERRNO_H */

--- a/include/sys/fcntl.h
+++ b/include/sys/fcntl.h
@@ -22,11 +22,11 @@
  */
 
 #ifndef _SPL_FCNTL_H
-#define _SPL_FCNTL_H
+#define	_SPL_FCNTL_H
 
 #include <asm/fcntl.h>
 
-#define F_FREESP 11
+#define	F_FREESP 11
 
 #ifdef CONFIG_64BIT
 typedef struct flock flock64_t;

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_FILE_H
-#define _SPL_FILE_H
+#define	_SPL_FILE_H
 
 #define	FIGNORECASE	0x00080000
 #define	FKIOCTL		0x80000000

--- a/include/sys/fs/swapnode.h
+++ b/include/sys/fs/swapnode.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_SWAPNODE_H
-#define _SPL_SWAPNODE_H
+#define	_SPL_SWAPNODE_H
 
 #endif /* SPL_SWAPNODE_H */

--- a/include/sys/idmap.h
+++ b/include/sys/idmap.h
@@ -22,8 +22,8 @@
  */
 
 #ifndef _SPL_IDMAP_H
-#define _SPL_IDMAP_H
+#define	_SPL_IDMAP_H
 
-#define IDMAP_WK_CREATOR_OWNER_UID	2147483648U
+#define	IDMAP_WK_CREATOR_OWNER_UID	2147483648U
 
 #endif /* SPL_IDMAP_H */

--- a/include/sys/int_limits.h
+++ b/include/sys/int_limits.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_INT_LIMITS_H
-#define _SPL_INT_LIMITS_H
+#define	_SPL_INT_LIMITS_H
 
 #endif /* SPL_INT_LIMITS_H */

--- a/include/sys/int_types.h
+++ b/include/sys/int_types.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_INT_TYPES_H
-#define _SPL_INT_TYPES_H
+#define	_SPL_INT_TYPES_H
 
 #include <sys/inttypes.h>
 

--- a/include/sys/inttypes.h
+++ b/include/sys/inttypes.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_INTTYPES_H
-#define _SPL_INTTYPES_H
+#define	_SPL_INTTYPES_H
 
 #endif /* SPL_INTTYPES_H */

--- a/include/sys/isa_defs.h
+++ b/include/sys/isa_defs.h
@@ -29,59 +29,59 @@
 #if defined(__x86_64) || defined(__x86_64__)
 
 #if !defined(__x86_64)
-#define __x86_64
+#define	__x86_64
 #endif
 
 #if !defined(__amd64)
-#define __amd64
+#define	__amd64
 #endif
 
 #if !defined(__x86)
-#define __x86
+#define	__x86
 #endif
 
 #if !defined(_LP64)
-#define _LP64
+#define	_LP64
 #endif
 
-#define _ALIGNMENT_REQUIRED            1
+#define	_ALIGNMENT_REQUIRED	1
 
 
 /* i386 arch specific defines */
 #elif defined(__i386) || defined(__i386__)
 
 #if !defined(__i386)
-#define __i386
+#define	__i386
 #endif
 
 #if !defined(__x86)
-#define __x86
+#define	__x86
 #endif
 
 #if !defined(_ILP32)
-#define _ILP32
+#define	_ILP32
 #endif
 
-#define _ALIGNMENT_REQUIRED            0
+#define	_ALIGNMENT_REQUIRED	0
 
 /* powerpc (ppc64) arch specific defines */
 #elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__)
 
 #if !defined(__powerpc)
-#define __powerpc
+#define	__powerpc
 #endif
 
 #if !defined(__powerpc__)
-#define __powerpc__
+#define	__powerpc__
 #endif
 
 #if defined(__powerpc64__)
 #if !defined(_LP64)
-#define _LP64
+#define	_LP64
 #endif
 #else
 #if !defined(_ILP32)
-#define _ILP32
+#define	_ILP32
 #endif
 #endif
 
@@ -89,65 +89,65 @@
  * Illumos doesn't define _ALIGNMENT_REQUIRED for PPC, so default to 1
  * out of paranoia.
  */
-#define _ALIGNMENT_REQUIRED            1
+#define	_ALIGNMENT_REQUIRED	1
 
 /* arm arch specific defines */
 #elif defined(__arm) || defined(__arm__) || defined(__aarch64__)
 
 #if !defined(__arm)
-#define __arm
+#define	__arm
 #endif
 
 #if !defined(__arm__)
-#define __arm__
+#define	__arm__
 #endif
 
 #if defined(__aarch64__)
 #if !defined(_LP64)
-#define _LP64
+#define	_LP64
 #endif
 #else
 #if !defined(_ILP32)
-#define _ILP32
+#define	_ILP32
 #endif
 #endif
 
 #if defined(__ARMEL__) || defined(__AARCH64EL__)
-#define _LITTLE_ENDIAN
+#define	_LITTLE_ENDIAN
 #else
-#define _BIG_ENDIAN
+#define	_BIG_ENDIAN
 #endif
 
 /*
  * Illumos doesn't define _ALIGNMENT_REQUIRED for ARM, so default to 1
  * out of paranoia.
  */
-#define _ALIGNMENT_REQUIRED            1
+#define	_ALIGNMENT_REQUIRED	1
 
 /* sparc arch specific defines */
 #elif defined(__sparc) || defined(__sparc__)
 
 #if !defined(__sparc)
-#define __sparc
+#define	__sparc
 #endif
 
 #if !defined(__sparc__)
-#define __sparc__
+#define	__sparc__
 #endif
 
 #if defined(__arch64__)
 #if !defined(_LP64)
-#define _LP64
+#define	_LP64
 #endif
 #else
 #if !defined(_ILP32)
-#define _ILP32
+#define	_ILP32
 #endif
 #endif
 
-#define _BIG_ENDIAN
-#define _SUNOS_VTOC_16
-#define _ALIGNMENT_REQUIRED            1
+#define	_BIG_ENDIAN
+#define	_SUNOS_VTOC_16
+#define	_ALIGNMENT_REQUIRED	1
 
 /* s390 arch specific defines */
 #elif defined(__s390__)
@@ -167,7 +167,7 @@
  * Illumos doesn't define _ALIGNMENT_REQUIRED for s390, so default to 1
  * out of paranoia.
  */
-#define _ALIGNMENT_REQUIRED            1
+#define	_ALIGNMENT_REQUIRED	1
 
 /* MIPS arch specific defines */
 #elif defined(__mips__)
@@ -190,7 +190,7 @@
  * Illumos doesn't define _ALIGNMENT_REQUIRED for MIPS, so default to 1
  * out of paranoia.
  */
-#define _ALIGNMENT_REQUIRED            1
+#define	_ALIGNMENT_REQUIRED	1
 
 #else
 /*
@@ -211,11 +211,11 @@
 #include <sys/byteorder.h>
 
 #if defined(__LITTLE_ENDIAN) && !defined(_LITTLE_ENDIAN)
-#define _LITTLE_ENDIAN __LITTLE_ENDIAN
+#define	_LITTLE_ENDIAN __LITTLE_ENDIAN
 #endif
 
 #if defined(__BIG_ENDIAN) && !defined(_BIG_ENDIAN)
-#define _BIG_ENDIAN __BIG_ENDIAN
+#define	_BIG_ENDIAN __BIG_ENDIAN
 #endif
 
 #if defined(_LITTLE_ENDIAN) && defined(_BIG_ENDIAN)

--- a/include/sys/kidmap.h
+++ b/include/sys/kidmap.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_KIDMAP_H
-#define _SPL_KIDMAP_H
+#define	_SPL_KIDMAP_H
 
 #include <sys/idmap.h>
 

--- a/include/sys/kobj.h
+++ b/include/sys/kobj.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_KOBJ_H
-#define _SPL_KOBJ_H
+#define	_SPL_KOBJ_H
 
 #include <sys/vnode.h>
 

--- a/include/sys/kstat.h
+++ b/include/sys/kstat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_KSTAT_H
-#define _SPL_KSTAT_H
+#define	_SPL_KSTAT_H
 
 #include <linux/module.h>
 #include <linux/proc_compat.h>
@@ -32,63 +32,65 @@
 #include <sys/kmem.h>
 #include <sys/mutex.h>
 
-#define KSTAT_STRLEN            255
-#define KSTAT_RAW_MAX		(128*1024)
+#define	KSTAT_STRLEN		255
+#define	KSTAT_RAW_MAX		(128*1024)
 
-/* For reference valid classes are:
+/*
+ * For reference valid classes are:
  * disk, tape, net, controller, vm, kvm, hat, streams, kstat, misc
  */
 
-#define KSTAT_TYPE_RAW          0       /* can be anything; ks_ndata >= 1 */
-#define KSTAT_TYPE_NAMED        1       /* name/value pair; ks_ndata >= 1 */
-#define KSTAT_TYPE_INTR         2       /* interrupt stats; ks_ndata == 1 */
-#define KSTAT_TYPE_IO           3       /* I/O stats; ks_ndata == 1 */
-#define KSTAT_TYPE_TIMER        4       /* event timer; ks_ndata >= 1 */
-#define KSTAT_NUM_TYPES         5
+#define	KSTAT_TYPE_RAW		0 /* can be anything; ks_ndata >= 1 */
+#define	KSTAT_TYPE_NAMED	1 /* name/value pair; ks_ndata >= 1 */
+#define	KSTAT_TYPE_INTR		2 /* interrupt stats; ks_ndata == 1 */
+#define	KSTAT_TYPE_IO		3 /* I/O stats; ks_ndata == 1 */
+#define	KSTAT_TYPE_TIMER	4 /* event timer; ks_ndata >= 1 */
+#define	KSTAT_NUM_TYPES		5
 
-#define KSTAT_DATA_CHAR         0
-#define KSTAT_DATA_INT32        1
-#define KSTAT_DATA_UINT32       2
-#define KSTAT_DATA_INT64        3
-#define KSTAT_DATA_UINT64       4
-#define KSTAT_DATA_LONG         5
-#define KSTAT_DATA_ULONG        6
-#define KSTAT_DATA_STRING       7
-#define KSTAT_NUM_DATAS         8
+#define	KSTAT_DATA_CHAR		0
+#define	KSTAT_DATA_INT32	1
+#define	KSTAT_DATA_UINT32	2
+#define	KSTAT_DATA_INT64	3
+#define	KSTAT_DATA_UINT64	4
+#define	KSTAT_DATA_LONG		5
+#define	KSTAT_DATA_ULONG	6
+#define	KSTAT_DATA_STRING	7
+#define	KSTAT_NUM_DATAS		8
 
-#define KSTAT_INTR_HARD         0
-#define KSTAT_INTR_SOFT         1
-#define KSTAT_INTR_WATCHDOG     2
-#define KSTAT_INTR_SPURIOUS     3
-#define KSTAT_INTR_MULTSVC      4
-#define KSTAT_NUM_INTRS         5
+#define	KSTAT_INTR_HARD		0
+#define	KSTAT_INTR_SOFT		1
+#define	KSTAT_INTR_WATCHDOG	2
+#define	KSTAT_INTR_SPURIOUS	3
+#define	KSTAT_INTR_MULTSVC	4
+#define	KSTAT_NUM_INTRS		5
 
-#define KSTAT_FLAG_VIRTUAL      0x01
-#define KSTAT_FLAG_VAR_SIZE     0x02
-#define KSTAT_FLAG_WRITABLE     0x04
-#define KSTAT_FLAG_PERSISTENT   0x08
-#define KSTAT_FLAG_DORMANT      0x10
-#define KSTAT_FLAG_UNSUPPORTED  (KSTAT_FLAG_VAR_SIZE | KSTAT_FLAG_WRITABLE | \
-				 KSTAT_FLAG_PERSISTENT | KSTAT_FLAG_DORMANT)
+#define	KSTAT_FLAG_VIRTUAL	0x01
+#define	KSTAT_FLAG_VAR_SIZE	0x02
+#define	KSTAT_FLAG_WRITABLE	0x04
+#define	KSTAT_FLAG_PERSISTENT	0x08
+#define	KSTAT_FLAG_DORMANT	0x10
+#define	KSTAT_FLAG_UNSUPPORTED	\
+	(KSTAT_FLAG_VAR_SIZE | KSTAT_FLAG_WRITABLE | \
+	KSTAT_FLAG_PERSISTENT | KSTAT_FLAG_DORMANT)
 
 
-#define KS_MAGIC                0x9d9d9d9d
+#define	KS_MAGIC		0x9d9d9d9d
 
 /* Dynamic updates */
-#define KSTAT_READ              0
-#define KSTAT_WRITE             1
+#define	KSTAT_READ		0
+#define	KSTAT_WRITE		1
 
 struct kstat_s;
 typedef struct kstat_s kstat_t;
 
-typedef int kid_t;                                  /* unique kstat id */
-typedef int kstat_update_t(struct kstat_s *, int);  /* dynamic update cb */
+typedef int kid_t;				/* unique kstat id */
+typedef int kstat_update_t(struct kstat_s *, int); /* dynamic update cb */
 
 typedef struct kstat_module {
-	char             ksm_name[KSTAT_STRLEN+1];  /* module name */
-	struct list_head ksm_module_list;           /* module linkage */
-	struct list_head ksm_kstat_list;            /* list of kstat entries */
-	struct proc_dir_entry *ksm_proc;            /* proc entry */
+	char ksm_name[KSTAT_STRLEN+1];		/* module name */
+	struct list_head ksm_module_list;	/* module linkage */
+	struct list_head ksm_kstat_list;	/* list of kstat entries */
+	struct proc_dir_entry *ksm_proc;	/* proc entry */
 } kstat_module_t;
 
 typedef struct kstat_raw_ops {
@@ -98,95 +100,96 @@ typedef struct kstat_raw_ops {
 } kstat_raw_ops_t;
 
 struct kstat_s {
-	int              ks_magic;                  /* magic value */
-        kid_t            ks_kid;                    /* unique kstat ID */
-        hrtime_t         ks_crtime;                 /* creation time */
-	hrtime_t         ks_snaptime;               /* last access time */
-        char             ks_module[KSTAT_STRLEN+1]; /* provider module name */
-        int              ks_instance;               /* provider module instance */
-        char             ks_name[KSTAT_STRLEN+1];   /* kstat name */
-        char             ks_class[KSTAT_STRLEN+1];  /* kstat class */
-        uchar_t          ks_type;                   /* kstat data type */
-        uchar_t          ks_flags;                  /* kstat flags */
-        void             *ks_data;                  /* kstat type-specific data */
-        uint_t           ks_ndata;                  /* # of type-specific data records */
-        size_t           ks_data_size;              /* size of kstat data section */
-        struct proc_dir_entry *ks_proc;             /* proc linkage */
-        kstat_update_t   *ks_update;                /* dynamic updates */
-        void             *ks_private;               /* private data */
-	kmutex_t         ks_private_lock;           /* kstat private data lock */
-	kmutex_t         *ks_lock;                  /* kstat data lock */
-        struct list_head ks_list;                   /* kstat linkage */
-	kstat_module_t   *ks_owner;                 /* kstat module linkage */
-	kstat_raw_ops_t  ks_raw_ops;                /* ops table for raw type */
-	char             *ks_raw_buf;               /* buf used for raw ops */
-	size_t           ks_raw_bufsize;            /* size of raw ops buffer */
+	int		ks_magic;		/* magic value */
+	kid_t		ks_kid;			/* unique kstat ID */
+	hrtime_t	ks_crtime;		/* creation time */
+	hrtime_t	ks_snaptime;		/* last access time */
+	char		ks_module[KSTAT_STRLEN+1]; /* provider module name */
+	int		ks_instance;		/* provider module instance */
+	char		ks_name[KSTAT_STRLEN+1]; /* kstat name */
+	char		ks_class[KSTAT_STRLEN+1]; /* kstat class */
+	uchar_t		ks_type;		/* kstat data type */
+	uchar_t		ks_flags;		/* kstat flags */
+	void		*ks_data;		/* kstat type-specific data */
+	uint_t		ks_ndata;		/* # of data records */
+	size_t		ks_data_size;		/* size of kstat data section */
+	struct proc_dir_entry *ks_proc;		/* proc linkage */
+	kstat_update_t	*ks_update;		/* dynamic updates */
+	void		*ks_private;		/* private data */
+	kmutex_t	ks_private_lock;	/* kstat private data lock */
+	kmutex_t	*ks_lock;		/* kstat data lock */
+	struct list_head ks_list;		/* kstat linkage */
+	kstat_module_t	*ks_owner;		/* kstat module linkage */
+	kstat_raw_ops_t	ks_raw_ops;		/* ops table for raw type */
+	char		*ks_raw_buf;		/* buf used for raw ops */
+	size_t		ks_raw_bufsize;		/* size of raw ops buffer */
 };
 
 typedef struct kstat_named_s {
-        char             name[KSTAT_STRLEN];        /* name of counter */
-        uchar_t          data_type;                 /* data type */
-        union {
-                char            c[16];              /* 128-bit int */
-                int32_t         i32;                /* 32-bit signed int */
-                uint32_t        ui32;               /* 32-bit unsigned int */
-                int64_t         i64;                /* 64-bit signed int */
-                uint64_t        ui64;               /* 64-bit unsigned int */
-                long            l;                  /* native signed long */
-                ulong_t         ul;                 /* native unsigned long */
-                struct {
-                        union {
-                                char *ptr;          /* NULL-term string */
-                                char __pad[8];      /* 64-bit padding */
-                        } addr;
-                        uint32_t len;               /* # bytes for strlen + '\0' */
-                } string;
-        } value;
+	char	name[KSTAT_STRLEN];	/* name of counter */
+	uchar_t	data_type;		/* data type */
+	union {
+		char c[16];	/* 128-bit int */
+		int32_t	i32;	/* 32-bit signed int */
+		uint32_t ui32;	/* 32-bit unsigned int */
+		int64_t i64;	/* 64-bit signed int */
+		uint64_t ui64;	/* 64-bit unsigned int */
+		long l;		/* native signed long */
+		ulong_t ul;	/* native unsigned long */
+		struct {
+			union {
+				char *ptr;	/* NULL-term string */
+				char __pad[8];	/* 64-bit padding */
+			} addr;
+			uint32_t len;		/* # bytes for strlen + '\0' */
+		} string;
+	} value;
 } kstat_named_t;
 
-#define KSTAT_NAMED_STR_PTR(knptr) ((knptr)->value.string.addr.ptr)
-#define KSTAT_NAMED_STR_BUFLEN(knptr) ((knptr)->value.string.len)
+#define	KSTAT_NAMED_STR_PTR(knptr) ((knptr)->value.string.addr.ptr)
+#define	KSTAT_NAMED_STR_BUFLEN(knptr) ((knptr)->value.string.len)
 
 typedef struct kstat_intr {
-        uint_t intrs[KSTAT_NUM_INTRS];
+	uint_t intrs[KSTAT_NUM_INTRS];
 } kstat_intr_t;
 
 typedef struct kstat_io {
-        u_longlong_t     nread;       /* number of bytes read */
-        u_longlong_t     nwritten;    /* number of bytes written */
-        uint_t           reads;       /* number of read operations */
-        uint_t           writes;      /* number of write operations */
-        hrtime_t         wtime;       /* cumulative wait (pre-service) time */
-        hrtime_t         wlentime;    /* cumulative wait length*time product*/
-        hrtime_t         wlastupdate; /* last time wait queue changed */
-        hrtime_t         rtime;       /* cumulative run (service) time */
-        hrtime_t         rlentime;    /* cumulative run length*time product */
-        hrtime_t         rlastupdate; /* last time run queue changed */
-        uint_t           wcnt;        /* count of elements in wait state */
-        uint_t           rcnt;        /* count of elements in run state */
+	u_longlong_t	nread;		/* number of bytes read */
+	u_longlong_t	nwritten;	/* number of bytes written */
+	uint_t		reads;		/* number of read operations */
+	uint_t		writes;		/* number of write operations */
+	hrtime_t	wtime;		/* cumulative wait (pre-service) time */
+	hrtime_t	wlentime;	/* cumulative wait len*time product */
+	hrtime_t	wlastupdate;	/* last time wait queue changed */
+	hrtime_t	rtime;		/* cumulative run (service) time */
+	hrtime_t	rlentime;	/* cumulative run length*time product */
+	hrtime_t	rlastupdate;	/* last time run queue changed */
+	uint_t		wcnt;		/* count of elements in wait state */
+	uint_t		rcnt;		/* count of elements in run state */
 } kstat_io_t;
 
 typedef struct kstat_timer {
-        char         name[KSTAT_STRLEN+1]; /* event name */
-        u_longlong_t num_events;           /* number of events */
-        hrtime_t     elapsed_time;         /* cumulative elapsed time */
-        hrtime_t     min_time;             /* shortest event duration */
-        hrtime_t     max_time;             /* longest event duration */
-        hrtime_t     start_time;           /* previous event start time */
-        hrtime_t     stop_time;            /* previous event stop time */
+	char		name[KSTAT_STRLEN+1]; /* event name */
+	u_longlong_t	num_events;	 /* number of events */
+	hrtime_t	elapsed_time;	 /* cumulative elapsed time */
+	hrtime_t	min_time;	 /* shortest event duration */
+	hrtime_t	max_time;	 /* longest event duration */
+	hrtime_t	start_time;	 /* previous event start time */
+	hrtime_t	stop_time;	 /* previous event stop time */
 } kstat_timer_t;
 
 int spl_kstat_init(void);
 void spl_kstat_fini(void);
 
 extern void __kstat_set_raw_ops(kstat_t *ksp,
-		    int (*headers)(char *buf, size_t size),
-		    int (*data)(char *buf, size_t size, void *data),
-		    void* (*addr)(kstat_t *ksp, loff_t index));
+    int (*headers)(char *buf, size_t size),
+    int (*data)(char *buf, size_t size, void *data),
+    void* (*addr)(kstat_t *ksp, loff_t index));
+
 extern kstat_t *__kstat_create(const char *ks_module, int ks_instance,
-			     const char *ks_name, const char *ks_class,
-			     uchar_t ks_type, uint_t ks_ndata,
-			     uchar_t ks_flags);
+    const char *ks_name, const char *ks_class, uchar_t ks_type,
+    uint_t ks_ndata, uchar_t ks_flags);
+
 extern void __kstat_install(kstat_t *ksp);
 extern void __kstat_delete(kstat_t *ksp);
 extern void kstat_waitq_enter(kstat_io_t *);
@@ -194,9 +197,12 @@ extern void kstat_waitq_exit(kstat_io_t *);
 extern void kstat_runq_enter(kstat_io_t *);
 extern void kstat_runq_exit(kstat_io_t *);
 
-#define kstat_set_raw_ops(k,h,d,a)	__kstat_set_raw_ops(k,h,d,a)
-#define kstat_create(m,i,n,c,t,s,f)	__kstat_create(m,i,n,c,t,s,f)
-#define kstat_install(k)		__kstat_install(k)
-#define kstat_delete(k)			__kstat_delete(k)
+#define	kstat_set_raw_ops(k, h, d, a) \
+    __kstat_set_raw_ops(k, h, d, a)
+#define	kstat_create(m, i, n, c, t, s, f) \
+    __kstat_create(m, i, n, c, t, s, f)
+
+#define	kstat_install(k)		__kstat_install(k)
+#define	kstat_delete(k)			__kstat_delete(k)
 
 #endif  /* _SPL_KSTAT_H */

--- a/include/sys/list.h
+++ b/include/sys/list.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_LIST_H
-#define _SPL_LIST_H
+#define	_SPL_LIST_H
 
 #include <sys/types.h>
 #include <linux/list.h>
@@ -53,13 +53,13 @@ typedef struct list {
 	list_node_t list_head;
 } list_t;
 
-#define list_d2l(a, obj) ((list_node_t *)(((char *)obj) + (a)->list_offset))
-#define list_object(a, node) ((void *)(((char *)node) - (a)->list_offset))
+#define	list_d2l(a, obj) ((list_node_t *)(((char *)obj) + (a)->list_offset))
+#define	list_object(a, node) ((void *)(((char *)node) - (a)->list_offset))
 
 static inline int
 list_is_empty(list_t *list)
 {
-	return list_empty(&list->list_head);
+	return (list_empty(&list->list_head));
 }
 
 static inline void
@@ -74,7 +74,7 @@ list_create(list_t *list, size_t size, size_t offset)
 {
 	ASSERT(list);
 	ASSERT(size > 0);
-	ASSERT(size >= offset + sizeof(list_node_t));
+	ASSERT(size >= offset + sizeof (list_node_t));
 
 	list->list_size = size;
 	list->list_offset = offset;
@@ -132,10 +132,10 @@ list_remove_head(list_t *list)
 {
 	list_node_t *head = list->list_head.next;
 	if (head == &list->list_head)
-		return NULL;
+		return (NULL);
 
 	list_del(head);
-	return list_object(list, head);
+	return (list_object(list, head));
 }
 
 static inline void *
@@ -143,28 +143,28 @@ list_remove_tail(list_t *list)
 {
 	list_node_t *tail = list->list_head.prev;
 	if (tail == &list->list_head)
-		return NULL;
+		return (NULL);
 
 	list_del(tail);
-	return list_object(list, tail);
+	return (list_object(list, tail));
 }
 
 static inline void *
 list_head(list_t *list)
 {
 	if (list_is_empty(list))
-		return NULL;
+		return (NULL);
 
-	return list_object(list, list->list_head.next);
+	return (list_object(list, list->list_head.next));
 }
 
 static inline void *
 list_tail(list_t *list)
 {
 	if (list_is_empty(list))
-		return NULL;
+		return (NULL);
 
-	return list_object(list, list->list_head.prev);
+	return (list_object(list, list->list_head.prev));
 }
 
 static inline void *
@@ -173,9 +173,9 @@ list_next(list_t *list, void *object)
 	list_node_t *node = list_d2l(list, object);
 
 	if (node->next != &list->list_head)
-		return list_object(list, node->next);
+		return (list_object(list, node->next));
 
-	return NULL;
+	return (NULL);
 }
 
 static inline void *
@@ -184,9 +184,9 @@ list_prev(list_t *list, void *object)
 	list_node_t *node = list_d2l(list, object);
 
 	if (node->prev != &list->list_head)
-		return list_object(list, node->prev);
+		return (list_object(list, node->prev));
 
-	return NULL;
+	return (NULL);
 }
 
 static inline int
@@ -201,7 +201,7 @@ spl_list_move_tail(list_t *dst, list_t *src)
 	list_splice_init(&src->list_head, dst->list_head.prev);
 }
 
-#define list_move_tail(dst, src)	spl_list_move_tail(dst, src)
+#define	list_move_tail(dst, src)	spl_list_move_tail(dst, src)
 
 static inline void
 list_link_replace(list_node_t *old_node, list_node_t *new_node)

--- a/include/sys/mkdev.h
+++ b/include/sys/mkdev.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_MKDEV_H
-#define _SPL_MKDEV_H
+#define	_SPL_MKDEV_H
 
 #endif /* SPL_MKDEV_H */

--- a/include/sys/mntent.h
+++ b/include/sys/mntent.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_MNTENT_H
-#define _SPL_MNTENT_H
+#define	_SPL_MNTENT_H
 
 #endif /* SPL_MNTENT_H */

--- a/include/sys/modctl.h
+++ b/include/sys/modctl.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_MODCTL_H
-#define _SPL_MODCTL_H
+#define	_SPL_MODCTL_H
 
 #endif /* SPL_MODCTL_H */

--- a/include/sys/mode.h
+++ b/include/sys/mode.h
@@ -23,10 +23,10 @@
  */
 
 #ifndef _SPL_MODE_H
-#define _SPL_MODE_H
+#define	_SPL_MODE_H
 
-#define IFTOVT(mode)	vn_mode_to_vtype(mode)
-#define VTTOIF(vtype)	vn_vtype_to_mode(vtype)
-#define MAKEIMODE(T, M) (VTTOIF(T) | ((M) & ~S_IFMT))
+#define	IFTOVT(mode)	vn_mode_to_vtype(mode)
+#define	VTTOIF(vtype)	vn_vtype_to_mode(vtype)
+#define	MAKEIMODE(T, M) (VTTOIF(T) | ((M) & ~S_IFMT))
 
 #endif /* SPL_MODE_H */

--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_MOUNT_H
-#define _SPL_MOUNT_H
+#define	_SPL_MOUNT_H
 
 #endif /* SPL_MOUNT_H */

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -84,13 +84,13 @@ spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
 		lockdep_on();					\
 }
 #else  /* CONFIG_LOCKDEP */
-#define spl_mutex_set_type(mp, type)
-#define spl_mutex_lockdep_off_maybe(mp)
-#define spl_mutex_lockdep_on_maybe(mp)
+#define	spl_mutex_set_type(mp, type)
+#define	spl_mutex_lockdep_off_maybe(mp)
+#define	spl_mutex_lockdep_on_maybe(mp)
 #endif /* CONFIG_LOCKDEP */
 
 /*
- * The following functions must be a #define and not static inline.
+ * The following functions must be a #define	and not static inline.
  * This ensures that the native linux mutex functions (lock/unlock)
  * will be correctly located in the users code which is important
  * for the built in kernel lock analysis tools
@@ -113,6 +113,7 @@ spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
 	VERIFY3P(mutex_owner(mp), ==, NULL);			\
 }
 
+/* BEGIN CSTYLED */
 #define	mutex_tryenter(mp)					\
 ({								\
 	int _rc_;						\
@@ -124,6 +125,7 @@ spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
 								\
 	_rc_;							\
 })
+/* END CSTYLED */
 
 #ifdef CONFIG_DEBUG_LOCK_ALLOC
 #define	mutex_enter_nested(mp, subclass)			\

--- a/include/sys/note.h
+++ b/include/sys/note.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_NOTE_H
-#define _SPL_NOTE_H
+#define	_SPL_NOTE_H
 
 #endif /* SPL_NOTE_H */

--- a/include/sys/open.h
+++ b/include/sys/open.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_OPEN_H
-#define _SPL_OPEN_H
+#define	_SPL_OPEN_H
 
 #endif /* SPL_OPEN_H */

--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -23,14 +23,14 @@
  */
 
 #ifndef _SPL_PARAM_H
-#define _SPL_PARAM_H
+#define	_SPL_PARAM_H
 
 #include <asm/page.h>
 
 /* Pages to bytes and back */
-#define ptob(pages)			((pages) << PAGE_SHIFT)
-#define btop(bytes)			((bytes) >> PAGE_SHIFT)
+#define	ptob(pages)			((pages) << PAGE_SHIFT)
+#define	btop(bytes)			((bytes) >> PAGE_SHIFT)
 
-#define MAXUID				UINT32_MAX
+#define	MAXUID				UINT32_MAX
 
 #endif /* SPL_PARAM_H */

--- a/include/sys/pathname.h
+++ b/include/sys/pathname.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_PATHNAME_H
-#define _SPL_PATHNAME_H
+#define	_SPL_PATHNAME_H
 
 typedef struct pathname {
 	char	*pn_buf;		/* underlying storage */

--- a/include/sys/policy.h
+++ b/include/sys/policy.h
@@ -23,25 +23,25 @@
  */
 
 #ifndef _SPL_POLICY_H
-#define _SPL_POLICY_H
+#define	_SPL_POLICY_H
 
-#define	secpolicy_fs_unmount(c,vfs)			(0)
+#define	secpolicy_fs_unmount(c, vfs)			(0)
 #define	secpolicy_nfs(c)				(0)
-#define	secpolicy_sys_config(c,co)			(0)
+#define	secpolicy_sys_config(c, co)			(0)
 #define	secpolicy_zfs(c)				(0)
 #define	secpolicy_zinject(c)				(0)
-#define	secpolicy_vnode_setids_setgids(c,id)		(0)
+#define	secpolicy_vnode_setids_setgids(c, id)		(0)
 #define	secpolicy_vnode_setid_retain(c, sr)		(0)
 #define	secpolicy_setid_clear(v, c)			(0)
-#define	secpolicy_vnode_any_access(c,vp,o)		(0)
-#define	secpolicy_vnode_access2(c,cp,o,m1,m2)		(0)
-#define	secpolicy_vnode_chown(c,o)			(0)
-#define	secpolicy_vnode_setdac(c,o)			(0)
+#define	secpolicy_vnode_any_access(c, vp, o)		(0)
+#define	secpolicy_vnode_access2(c, cp, o, m1, m2)	(0)
+#define	secpolicy_vnode_chown(c, o)			(0)
+#define	secpolicy_vnode_setdac(c, o)			(0)
 #define	secpolicy_vnode_remove(c)			(0)
-#define	secpolicy_vnode_setattr(c,v,a,o,f,func,n)	(0)
+#define	secpolicy_vnode_setattr(c, v, a, o, f, func, n)	(0)
 #define	secpolicy_xvattr(x, o, c, t)			(0)
 #define	secpolicy_vnode_stky_modify(c)			(0)
-#define	secpolicy_setid_setsticky_clear(v,a,o,c)	(0)
+#define	secpolicy_setid_setsticky_clear(v, a, o, c)	(0)
 #define	secpolicy_basic_link(c)				(0)
 
 #endif /* SPL_POLICY_H */

--- a/include/sys/pool.h
+++ b/include/sys/pool.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_POOL_H
-#define _SPL_POOL_H
+#define	_SPL_POOL_H
 
 #include <sys/pset.h>
 

--- a/include/sys/priv_impl.h
+++ b/include/sys/priv_impl.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_PRIV_IMPL_H
-#define _SPL_PRIV_IMPL_H
+#define	_SPL_PRIV_IMPL_H
 
 #endif /* _SPL_PRIV_IMPL_H */

--- a/include/sys/proc.h
+++ b/include/sys/proc.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_PROC_H
-#define _SPL_PROC_H
+#define	_SPL_PROC_H
 
 #endif /* SPL_PROC_H */

--- a/include/sys/processor.h
+++ b/include/sys/processor.h
@@ -25,7 +25,7 @@
 #ifndef	_SPL_PROCESSOR_H
 #define	_SPL_PROCESSOR_H
 
-#define getcpuid() smp_processor_id()
+#define	getcpuid() smp_processor_id()
 
 typedef int	processorid_t;
 

--- a/include/sys/pset.h
+++ b/include/sys/pset.h
@@ -23,16 +23,16 @@
  */
 
 #ifndef _SPL_PSET_H
-#define _SPL_PSET_H
+#define	_SPL_PSET_H
 
 typedef int psetid_t;
 
 /* special processor set id's */
-#define PS_NONE         -1
-#define PS_QUERY        -2
-#define PS_MYID         -3
-#define PS_SOFT         -4
-#define PS_HARD         -5
-#define PS_QUERY_TYPE   -6
+#define	PS_NONE		-1
+#define	PS_QUERY	-2
+#define	PS_MYID		-3
+#define	PS_SOFT		-4
+#define	PS_HARD		-5
+#define	PS_QUERY_TYPE	-6
 
 #endif /* SPL_PSET_H */

--- a/include/sys/random.h
+++ b/include/sys/random.h
@@ -31,8 +31,8 @@
 static __inline__ int
 random_get_bytes(uint8_t *ptr, size_t len)
 {
-	get_random_bytes((void *)ptr,(int)len);
-	return 0;
+	get_random_bytes((void *)ptr, (int)len);
+	return (0);
 }
 
 extern int random_get_pseudo_bytes(uint8_t *ptr, size_t len);

--- a/include/sys/refstr.h
+++ b/include/sys/refstr.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_REFSTR_H
-#define _SPL_REFSTR_H
+#define	_SPL_REFSTR_H
 
 #endif /* SPL_REFSTR_H */

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_RESOURCE_H
-#define _SPL_RESOURCE_H
+#define	_SPL_RESOURCE_H
 
 #include <linux/resource.h>
 

--- a/include/sys/rwlock.h
+++ b/include/sys/rwlock.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_RWLOCK_H
-#define _SPL_RWLOCK_H
+#define	_SPL_RWLOCK_H
 
 #include <sys/types.h>
 #include <linux/rwsem.h>
@@ -55,7 +55,7 @@ typedef struct {
 #endif /* CONFIG_LOCKDEP */
 } krwlock_t;
 
-#define SEM(rwp)	(&(rwp)->rw_rwlock)
+#define	SEM(rwp)	(&(rwp)->rw_rwlock)
 
 static inline void
 spl_rw_set_owner(krwlock_t *rwp)
@@ -81,9 +81,9 @@ static inline kthread_t *
 rw_owner(krwlock_t *rwp)
 {
 #ifdef CONFIG_RWSEM_SPIN_ON_OWNER
-	return SEM(rwp)->owner;
+	return (SEM(rwp)->owner);
 #else
-	return rwp->rw_owner;
+	return (rwp->rw_owner);
 #endif
 }
 
@@ -106,9 +106,9 @@ spl_rw_lockdep_on_maybe(krwlock_t *rwp)			\
 		lockdep_on();				\
 }
 #else  /* CONFIG_LOCKDEP */
-#define spl_rw_set_type(rwp, type)
-#define spl_rw_lockdep_off_maybe(rwp)
-#define spl_rw_lockdep_on_maybe(rwp)
+#define	spl_rw_set_type(rwp, type)
+#define	spl_rw_lockdep_off_maybe(rwp)
+#define	spl_rw_lockdep_on_maybe(rwp)
 #endif /* CONFIG_LOCKDEP */
 
 static inline int
@@ -131,16 +131,17 @@ RW_WRITE_HELD(krwlock_t *rwp)
 static inline int
 RW_LOCK_HELD(krwlock_t *rwp)
 {
-	return spl_rwsem_is_locked(SEM(rwp));
+	return (spl_rwsem_is_locked(SEM(rwp)));
 }
 
 /*
- * The following functions must be a #define and not static inline.
+ * The following functions must be a #define	and not static inline.
  * This ensures that the native linux semaphore functions (down/up)
  * will be correctly located in the users code which is important
  * for the built in kernel lock analysis tools
  */
-#define rw_init(rwp, name, type, arg)					\
+/* BEGIN CSTYLED */
+#define	rw_init(rwp, name, type, arg)					\
 ({									\
 	static struct lock_class_key __key;				\
 	ASSERT(type == RW_DEFAULT || type == RW_NOLOCKDEP);		\
@@ -150,12 +151,12 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	spl_rw_set_type(rwp, type);					\
 })
 
-#define rw_destroy(rwp)							\
+#define	rw_destroy(rwp)							\
 ({									\
 	VERIFY(!RW_LOCK_HELD(rwp));					\
 })
 
-#define rw_tryenter(rwp, rw)						\
+#define	rw_tryenter(rwp, rw)						\
 ({									\
 	int _rc_ = 0;							\
 									\
@@ -175,7 +176,7 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	_rc_;								\
 })
 
-#define rw_enter(rwp, rw)						\
+#define	rw_enter(rwp, rw)						\
 ({									\
 	spl_rw_lockdep_off_maybe(rwp);					\
 	switch (rw) {							\
@@ -192,7 +193,7 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	spl_rw_lockdep_on_maybe(rwp);					\
 })
 
-#define rw_exit(rwp)							\
+#define	rw_exit(rwp)							\
 ({									\
 	spl_rw_lockdep_off_maybe(rwp);					\
 	if (RW_WRITE_HELD(rwp)) {					\
@@ -205,7 +206,7 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	spl_rw_lockdep_on_maybe(rwp);					\
 })
 
-#define rw_downgrade(rwp)						\
+#define	rw_downgrade(rwp)						\
 ({									\
 	spl_rw_lockdep_off_maybe(rwp);					\
 	spl_rw_clear_owner(rwp);					\
@@ -213,7 +214,7 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	spl_rw_lockdep_on_maybe(rwp);					\
 })
 
-#define rw_tryupgrade(rwp)						\
+#define	rw_tryupgrade(rwp)						\
 ({									\
 	int _rc_ = 0;							\
 									\
@@ -227,6 +228,7 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	}								\
 	_rc_;								\
 })
+/* END CSTYLED */
 
 int spl_rw_init(void);
 void spl_rw_fini(void);

--- a/include/sys/sdt.h
+++ b/include/sys/sdt.h
@@ -23,8 +23,8 @@
  */
 
 #ifndef _SPL_SDT_H
-#define _SPL_SDT_H
+#define	_SPL_SDT_H
 
-#define SET_ERROR(x) (x)
+#define	SET_ERROR(x) (x)
 
 #endif /* SPL_SDT_H */

--- a/include/sys/sid.h
+++ b/include/sys/sid.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_SID_H
-#define _SPL_SID_H
+#define	_SPL_SID_H
 
 typedef struct ksiddomain {
 	char		*kd_name;
@@ -41,21 +41,21 @@ typedef int ksid_t;
 static inline ksiddomain_t *
 ksid_lookupdomain(const char *dom)
 {
-        ksiddomain_t *kd;
+	ksiddomain_t *kd;
 	int len = strlen(dom);
 
-        kd = kmem_zalloc(sizeof(ksiddomain_t), KM_SLEEP);
-        kd->kd_name = kmem_zalloc(len + 1, KM_SLEEP);
+	kd = kmem_zalloc(sizeof (ksiddomain_t), KM_SLEEP);
+	kd->kd_name = kmem_zalloc(len + 1, KM_SLEEP);
 	memcpy(kd->kd_name, dom, len);
 
-        return (kd);
+	return (kd);
 }
 
 static inline void
 ksiddomain_rele(ksiddomain_t *ksid)
 {
 	kmem_free(ksid->kd_name, strlen(ksid->kd_name) + 1);
-        kmem_free(ksid, sizeof(ksiddomain_t));
+	kmem_free(ksid, sizeof (ksiddomain_t));
 }
 
 #endif /* _SPL_SID_H */

--- a/include/sys/signal.h
+++ b/include/sys/signal.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_SIGNAL_H
-#define _SPL_SIGNAL_H
+#define	_SPL_SIGNAL_H
 
 #include <linux/sched.h>
 
@@ -34,7 +34,8 @@
 #define	FORREAL		0	/* Usual side-effects */
 #define	JUSTLOOKING	1	/* Don't stop the process */
 
-/* The "why" argument indicates the allowable side-effects of the call:
+/*
+ * The "why" argument indicates the allowable side-effects of the call:
  *
  * FORREAL:  Extract the next pending signal from p_sig into p_cursig;
  * stop the process if a stop has been requested or if a traced signal
@@ -48,7 +49,7 @@ issig(int why)
 {
 	ASSERT(why == FORREAL || why == JUSTLOOKING);
 
-	return signal_pending(current);
+	return (signal_pending(current));
 }
 
 #endif /* SPL_SIGNAL_H */

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_STAT_H
-#define _SPL_STAT_H
+#define	_SPL_STAT_H
 
 #include <linux/stat.h>
 

--- a/include/sys/stropts.h
+++ b/include/sys/stropts.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_STROPTS_H
-#define _SPL_STROPTS_H
+#define	_SPL_STROPTS_H
 
 #endif /* SPL_STROPTS_H */

--- a/include/sys/sunddi.h
+++ b/include/sys/sunddi.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_SUNDDI_H
-#define _SPL_SUNDDI_H
+#define	_SPL_SUNDDI_H
 
 #include <sys/cred.h>
 #include <sys/uio.h>
@@ -44,9 +44,9 @@ typedef int ddi_devid_t;
 #define	DDI_SUCCESS				0
 #define	DDI_FAILURE				-1
 
-#define	ddi_prop_lookup_string(x1,x2,x3,x4,x5)	(*x5 = NULL)
-#define	ddi_prop_free(x)			(void)0
-#define	ddi_root_node()				(void)0
+#define	ddi_prop_lookup_string(x1, x2, x3, x4, x5)	(*x5 = NULL)
+#define	ddi_prop_free(x)				(void)0
+#define	ddi_root_node()					(void)0
 
 extern int ddi_strtoul(const char *, char **, int, unsigned long *);
 extern int ddi_strtol(const char *, char **, int, long *);

--- a/include/sys/sunldi.h
+++ b/include/sys/sunldi.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_SUNLDI_H
-#define _SPL_SUNLDI_H
+#define	_SPL_SUNLDI_H
 
 #include <sys/types.h>
 #include <linux/fs.h>
@@ -32,6 +32,6 @@
 #include <linux/bio.h>
 #include <linux/blkdev.h>
 
-#define SECTOR_SIZE 512
+#define	SECTOR_SIZE 512
 
 #endif /* SPL_SUNLDI_H */

--- a/include/sys/sysdc.h
+++ b/include/sys/sysdc.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_SYSDC_H
-#define _SPL_SYSDC_H
+#define	_SPL_SYSDC_H
 
 #endif /* SPL_SYSDC_H */

--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_SYSMACROS_H
-#define _SPL_SYSMACROS_H
+#define	_SPL_SYSMACROS_H
 
 #include <linux/module.h>
 #include <linux/sched.h>
@@ -39,120 +39,122 @@
 #endif
 
 #ifndef _KERNEL
-#define _KERNEL				__KERNEL__
+#define	_KERNEL				__KERNEL__
 #endif
 
-#define FALSE				0
-#define TRUE				1
+#define	FALSE				0
+#define	TRUE				1
 
-#define INT8_MAX			(127)
-#define INT8_MIN			(-128)
-#define UINT8_MAX			(255)
-#define UINT8_MIN			(0)
+#define	INT8_MAX			(127)
+#define	INT8_MIN			(-128)
+#define	UINT8_MAX			(255)
+#define	UINT8_MIN			(0)
 
-#define INT16_MAX			(32767)
-#define INT16_MIN			(-32768)
-#define UINT16_MAX			(65535)
-#define UINT16_MIN			(0)
+#define	INT16_MAX			(32767)
+#define	INT16_MIN			(-32768)
+#define	UINT16_MAX			(65535)
+#define	UINT16_MIN			(0)
 
-#define INT32_MAX			INT_MAX
-#define INT32_MIN			INT_MIN
-#define UINT32_MAX			UINT_MAX
-#define UINT32_MIN			UINT_MIN
+#define	INT32_MAX			INT_MAX
+#define	INT32_MIN			INT_MIN
+#define	UINT32_MAX			UINT_MAX
+#define	UINT32_MIN			UINT_MIN
 
-#define INT64_MAX			LLONG_MAX
-#define INT64_MIN			LLONG_MIN
-#define UINT64_MAX			ULLONG_MAX
-#define UINT64_MIN			ULLONG_MIN
+#define	INT64_MAX			LLONG_MAX
+#define	INT64_MIN			LLONG_MIN
+#define	UINT64_MAX			ULLONG_MAX
+#define	UINT64_MIN			ULLONG_MIN
 
-#define NBBY				8
-#define ENOTSUP				EOPNOTSUPP
+#define	NBBY				8
+#define	ENOTSUP				EOPNOTSUPP
 
-#define MAXMSGLEN			256
-#define MAXNAMELEN			256
-#define MAXPATHLEN			PATH_MAX
-#define MAXOFFSET_T			LLONG_MAX
-#define MAXBSIZE			8192
-#define DEV_BSIZE			512
-#define DEV_BSHIFT			9 /* log2(DEV_BSIZE) */
+#define	MAXMSGLEN			256
+#define	MAXNAMELEN			256
+#define	MAXPATHLEN			PATH_MAX
+#define	MAXOFFSET_T			LLONG_MAX
+#define	MAXBSIZE			8192
+#define	DEV_BSIZE			512
+#define	DEV_BSHIFT			9 /* log2(DEV_BSIZE) */
 
-#define proc_pageout			NULL
-#define curproc				current
-#define max_ncpus			num_possible_cpus()
-#define boot_ncpus			num_online_cpus()
-#define CPU_SEQID			smp_processor_id()
-#define _NOTE(x)
-#define is_system_labeled()		0
+#define	proc_pageout			NULL
+#define	curproc				current
+#define	max_ncpus			num_possible_cpus()
+#define	boot_ncpus			num_online_cpus()
+#define	CPU_SEQID			smp_processor_id()
+#define	_NOTE(x)
+#define	is_system_labeled()		0
 
 #ifndef RLIM64_INFINITY
-#define RLIM64_INFINITY			(~0ULL)
+#define	RLIM64_INFINITY			(~0ULL)
 #endif
 
-/* 0..MAX_PRIO-1:		Process priority
+/*
+ * 0..MAX_PRIO-1:		Process priority
  * 0..MAX_RT_PRIO-1:		RT priority tasks
  * MAX_RT_PRIO..MAX_PRIO-1:	SCHED_NORMAL tasks
  *
  * Treat shim tasks as SCHED_NORMAL tasks
  */
-#define minclsyspri			(MAX_PRIO-1)
-#define maxclsyspri			(MAX_RT_PRIO)
-#define defclsyspri			(DEFAULT_PRIO)
+#define	minclsyspri			(MAX_PRIO-1)
+#define	maxclsyspri			(MAX_RT_PRIO)
+#define	defclsyspri			(DEFAULT_PRIO)
 
 #ifndef NICE_TO_PRIO
-#define NICE_TO_PRIO(nice)		(MAX_RT_PRIO + (nice) + 20)
+#define	NICE_TO_PRIO(nice)		(MAX_RT_PRIO + (nice) + 20)
 #endif
 #ifndef PRIO_TO_NICE
-#define PRIO_TO_NICE(prio)		((prio) - MAX_RT_PRIO - 20)
+#define	PRIO_TO_NICE(prio)		((prio) - MAX_RT_PRIO - 20)
 #endif
 
 /*
  * Missing macros
  */
 #ifndef PAGESIZE
-#define PAGESIZE			PAGE_SIZE
+#define	PAGESIZE			PAGE_SIZE
 #endif
 
 #ifndef PAGESHIFT
-#define PAGESHIFT			PAGE_SHIFT
+#define	PAGESHIFT			PAGE_SHIFT
 #endif
 
 /* from Solaris sys/byteorder.h */
-#define BSWAP_8(x)	((x) & 0xff)
-#define BSWAP_16(x)	((BSWAP_8(x) << 8) | BSWAP_8((x) >> 8))
-#define BSWAP_32(x)	((BSWAP_16(x) << 16) | BSWAP_16((x) >> 16))
-#define BSWAP_64(x)	((BSWAP_32(x) << 32) | BSWAP_32((x) >> 32))
+#define	BSWAP_8(x)	((x) & 0xff)
+#define	BSWAP_16(x)	((BSWAP_8(x) << 8) | BSWAP_8((x) >> 8))
+#define	BSWAP_32(x)	((BSWAP_16(x) << 16) | BSWAP_16((x) >> 16))
+#define	BSWAP_64(x)	((BSWAP_32(x) << 32) | BSWAP_32((x) >> 32))
 
-/* Map some simple functions.
+/*
+ * Map some simple functions.
  */
-#define bzero(ptr,size)			memset(ptr,0,size)
-#define bcopy(src,dest,size)		memmove(dest,src,size)
-#define bcmp(src,dest,size)		memcmp((src), (dest), (size_t)(size))
+#define	bzero(ptr, size)		memset(ptr, 0, size)
+#define	bcopy(src, dest, size)		memmove(dest, src, size)
+#define	bcmp(src, dest, size)		memcmp((src), (dest), (size_t)(size))
 
 /* Dtrace probes do not exist in the linux kernel */
 #ifdef DTRACE_PROBE
 #undef  DTRACE_PROBE
 #endif  /* DTRACE_PROBE */
-#define DTRACE_PROBE(a)					((void)0)
+#define	DTRACE_PROBE(a)					((void)0)
 
 #ifdef DTRACE_PROBE1
 #undef  DTRACE_PROBE1
 #endif  /* DTRACE_PROBE1 */
-#define DTRACE_PROBE1(a, b, c)				((void)0)
+#define	DTRACE_PROBE1(a, b, c)				((void)0)
 
 #ifdef DTRACE_PROBE2
 #undef  DTRACE_PROBE2
 #endif  /* DTRACE_PROBE2 */
-#define DTRACE_PROBE2(a, b, c, d, e)			((void)0)
+#define	DTRACE_PROBE2(a, b, c, d, e)			((void)0)
 
 #ifdef DTRACE_PROBE3
 #undef  DTRACE_PROBE3
 #endif  /* DTRACE_PROBE3 */
-#define DTRACE_PROBE3(a, b, c, d, e, f, g)		((void)0)
+#define	DTRACE_PROBE3(a, b, c, d, e, f, g)		((void)0)
 
 #ifdef DTRACE_PROBE4
 #undef  DTRACE_PROBE4
 #endif  /* DTRACE_PROBE4 */
-#define DTRACE_PROBE4(a, b, c, d, e, f, g, h, i)	((void)0)
+#define	DTRACE_PROBE4(a, b, c, d, e, f, g, h, i)	((void)0)
 
 /* Missing globals */
 extern char spl_version[32];
@@ -167,39 +169,39 @@ extern void spl_cleanup(void);
 #define	lowbit(x)		__ffs(x)
 
 #define	highbit64(x)		fls64(x)
-#define	makedevice(maj,min)	makedev(maj,min)
+#define	makedevice(maj, min)	makedev(maj, min)
 
 /* common macros */
 #ifndef MIN
-#define MIN(a, b)		((a) < (b) ? (a) : (b))
+#define	MIN(a, b)		((a) < (b) ? (a) : (b))
 #endif
 #ifndef MAX
-#define MAX(a, b)		((a) < (b) ? (b) : (a))
+#define	MAX(a, b)		((a) < (b) ? (b) : (a))
 #endif
 #ifndef ABS
-#define ABS(a)			((a) < 0 ? -(a) : (a))
+#define	ABS(a)			((a) < 0 ? -(a) : (a))
 #endif
 #ifndef DIV_ROUND_UP
-#define DIV_ROUND_UP(n,d)	(((n) + (d) - 1) / (d))
+#define	DIV_ROUND_UP(n, d)	(((n) + (d) - 1) / (d))
 #endif
 #ifndef roundup
-#define roundup(x, y)		((((x) + ((y) - 1)) / (y)) * (y))
+#define	roundup(x, y)		((((x) + ((y) - 1)) / (y)) * (y))
 #endif
 #ifndef howmany
-#define howmany(x, y)		(((x) + ((y) - 1)) / (y))
+#define	howmany(x, y)		(((x) + ((y) - 1)) / (y))
 #endif
 
 /*
  * Compatibility macros/typedefs needed for Solaris -> Linux port
  */
-#define P2ALIGN(x, align)	((x) & -(align))
-#define P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
-#define P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
-#define P2PHASE(x, align)	((x) & ((align) - 1))
-#define P2NPHASE(x, align)	(-(x) & ((align) - 1))
-#define ISP2(x)			(((x) & ((x) - 1)) == 0)
-#define IS_P2ALIGNED(v, a)	((((uintptr_t)(v)) & ((uintptr_t)(a) - 1))==0)
-#define P2BOUNDARY(off, len, align) \
+#define	P2ALIGN(x, align)	((x) & -(align))
+#define	P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
+#define	P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
+#define	P2PHASE(x, align)	((x) & ((align) - 1))
+#define	P2NPHASE(x, align)	(-(x) & ((align) - 1))
+#define	ISP2(x)			(((x) & ((x) - 1)) == 0)
+#define	IS_P2ALIGNED(v, a)	((((uintptr_t)(v)) & ((uintptr_t)(a) - 1)) == 0)
+#define	P2BOUNDARY(off, len, align) \
 				(((off) ^ ((off) + (len) - 1)) > (align) - 1)
 
 /*
@@ -214,28 +216,28 @@ extern void spl_cleanup(void);
  * or
  * P2ROUNDUP_TYPED(x, PAGESIZE, uint64_t)
  */
-#define P2ALIGN_TYPED(x, align, type)   \
-        ((type)(x) & -(type)(align))
-#define P2PHASE_TYPED(x, align, type)   \
-        ((type)(x) & ((type)(align) - 1))
-#define P2NPHASE_TYPED(x, align, type)  \
-        (-(type)(x) & ((type)(align) - 1))
-#define P2ROUNDUP_TYPED(x, align, type) \
-        ((((type)(x) - 1) | ((type)(align) - 1)) + 1)
-#define P2END_TYPED(x, align, type)     \
-        (-(~(type)(x) & -(type)(align)))
-#define P2PHASEUP_TYPED(x, align, phase, type)  \
-        ((type)(phase) - (((type)(phase) - (type)(x)) & -(type)(align)))
-#define P2CROSS_TYPED(x, y, align, type)        \
-        (((type)(x) ^ (type)(y)) > (type)(align) - 1)
-#define P2SAMEHIGHBIT_TYPED(x, y, type) \
-        (((type)(x) ^ (type)(y)) < ((type)(x) & (type)(y)))
+#define	P2ALIGN_TYPED(x, align, type)   \
+	((type)(x) & -(type)(align))
+#define	P2PHASE_TYPED(x, align, type)   \
+	((type)(x) & ((type)(align) - 1))
+#define	P2NPHASE_TYPED(x, align, type)  \
+	(-(type)(x) & ((type)(align) - 1))
+#define	P2ROUNDUP_TYPED(x, align, type) \
+	((((type)(x) - 1) | ((type)(align) - 1)) + 1)
+#define	P2END_TYPED(x, align, type)     \
+	(-(~(type)(x) & -(type)(align)))
+#define	P2PHASEUP_TYPED(x, align, phase, type)  \
+	((type)(phase) - (((type)(phase) - (type)(x)) & -(type)(align)))
+#define	P2CROSS_TYPED(x, y, align, type)	\
+	(((type)(x) ^ (type)(y)) > (type)(align) - 1)
+#define	P2SAMEHIGHBIT_TYPED(x, y, type) \
+	(((type)(x) ^ (type)(y)) < ((type)(x) & (type)(y)))
 
 #if defined(_KERNEL) && !defined(_KMEMUSER) && !defined(offsetof)
 
 /* avoid any possibility of clashing with <stddef.h> version */
 
-#define offsetof(s, m)  ((size_t)(&(((s *)0)->m)))
+#define	offsetof(s, m)  ((size_t)(&(((s *)0)->m)))
 #endif
 
 #endif  /* _SPL_SYSMACROS_H */

--- a/include/sys/systeminfo.h
+++ b/include/sys/systeminfo.h
@@ -23,14 +23,14 @@
  */
 
 #ifndef _SPL_SYSTEMINFO_H
-#define _SPL_SYSTEMINFO_H
+#define	_SPL_SYSTEMINFO_H
 
-#define HW_HOSTID_LEN		11		/* minimum buffer size needed */
+#define	HW_HOSTID_LEN		11		/* minimum buffer size needed */
 						/* to hold a decimal or hex */
 						/* hostid string */
 
 /* Supplemental definitions for Linux. */
-#define HW_HOSTID_PATH		"/etc/hostid"   /* binary configuration file */
-#define HW_HOSTID_MASK		0xFFFFFFFF 	/* significant hostid bits */
+#define	HW_HOSTID_PATH		"/etc/hostid"   /* binary configuration file */
+#define	HW_HOSTID_MASK		0xFFFFFFFF 	/* significant hostid bits */
 
 #endif /* SPL_SYSTEMINFO_H */

--- a/include/sys/systm.h
+++ b/include/sys/systm.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_SYSTM_H
-#define _SPL_SYSTM_H
+#define	_SPL_SYSTM_H
 
 #include <sys/sunddi.h>
 

--- a/include/sys/t_lock.h
+++ b/include/sys/t_lock.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_T_LOCK_H
-#define _SPL_T_LOCK_H
+#define	_SPL_T_LOCK_H
 
 #include <sys/param.h>
 #include <sys/mutex.h>

--- a/include/sys/taskq.h
+++ b/include/sys/taskq.h
@@ -94,7 +94,7 @@ typedef struct taskq {
 	taskqid_t		tq_lowest_id;	/* lowest pend/work id */
 	struct list_head	tq_free_list;	/* free taskq_ent_t's */
 	struct list_head	tq_pend_list;	/* pending taskq_ent_t's */
-	struct list_head	tq_prio_list;	/* priority pending taskq_ent_t's */
+	struct list_head	tq_prio_list;	/* priority taskq_ent_t's */
 	struct list_head	tq_delay_list;	/* delayed taskq_ent_t's */
 	struct list_head	tq_taskqs;	/* all taskq_t's */
 	spl_wait_queue_head_t	tq_work_waitq;	/* new work waitq */

--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_THREAD_H
-#define _SPL_THREAD_H
+#define	_SPL_THREAD_H
 
 #include <linux/module.h>
 #include <linux/mm.h>
@@ -36,28 +36,30 @@
 /*
  * Thread interfaces
  */
-#define TP_MAGIC			0x53535353
+#define	TP_MAGIC			0x53535353
 
-#define TS_SLEEP			TASK_INTERRUPTIBLE
-#define TS_RUN				TASK_RUNNING
-#define TS_ZOMB				EXIT_ZOMBIE
-#define TS_STOPPED			TASK_STOPPED
+#define	TS_SLEEP			TASK_INTERRUPTIBLE
+#define	TS_RUN				TASK_RUNNING
+#define	TS_ZOMB				EXIT_ZOMBIE
+#define	TS_STOPPED			TASK_STOPPED
 
 typedef void (*thread_func_t)(void *);
 
-#define thread_create(stk, stksize, func, arg, len, pp, state, pri)      \
-	__thread_create(stk, stksize, (thread_func_t)func,               \
-	                #func, arg, len, pp, state, pri)
-#define thread_exit()			__thread_exit()
-#define thread_join(t)			VERIFY(0)
-#define curthread			current
-#define getcomm()			current->comm
-#define getpid()			current->pid
+/* BEGIN CSTYLED */
+#define	thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
+	__thread_create(stk, stksize, (thread_func_t)func,		\
+	#func, arg, len, pp, state, pri)
+/* END CSTYLED */
+
+#define	thread_exit()			__thread_exit()
+#define	thread_join(t)			VERIFY(0)
+#define	curthread			current
+#define	getcomm()			current->comm
+#define	getpid()			current->pid
 
 extern kthread_t *__thread_create(caddr_t stk, size_t  stksize,
-                                  thread_func_t func, const char *name,
-                                  void *args, size_t len, proc_t *pp,
-                                  int state, pri_t pri);
+    thread_func_t func, const char *name, void *args, size_t len, proc_t *pp,
+    int state, pri_t pri);
 extern void __thread_exit(void);
 extern struct task_struct *spl_kthread_create(int (*func)(void *),
 			void *data, const char namefmt[], ...);

--- a/include/sys/timer.h
+++ b/include/sys/timer.h
@@ -23,38 +23,37 @@
  */
 
 #ifndef _SPL_TIMER_H
-#define _SPL_TIMER_H
+#define	_SPL_TIMER_H
 
 #include <linux/module.h>
 #include <linux/sched.h>
 #include <linux/timer.h>
 
-#define lbolt				((clock_t)jiffies)
-#define lbolt64				((int64_t)get_jiffies_64())
+#define	lbolt				((clock_t)jiffies)
+#define	lbolt64				((int64_t)get_jiffies_64())
 
-#define ddi_get_lbolt()			((clock_t)jiffies)
-#define ddi_get_lbolt64()		((int64_t)get_jiffies_64())
+#define	ddi_get_lbolt()			((clock_t)jiffies)
+#define	ddi_get_lbolt64()		((int64_t)get_jiffies_64())
 
-#define ddi_time_before(a, b)		(typecheck(clock_t, a) && \
+#define	ddi_time_before(a, b)		(typecheck(clock_t, a) && \
 					typecheck(clock_t, b) && \
 					((a) - (b) < 0))
-#define ddi_time_after(a, b)		ddi_time_before(b, a)
-#define ddi_time_before_eq(a, b)	(!ddi_time_after(a, b))
-#define ddi_time_after_eq(a, b)		ddi_time_before_eq(b, a)
+#define	ddi_time_after(a, b)		ddi_time_before(b, a)
+#define	ddi_time_before_eq(a, b)	(!ddi_time_after(a, b))
+#define	ddi_time_after_eq(a, b)		ddi_time_before_eq(b, a)
 
-#define ddi_time_before64(a, b)		(typecheck(int64_t, a) && \
+#define	ddi_time_before64(a, b)		(typecheck(int64_t, a) && \
 					typecheck(int64_t, b) && \
 					((a) - (b) < 0))
-#define ddi_time_after64(a, b)		ddi_time_before64(b, a)
-#define ddi_time_before_eq64(a, b)	(!ddi_time_after64(a, b))
-#define ddi_time_after_eq64(a, b)	ddi_time_before_eq64(b, a)
+#define	ddi_time_after64(a, b)		ddi_time_before64(b, a)
+#define	ddi_time_before_eq64(a, b)	(!ddi_time_after64(a, b))
+#define	ddi_time_after_eq64(a, b)	ddi_time_before_eq64(b, a)
 
-#define delay(ticks)			schedule_timeout_uninterruptible(ticks)
+#define	delay(ticks)			schedule_timeout_uninterruptible(ticks)
 
-#define SEC_TO_TICK(sec)		((sec) * HZ)
-#define MSEC_TO_TICK(ms)		msecs_to_jiffies(ms)
-#define USEC_TO_TICK(us)		usecs_to_jiffies(us)
-#define NSEC_TO_TICK(ns)		usecs_to_jiffies(ns / NSEC_PER_USEC)
+#define	SEC_TO_TICK(sec)		((sec) * HZ)
+#define	MSEC_TO_TICK(ms)		msecs_to_jiffies(ms)
+#define	USEC_TO_TICK(us)		usecs_to_jiffies(us)
+#define	NSEC_TO_TICK(ns)		usecs_to_jiffies(ns / NSEC_PER_USEC)
 
 #endif  /* _SPL_TIMER_H */
-

--- a/include/sys/tsd.h
+++ b/include/sys/tsd.h
@@ -22,14 +22,14 @@
  */
 
 #ifndef _SPL_TSD_H
-#define _SPL_TSD_H
+#define	_SPL_TSD_H
 
 #include <sys/types.h>
 
-#define TSD_HASH_TABLE_BITS_DEFAULT	9
-#define TSD_KEYS_MAX			32768
-#define DTOR_PID			(PID_MAX_LIMIT+1)
-#define PID_KEY				(TSD_KEYS_MAX+1)
+#define	TSD_HASH_TABLE_BITS_DEFAULT	9
+#define	TSD_KEYS_MAX			32768
+#define	DTOR_PID			(PID_MAX_LIMIT+1)
+#define	PID_KEY				(TSD_KEYS_MAX+1)
 
 typedef void (*dtor_func_t)(void *);
 

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -29,14 +29,14 @@
 #include <sys/sysmacros.h>
 
 #ifndef ULLONG_MAX
-#define ULLONG_MAX			(~0ULL)
+#define	ULLONG_MAX			(~0ULL)
 #endif
 
 #ifndef LLONG_MAX
-#define LLONG_MAX			((long long)(~0ULL>>1))
+#define	LLONG_MAX			((long long)(~0ULL>>1))
 #endif
 
-typedef enum { B_FALSE=0, B_TRUE=1 }	boolean_t;
+typedef enum { B_FALSE = 0, B_TRUE = 1 }	boolean_t;
 typedef unsigned long			intptr_t;
 typedef unsigned long			ulong_t;
 typedef unsigned int			uint_t;

--- a/include/sys/u8_textprep.h
+++ b/include/sys/u8_textprep.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_U8_TEXTPREP_H
-#define _SPL_U8_TEXTPREP_H
+#define	_SPL_U8_TEXTPREP_H
 
 #endif /* SPL_U8_TEXTPREP_H */

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -24,7 +24,7 @@
  */
 
 #ifndef _SPL_UIO_H
-#define _SPL_UIO_H
+#define	_SPL_UIO_H
 
 #include <linux/uio.h>
 #include <linux/blkdev.h>
@@ -34,15 +34,15 @@
 typedef struct iovec iovec_t;
 
 typedef enum uio_rw {
-	UIO_READ =	0,
-	UIO_WRITE =	1,
+	UIO_READ =		0,
+	UIO_WRITE =		1,
 } uio_rw_t;
 
 typedef enum uio_seg {
-	UIO_USERSPACE =	0,
-	UIO_SYSSPACE =	1,
-	UIO_USERISPACE=	2,
-	UIO_BVEC =	3,
+	UIO_USERSPACE =		0,
+	UIO_SYSSPACE =		1,
+	UIO_USERISPACE =	2,
+	UIO_BVEC =		3,
 } uio_seg_t;
 
 typedef struct uio {
@@ -71,7 +71,7 @@ typedef enum xuio_type {
 } xuio_type_t;
 
 
-#define UIOA_IOV_MAX    16
+#define	UIOA_IOV_MAX    16
 
 typedef struct uioa_page_s {
 	int	uioa_pfncnt;
@@ -100,7 +100,7 @@ typedef struct xuio {
 	} xu_ext;
 } xuio_t;
 
-#define XUIO_XUZC_PRIV(xuio)	xuio->xu_ext.xu_zc.xu_zc_priv
-#define XUIO_XUZC_RW(xuio)	xuio->xu_ext.xu_zc.xu_zc_rw
+#define	XUIO_XUZC_PRIV(xuio)	xuio->xu_ext.xu_zc.xu_zc_priv
+#define	XUIO_XUZC_RW(xuio)	xuio->xu_ext.xu_zc.xu_zc_rw
 
 #endif /* SPL_UIO_H */

--- a/include/sys/unistd.h
+++ b/include/sys/unistd.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_UNISTD_H
-#define _SPL_UNISTD_H
+#define	_SPL_UNISTD_H
 
 #endif /* SPL_UNISTD_H */

--- a/include/sys/user.h
+++ b/include/sys/user.h
@@ -21,7 +21,7 @@
  */
 
 #ifndef _SPL_USER_H
-#define _SPL_USER_H
+#define	_SPL_USER_H
 
 /*
  * We have uf_info_t for areleasef(). We implement areleasef() using a global
@@ -37,6 +37,6 @@
 struct uf_info;
 typedef struct uf_info uf_info_t;
 
-#define P_FINFO(x) ((uf_info_t *)x)
+#define	P_FINFO(x) ((uf_info_t *)x)
 
 #endif /* SPL_USER_H */

--- a/include/sys/va_list.h
+++ b/include/sys/va_list.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_VA_LIST_H
-#define _SPL_VA_LIST_H
+#define	_SPL_VA_LIST_H
 
 #endif /* SPL_VA_LIST_H */

--- a/include/sys/varargs.h
+++ b/include/sys/varargs.h
@@ -23,8 +23,8 @@
  */
 
 #ifndef _SPL_VARARGS_H
-#define _SPL_VARARGS_H
+#define	_SPL_VARARGS_H
 
-#define __va_list                       va_list
+#define	__va_list	va_list
 
 #endif /* SPL_VARARGS_H */

--- a/include/sys/vfs.h
+++ b/include/sys/vfs.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_ZFS_H
-#define _SPL_ZFS_H
+#define	_SPL_ZFS_H
 
 #include <linux/mount.h>
 #include <linux/fs.h>
@@ -40,7 +40,7 @@ typedef struct spl_fid {
 		long fid_pad;
 		struct {
 			ushort_t len;		/* length of data in bytes */
-			char     data[MAXFIDSZ];/* data (variable len) */
+			char data[MAXFIDSZ];	/* data (variable len) */
 		} _fid;
 	} un;
 } fid_t;

--- a/include/sys/vfs_opreg.h
+++ b/include/sys/vfs_opreg.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_OPREG_H
-#define _SPL_OPREG_H
+#define	_SPL_OPREG_H
 
 #endif /* SPL_OPREG_H */

--- a/include/sys/vmsystm.h
+++ b/include/sys/vmsystm.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_VMSYSTM_H
-#define _SPL_VMSYSTM_H
+#define	_SPL_VMSYSTM_H
 
 #include <linux/mmzone.h>
 #include <linux/mm.h>
@@ -48,9 +48,9 @@ copyin(const void *from, void *to, size_t len)
 {
 	/* On error copyin routine returns -1 */
 	if (xcopyin(from, to, len))
-		return -1;
+		return (-1);
 
-	return 0;
+	return (0);
 }
 
 static __inline__ int
@@ -58,9 +58,9 @@ copyout(const void *from, void *to, size_t len)
 {
 	/* On error copyout routine returns -1 */
 	if (xcopyout(from, to, len))
-		return -1;
+		return (-1);
 
-	return 0;
+	return (0);
 }
 
 static __inline__ int
@@ -69,7 +69,7 @@ copyinstr(const void *from, void *to, size_t len, size_t *done)
 	size_t rc;
 
 	if (len == 0)
-		return -ENAMETOOLONG;
+		return (-ENAMETOOLONG);
 
 	/* XXX: Should return ENAMETOOLONG if 'strlen(from) > len' */
 
@@ -78,7 +78,7 @@ copyinstr(const void *from, void *to, size_t len, size_t *done)
 	if (done != NULL)
 		*done = rc;
 
-	return 0;
+	return (0);
 }
 
 #endif /* SPL_VMSYSTM_H */

--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_VNODE_H
-#define _SPL_VNODE_H
+#define	_SPL_VNODE_H
 
 #include <linux/module.h>
 #include <linux/syscalls.h>
@@ -49,25 +49,25 @@
  * was properly split in to O_SYNC and O_DSYNC respectively.
  */
 #ifndef O_DSYNC
-#define O_DSYNC		O_SYNC
+#define	O_DSYNC		O_SYNC
 #endif
 
-#define FREAD		1
-#define FWRITE		2
-#define FCREAT		O_CREAT
-#define FTRUNC		O_TRUNC
-#define FOFFMAX		O_LARGEFILE
-#define FSYNC		O_SYNC
-#define FDSYNC		O_DSYNC
-#define FRSYNC		O_SYNC
-#define FEXCL		O_EXCL
-#define FDIRECT		O_DIRECT
-#define FAPPEND		O_APPEND
+#define	FREAD		1
+#define	FWRITE		2
+#define	FCREAT		O_CREAT
+#define	FTRUNC		O_TRUNC
+#define	FOFFMAX		O_LARGEFILE
+#define	FSYNC		O_SYNC
+#define	FDSYNC		O_DSYNC
+#define	FRSYNC		O_SYNC
+#define	FEXCL		O_EXCL
+#define	FDIRECT		O_DIRECT
+#define	FAPPEND		O_APPEND
 
-#define FNODSYNC	0x10000 /* fsync pseudo flag */
-#define FNOFOLLOW	0x20000 /* don't follow symlinks */
+#define	FNODSYNC	0x10000 /* fsync pseudo flag */
+#define	FNOFOLLOW	0x20000 /* don't follow symlinks */
 
-#define F_FREESP	11 	/* Free file space */
+#define	F_FREESP	11 	/* Free file space */
 
 
 /*
@@ -79,30 +79,30 @@
 #undef AT_UID
 #undef AT_GID
 
-#define AT_MODE		ATTR_MODE
-#define AT_UID		ATTR_UID
-#define AT_GID		ATTR_GID
-#define AT_SIZE		ATTR_SIZE
-#define AT_ATIME	ATTR_ATIME
-#define AT_MTIME	ATTR_MTIME
-#define AT_CTIME	ATTR_CTIME
+#define	AT_MODE		ATTR_MODE
+#define	AT_UID		ATTR_UID
+#define	AT_GID		ATTR_GID
+#define	AT_SIZE		ATTR_SIZE
+#define	AT_ATIME	ATTR_ATIME
+#define	AT_MTIME	ATTR_MTIME
+#define	AT_CTIME	ATTR_CTIME
 
-#define ATTR_XVATTR	(1 << 31)
-#define AT_XVATTR	ATTR_XVATTR
+#define	ATTR_XVATTR	(1 << 31)
+#define	AT_XVATTR	ATTR_XVATTR
 
-#define ATTR_IATTR_MASK	(ATTR_MODE | ATTR_UID | ATTR_GID | ATTR_SIZE | \
+#define	ATTR_IATTR_MASK	(ATTR_MODE | ATTR_UID | ATTR_GID | ATTR_SIZE | \
 			ATTR_ATIME | ATTR_MTIME | ATTR_CTIME | ATTR_FILE)
 
-#define CRCREAT		0x01
-#define RMFILE		0x02
+#define	CRCREAT		0x01
+#define	RMFILE		0x02
 
-#define B_INVAL		0x01
-#define B_TRUNC		0x02
+#define	B_INVAL		0x01
+#define	B_TRUNC		0x02
 
-#define LOOKUP_DIR		0x01
-#define LOOKUP_XATTR		0x02
-#define CREATE_XATTR_DIR	0x04
-#define ATTR_NOACLCHECK		0x20
+#define	LOOKUP_DIR		0x01
+#define	LOOKUP_XATTR		0x02
+#define	CREATE_XATTR_DIR	0x04
+#define	ATTR_NOACLCHECK		0x20
 
 typedef enum vtype {
 	VNON		= 0,
@@ -121,8 +121,8 @@ typedef enum vtype {
 
 typedef struct vattr {
 	enum vtype	va_type;	/* vnode type */
-	u_int		va_mask;	/* attribute bit-mask */
-	u_short		va_mode;	/* acc mode */
+	uint_t		va_mask;	/* attribute bit-mask */
+	ushort_t	va_mode;	/* acc mode */
 	uid_t		va_uid;		/* owner uid */
 	gid_t		va_gid;		/* owner gid */
 	long		va_fsid;	/* fs id */
@@ -168,12 +168,12 @@ void vn_free(vnode_t *vp);
 extern vtype_t vn_mode_to_vtype(mode_t);
 extern mode_t vn_vtype_to_mode(vtype_t);
 extern int vn_open(const char *path, uio_seg_t seg, int flags, int mode,
-		   vnode_t **vpp, int x1, void *x2);
+    vnode_t **vpp, int x1, void *x2);
 extern int vn_openat(const char *path, uio_seg_t seg, int flags, int mode,
-		     vnode_t **vpp, int x1, void *x2, vnode_t *vp, int fd);
+    vnode_t **vpp, int x1, void *x2, vnode_t *vp, int fd);
 extern int vn_rdwr(uio_rw_t uio, vnode_t *vp, void *addr, ssize_t len,
-		   offset_t off, uio_seg_t seg, int x1, rlim64_t x2,
-		   void *x3, ssize_t *residp);
+    offset_t off, uio_seg_t seg, int x1, rlim64_t x2,
+    void *x3, ssize_t *residp);
 extern int vn_close(vnode_t *vp, int flags, int x1, int x2, void *x3, void *x4);
 extern int vn_seek(vnode_t *vp, offset_t o, offset_t *op, void *ct);
 
@@ -189,16 +189,16 @@ extern int vn_set_pwd(const char *filename);
 int spl_vn_init(void);
 void spl_vn_fini(void);
 
-#define VOP_CLOSE				vn_close
-#define VOP_SEEK				vn_seek
-#define VOP_GETATTR				vn_getattr
-#define VOP_FSYNC				vn_fsync
-#define VOP_SPACE				vn_space
-#define VOP_PUTPAGE(vp, o, s, f, x1, x2)	((void)0)
-#define vn_is_readonly(vp)			0
-#define getf					vn_getf
-#define releasef				vn_releasef
-#define areleasef				vn_areleasef
+#define	VOP_CLOSE				vn_close
+#define	VOP_SEEK				vn_seek
+#define	VOP_GETATTR				vn_getattr
+#define	VOP_FSYNC				vn_fsync
+#define	VOP_SPACE				vn_space
+#define	VOP_PUTPAGE(vp, o, s, f, x1, x2)	((void)0)
+#define	vn_is_readonly(vp)			0
+#define	getf					vn_getf
+#define	releasef				vn_releasef
+#define	areleasef				vn_areleasef
 
 extern vnode_t *rootdir;
 

--- a/include/sys/zmod.h
+++ b/include/sys/zmod.h
@@ -20,7 +20,8 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
+ *
  *  z_compress_level/z_uncompress are nearly identical copies of the
  *  compress2/uncompress functions provided by the official zlib package
  *  available at http://zlib.net/.  The only changes made we to slightly
@@ -53,7 +54,7 @@
  */
 
 #ifndef _SPL_ZMOD_H
-#define _SPL_ZMOD_H
+#define	_SPL_ZMOD_H
 
 #include <sys/types.h>
 #include <linux/zlib.h>

--- a/include/sys/zone.h
+++ b/include/sys/zone.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_ZONE_H
-#define _SPL_ZONE_H
+#define	_SPL_ZONE_H
 
 #include <sys/byteorder.h>
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_UNISTD_H
-#define _SPL_UNISTD_H
+#define	_SPL_UNISTD_H
 
 #endif /* SPL_UNISTD_H */

--- a/include/util/qsort.h
+++ b/include/util/qsort.h
@@ -23,10 +23,10 @@
  */
 
 #ifndef _SPL_QSORT_H
-#define _SPL_QSORT_H
+#define	_SPL_QSORT_H
 
 #include <linux/sort.h>
 
-#define qsort(base, num, size, cmp)	sort(base, num, size, cmp, NULL)
+#define	qsort(base, num, size, cmp)	sort(base, num, size, cmp, NULL)
 
 #endif /* SPL_QSORT_H */

--- a/include/util/sscanf.h
+++ b/include/util/sscanf.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_UTIL_SSCANF_H
-#define _SPL_UTIL_SSCANF_H
+#define	_SPL_UTIL_SSCANF_H
 
 #endif /* SPL_UTIL_SSCAN_H */

--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_VM_ANON_H
-#define _SPL_VM_ANON_H
+#define	_SPL_VM_ANON_H
 
 #endif /* SPL_VM_ANON_H */

--- a/include/vm/pvn.h
+++ b/include/vm/pvn.h
@@ -23,6 +23,6 @@
  */
 
 #ifndef _SPL_VM_PVN_H
-#define _SPL_VM_PVN_H
+#define	_SPL_VM_PVN_H
 
 #endif /* SPL_VM_PVN_H */

--- a/include/vm/seg_kmem.h
+++ b/include/vm/seg_kmem.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef _SPL_SEG_KMEM_H
-#define _SPL_SEG_KMEM_H
+#define	_SPL_SEG_KMEM_H
 
 #include <sys/vmsystm.h>
 

--- a/module/spl/spl-atomic.c
+++ b/module/spl/spl-atomic.c
@@ -20,17 +20,11 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Atomic Implementation.
  */
 
 #include <sys/atomic.h>
-
-#ifdef DEBUG_SUBSYSTEM
-#undef DEBUG_SUBSYSTEM
-#endif
-
-#define DEBUG_SUBSYSTEM S_ATOMIC
 
 #ifdef ATOMIC_SPINLOCK
 /* Global atomic lock declarations */

--- a/module/spl/spl-condvar.c
+++ b/module/spl/spl-condvar.c
@@ -335,8 +335,8 @@ __cv_timedwait_hires(kcondvar_t *cvp, kmutex_t *mp, hrtime_t expire_time,
  * Compatibility wrapper for the cv_timedwait_hires() Illumos interface.
  */
 static clock_t
-cv_timedwait_hires_common(kcondvar_t *cvp, kmutex_t *mp, hrtime_t tim, hrtime_t res,
-    int flag, int state)
+cv_timedwait_hires_common(kcondvar_t *cvp, kmutex_t *mp, hrtime_t tim,
+    hrtime_t res, int flag, int state)
 {
 	if (res > 1) {
 		/*
@@ -363,8 +363,8 @@ cv_timedwait_hires(kcondvar_t *cvp, kmutex_t *mp, hrtime_t tim, hrtime_t res,
 EXPORT_SYMBOL(cv_timedwait_hires);
 
 clock_t
-cv_timedwait_sig_hires(kcondvar_t *cvp, kmutex_t *mp, hrtime_t tim, hrtime_t res,
-    int flag)
+cv_timedwait_sig_hires(kcondvar_t *cvp, kmutex_t *mp, hrtime_t tim,
+    hrtime_t res, int flag)
 {
 	return (cv_timedwait_hires_common(cvp, mp, tim, res, flag,
 	    TASK_INTERRUPTIBLE));

--- a/module/spl/spl-cred.c
+++ b/module/spl/spl-cred.c
@@ -20,17 +20,11 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Credential Implementation.
  */
 
 #include <sys/cred.h>
-
-#ifdef DEBUG_SUBSYSTEM
-#undef DEBUG_SUBSYSTEM
-#endif
-
-#define DEBUG_SUBSYSTEM S_CRED
 
 static int
 #ifdef HAVE_KUIDGID_T
@@ -43,7 +37,7 @@ cr_groups_search(const struct group_info *group_info, gid_t grp)
 	int cmp;
 
 	if (!group_info)
-		return 0;
+		return (0);
 
 	left = 0;
 	right = group_info->ngroups;
@@ -57,16 +51,16 @@ cr_groups_search(const struct group_info *group_info, gid_t grp)
 		else if (cmp < 0)
 			right = mid;
 		else
-			return 1;
+			return (1);
 	}
-	return 0;
+	return (0);
 }
 
 /* Hold a reference on the credential */
 void
 crhold(cred_t *cr)
 {
-	(void)get_cred((const cred_t *)cr);
+	(void) get_cred((const cred_t *)cr);
 }
 
 /* Free a reference on the credential */
@@ -96,7 +90,7 @@ crgetngroups(const cred_t *cr)
 		rc = NGROUPS_PER_BLOCK;
 	}
 #endif
-	return rc;
+	return (rc);
 }
 
 /*
@@ -119,7 +113,7 @@ crgetgroups(const cred_t *cr)
 	if (gi->nblocks > 0)
 		gids = KGIDP_TO_SGIDP(gi->blocks[0]);
 #endif
-	return gids;
+	return (gids);
 }
 
 /* Check if the passed gid is available in supplied credential. */
@@ -132,63 +126,63 @@ groupmember(gid_t gid, const cred_t *cr)
 	gi = cr->group_info;
 	rc = cr_groups_search(gi, SGID_TO_KGID(gid));
 
-	return rc;
+	return (rc);
 }
 
 /* Return the effective user id */
 uid_t
 crgetuid(const cred_t *cr)
 {
-	return KUID_TO_SUID(cr->euid);
+	return (KUID_TO_SUID(cr->euid));
 }
 
 /* Return the real user id */
 uid_t
 crgetruid(const cred_t *cr)
 {
-	return KUID_TO_SUID(cr->uid);
+	return (KUID_TO_SUID(cr->uid));
 }
 
 /* Return the saved user id */
 uid_t
 crgetsuid(const cred_t *cr)
 {
-	return KUID_TO_SUID(cr->suid);
+	return (KUID_TO_SUID(cr->suid));
 }
 
 /* Return the filesystem user id */
 uid_t
 crgetfsuid(const cred_t *cr)
 {
-	return KUID_TO_SUID(cr->fsuid);
+	return (KUID_TO_SUID(cr->fsuid));
 }
 
 /* Return the effective group id */
 gid_t
 crgetgid(const cred_t *cr)
 {
-	return KGID_TO_SGID(cr->egid);
+	return (KGID_TO_SGID(cr->egid));
 }
 
 /* Return the real group id */
 gid_t
 crgetrgid(const cred_t *cr)
 {
-	return KGID_TO_SGID(cr->gid);
+	return (KGID_TO_SGID(cr->gid));
 }
 
 /* Return the saved group id */
 gid_t
 crgetsgid(const cred_t *cr)
 {
-	return KGID_TO_SGID(cr->sgid);
+	return (KGID_TO_SGID(cr->sgid));
 }
 
 /* Return the filesystem group id */
 gid_t
 crgetfsgid(const cred_t *cr)
 {
-	return KGID_TO_SGID(cr->fsgid);
+	return (KGID_TO_SGID(cr->fsgid));
 }
 
 EXPORT_SYMBOL(crhold);

--- a/module/spl/spl-err.c
+++ b/module/spl/spl-err.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Error Implementation.
  */
 
@@ -36,8 +36,7 @@
  */
 unsigned int spl_panic_halt;
 module_param(spl_panic_halt, uint, 0644);
-MODULE_PARM_DESC(spl_panic_halt,
-		 "Cause kernel panic on assertion failures");
+MODULE_PARM_DESC(spl_panic_halt, "Cause kernel panic on assertion failures");
 
 /*
  * Limit the number of stack traces dumped to not more than 5 every

--- a/module/spl/spl-generic.c
+++ b/module/spl/spl-generic.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Generic Implementation.
  */
 
@@ -109,13 +109,14 @@ spl_rand_next(uint64_t *s) {
 
 static inline void
 spl_rand_jump(uint64_t *s) {
-	static const uint64_t JUMP[] = { 0x8a5cd789635d2dff, 0x121fd2155c472f96 };
+	static const uint64_t JUMP[] =
+	    { 0x8a5cd789635d2dff, 0x121fd2155c472f96 };
 
 	uint64_t s0 = 0;
 	uint64_t s1 = 0;
 	int i, b;
-	for(i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
-		for(b = 0; b < 64; b++) {
+	for (i = 0; i < sizeof (JUMP) / sizeof (*JUMP); i++)
+		for (b = 0; b < 64; b++) {
 			if (JUMP[i] & 1ULL << b) {
 				s0 ^= s[0];
 				s1 ^= s[1];
@@ -187,16 +188,16 @@ nlz64(uint64_t x) {
 	register int n = 0;
 
 	if (x == 0)
-		return 64;
+		return (64);
 
-	if (x <= 0x00000000FFFFFFFFULL) {n = n + 32; x = x << 32;}
-	if (x <= 0x0000FFFFFFFFFFFFULL) {n = n + 16; x = x << 16;}
-	if (x <= 0x00FFFFFFFFFFFFFFULL) {n = n +  8; x = x <<  8;}
-	if (x <= 0x0FFFFFFFFFFFFFFFULL) {n = n +  4; x = x <<  4;}
-	if (x <= 0x3FFFFFFFFFFFFFFFULL) {n = n +  2; x = x <<  2;}
-	if (x <= 0x7FFFFFFFFFFFFFFFULL) {n = n +  1;}
+	if (x <= 0x00000000FFFFFFFFULL) { n = n + 32; x = x << 32; }
+	if (x <= 0x0000FFFFFFFFFFFFULL) { n = n + 16; x = x << 16; }
+	if (x <= 0x00FFFFFFFFFFFFFFULL) { n = n +  8; x = x <<  8; }
+	if (x <= 0x0FFFFFFFFFFFFFFFULL) { n = n +  4; x = x <<  4; }
+	if (x <= 0x3FFFFFFFFFFFFFFFULL) { n = n +  2; x = x <<  2; }
+	if (x <= 0x7FFFFFFFFFFFFFFFULL) { n = n +  1; }
 
-	return n;
+	return (n);
 }
 
 /*
@@ -207,7 +208,7 @@ static inline uint64_t
 __div_u64(uint64_t u, uint32_t v)
 {
 	(void) do_div(u, v);
-	return u;
+	return (u);
 }
 
 /*
@@ -227,7 +228,7 @@ __udivdi3(uint64_t u, uint64_t v)
 
 	if (v >> 32 == 0) {			// If v < 2**32:
 		if (u >> 32 < v) {		// If u/v cannot overflow,
-			return __div_u64(u, v);	// just do one division.
+			return (__div_u64(u, v)); // just do one division.
 		} else {			// If u/v would overflow:
 			u1 = u >> 32;		// Break u into two halves.
 			u0 = u & 0xFFFFFFFF;
@@ -235,7 +236,7 @@ __udivdi3(uint64_t u, uint64_t v)
 			k  = u1 - q1 * v;	// First remainder, < v.
 			u0 += (k << 32);
 			q0 = __div_u64(u0, v);	// Seconds quotient digit.
-			return (q1 << 32) + q0;
+			return ((q1 << 32) + q0);
 		}
 	} else {				// If v >= 2**32:
 		n = nlz64(v);			// 0 <= n <= 31.
@@ -249,7 +250,7 @@ __udivdi3(uint64_t u, uint64_t v)
 		if ((u - q0 * v) >= v)
 			q0 = q0 + 1;		// Now q0 is correct.
 
-		return q0;
+		return (q0);
 	}
 }
 EXPORT_SYMBOL(__udivdi3);
@@ -263,7 +264,7 @@ __divdi3(int64_t u, int64_t v)
 	int64_t q, t;
 	q = __udivdi3(abs64(u), abs64(v));
 	t = (u ^ v) >> 63;	// If u, v have different
-	return (q ^ t) - t;	// signs, negate q.
+	return ((q ^ t) - t);	// signs, negate q.
 }
 EXPORT_SYMBOL(__divdi3);
 
@@ -344,9 +345,11 @@ __aeabi_uldivmod(uint64_t u, uint64_t v)
 		register uint32_t r2 asm("r2") = (mod & 0xFFFFFFFF);
 		register uint32_t r3 asm("r3") = (mod >> 32);
 
+		/* BEGIN CSTYLED */
 		asm volatile(""
 		    : "+r"(r0), "+r"(r1), "+r"(r2),"+r"(r3)  /* output */
 		    : "r"(r0), "r"(r1), "r"(r2), "r"(r3));   /* input */
+		/* END CSTYLED */
 
 		return; /* r0; */
 	}
@@ -367,9 +370,11 @@ __aeabi_ldivmod(int64_t u, int64_t v)
 		register uint32_t r2 asm("r2") = (mod & 0xFFFFFFFF);
 		register uint32_t r3 asm("r3") = (mod >> 32);
 
+		/* BEGIN CSTYLED */
 		asm volatile(""
 		    : "+r"(r0), "+r"(r1), "+r"(r2),"+r"(r3)  /* output */
 		    : "r"(r0), "r"(r1), "r"(r2), "r"(r3));   /* input */
+		/* END CSTYLED */
 
 		return; /* r0; */
 	}
@@ -378,7 +383,8 @@ EXPORT_SYMBOL(__aeabi_ldivmod);
 #endif /* __arm || __arm__ */
 #endif /* BITS_PER_LONG */
 
-/* NOTE: The strtoxx behavior is solely based on my reading of the Solaris
+/*
+ * NOTE: The strtoxx behavior is solely based on my reading of the Solaris
  * ddi_strtol(9F) man page.  I have not verified the behavior of these
  * functions against their Solaris counterparts.  It is possible that I
  * may have misinterpreted the man page or the man page is incorrect.
@@ -388,28 +394,28 @@ int ddi_strtol(const char *, char **, int, long *);
 int ddi_strtoull(const char *, char **, int, unsigned long long *);
 int ddi_strtoll(const char *, char **, int, long long *);
 
-#define define_ddi_strtoux(type, valtype)				\
+#define	define_ddi_strtoux(type, valtype)				\
 int ddi_strtou##type(const char *str, char **endptr,			\
-		     int base, valtype *result)				\
+    int base, valtype *result)						\
 {									\
 	valtype last_value, value = 0;					\
 	char *ptr = (char *)str;					\
 	int flag = 1, digit;						\
 									\
 	if (strlen(ptr) == 0)						\
-		return EINVAL;						\
+		return (EINVAL);					\
 									\
 	/* Auto-detect base based on prefix */				\
 	if (!base) {							\
 		if (str[0] == '0') {					\
-			if (tolower(str[1])=='x' && isxdigit(str[2])) {	\
+			if (tolower(str[1]) == 'x' && isxdigit(str[2])) { \
 				base = 16; /* hex */			\
 				ptr += 2;				\
 			} else if (str[1] >= '0' && str[1] < 8) {	\
 				base = 8; /* octal */			\
 				ptr += 1;				\
 			} else {					\
-				return EINVAL;				\
+				return (EINVAL);			\
 			}						\
 		} else {						\
 			base = 10; /* decimal */			\
@@ -430,7 +436,7 @@ int ddi_strtou##type(const char *str, char **endptr,			\
 		last_value = value;					\
 		value = value * base + digit;				\
 		if (last_value > value) /* Overflow */			\
-			return ERANGE;					\
+			return (ERANGE);				\
 									\
 		flag = 1;						\
 		ptr++;							\
@@ -442,12 +448,12 @@ int ddi_strtou##type(const char *str, char **endptr,			\
 	if (endptr)							\
 		*endptr = (char *)(flag ? ptr : str);			\
 									\
-	return 0;							\
+	return (0);							\
 }									\
 
-#define define_ddi_strtox(type, valtype)				\
+#define	define_ddi_strtox(type, valtype)				\
 int ddi_strto##type(const char *str, char **endptr,			\
-		       int base, valtype *result)			\
+    int base, valtype *result)						\
 {									\
 	int rc;								\
 									\
@@ -463,7 +469,7 @@ int ddi_strto##type(const char *str, char **endptr,			\
 		rc = ddi_strtou##type(str, endptr, base, result);	\
 	}								\
 									\
-	return rc;							\
+	return (rc);							\
 }
 
 define_ddi_strtoux(l, unsigned long)
@@ -482,10 +488,10 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 	/* Fake ioctl() issued by kernel, 'from' is a kernel address */
 	if (flags & FKIOCTL) {
 		memcpy(to, from, len);
-		return 0;
+		return (0);
 	}
 
-	return copyin(from, to, len);
+	return (copyin(from, to, len));
 }
 EXPORT_SYMBOL(ddi_copyin);
 
@@ -495,10 +501,10 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 	/* Fake ioctl() issued by kernel, 'from' is a kernel address */
 	if (flags & FKIOCTL) {
 		memcpy(to, from, len);
-		return 0;
+		return (0);
 	}
 
-	return copyout(from, to, len);
+	return (copyout(from, to, len));
 }
 EXPORT_SYMBOL(ddi_copyout);
 
@@ -559,7 +565,7 @@ hostid_read(uint32_t *hostid)
 		return (error);
 	}
 
-	if (size < sizeof(HW_HOSTID_MASK)) {
+	if (size < sizeof (HW_HOSTID_MASK)) {
 		kobj_close_file(file);
 		return (EINVAL);
 	}
@@ -568,7 +574,7 @@ hostid_read(uint32_t *hostid)
 	 * Read directly into the variable like eglibc does.
 	 * Short reads are okay; native behavior is preserved.
 	 */
-	error = kobj_read_file(file, (char *)&value, sizeof(value), 0);
+	error = kobj_read_file(file, (char *)&value, sizeof (value), 0);
 	if (error < 0) {
 		kobj_close_file(file);
 		return (EIO);
@@ -578,7 +584,7 @@ hostid_read(uint32_t *hostid)
 	*hostid = (value & HW_HOSTID_MASK);
 	kobj_close_file(file);
 
-	return 0;
+	return (0);
 }
 
 /*
@@ -704,7 +710,7 @@ spl_init(void)
 		goto out10;
 
 	printk(KERN_NOTICE "SPL: Loaded module v%s-%s%s\n", SPL_META_VERSION,
-	       SPL_META_RELEASE, SPL_DEBUG_STR);
+	    SPL_META_RELEASE, SPL_DEBUG_STR);
 	return (rc);
 
 out10:
@@ -727,8 +733,8 @@ out2:
 	spl_kvmem_fini();
 out1:
 	printk(KERN_NOTICE "SPL: Failed to Load Solaris Porting Layer "
-	       "v%s-%s%s, rc = %d\n", SPL_META_VERSION, SPL_META_RELEASE,
-	       SPL_DEBUG_STR, rc);
+	    "v%s-%s%s, rc = %d\n", SPL_META_VERSION, SPL_META_RELEASE,
+	    SPL_DEBUG_STR, rc);
 
 	return (rc);
 }
@@ -737,7 +743,7 @@ static void __exit
 spl_fini(void)
 {
 	printk(KERN_NOTICE "SPL: Unloaded module v%s-%s%s\n",
-	       SPL_META_VERSION, SPL_META_RELEASE, SPL_DEBUG_STR);
+	    SPL_META_VERSION, SPL_META_RELEASE, SPL_DEBUG_STR);
 	spl_zlib_fini();
 	spl_kstat_fini();
 	spl_proc_fini();

--- a/module/spl/spl-kmem-cache.c
+++ b/module/spl/spl-kmem-cache.c
@@ -134,8 +134,8 @@ MODULE_PARM_DESC(spl_kmem_cache_slab_limit,
  * have been deemed costly by the kernel.
  */
 unsigned int spl_kmem_cache_kmem_limit =
-    ((1 << (PAGE_ALLOC_COSTLY_ORDER - 1)) * PAGE_SIZE) /
-    SPL_KMEM_CACHE_OBJ_PER_SLAB;
+	((1 << (PAGE_ALLOC_COSTLY_ORDER - 1)) * PAGE_SIZE) /
+	SPL_KMEM_CACHE_OBJ_PER_SLAB;
 module_param(spl_kmem_cache_kmem_limit, uint, 0644);
 MODULE_PARM_DESC(spl_kmem_cache_kmem_limit,
 	"Objects less than N bytes use the kmalloc");
@@ -1000,15 +1000,15 @@ spl_kmem_cache_create(char *name, size_t size, size_t align,
 #endif
 
 #if defined(HAVE_KMEM_CACHE_CREATE_USERCOPY)
-        /*
-         * Newer grsec patchset uses kmem_cache_create_usercopy()
-         * instead of SLAB_USERCOPY flag
-         */
-        skc->skc_linux_cache = kmem_cache_create_usercopy(
-            skc->skc_name, size, align, slabflags, 0, size, NULL);
+	/*
+	 * Newer grsec patchset uses kmem_cache_create_usercopy()
+	 * instead of SLAB_USERCOPY flag
+	 */
+	skc->skc_linux_cache = kmem_cache_create_usercopy(
+	    skc->skc_name, size, align, slabflags, 0, size, NULL);
 #else
-        skc->skc_linux_cache = kmem_cache_create(
-            skc->skc_name, size, align, slabflags, NULL);
+	skc->skc_linux_cache = kmem_cache_create(
+	    skc->skc_name, size, align, slabflags, NULL);
 #endif
 		if (skc->skc_linux_cache == NULL) {
 			rc = ENOMEM;
@@ -1186,7 +1186,7 @@ spl_cache_grow_work(void *data)
 	spl_kmem_alloc_t *ska = (spl_kmem_alloc_t *)data;
 	spl_kmem_cache_t *skc = ska->ska_cache;
 
-	(void)__spl_cache_grow(skc, ska->ska_flags);
+	(void) __spl_cache_grow(skc, ska->ska_flags);
 
 	atomic_dec(&skc->skc_ref);
 	smp_mb__before_atomic();

--- a/module/spl/spl-kmem.c
+++ b/module/spl/spl-kmem.c
@@ -383,7 +383,7 @@ spl_kmem_free_track(const void *ptr, size_t size)
 {
 	kmem_debug_t *dptr;
 
-	/* Ignore NULL pointer since we haven't tracked it at all*/
+	/* Ignore NULL pointer since we haven't tracked it at all */
 	if (ptr == NULL)
 		return;
 

--- a/module/spl/spl-kobj.c
+++ b/module/spl/spl-kobj.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Kobj Implementation.
  */
 
@@ -33,7 +33,7 @@ kobj_open_file(const char *name)
 	vnode_t *vp;
 	int rc;
 
-	file = kmalloc(sizeof(_buf_t), kmem_flags_convert(KM_SLEEP));
+	file = kmalloc(sizeof (_buf_t), kmem_flags_convert(KM_SLEEP));
 	if (file == NULL)
 		return ((_buf_t *)-1UL);
 
@@ -52,7 +52,7 @@ void
 kobj_close_file(struct _buf *file)
 {
 	VOP_CLOSE(file->vp, 0, 0, 0, 0, 0);
-        kfree(file);
+	kfree(file);
 } /* kobj_close_file() */
 EXPORT_SYMBOL(kobj_close_file);
 
@@ -72,15 +72,15 @@ EXPORT_SYMBOL(kobj_read_file);
 int
 kobj_get_filesize(struct _buf *file, uint64_t *size)
 {
-        vattr_t vap;
+	vattr_t vap;
 	int rc;
 
 	rc = VOP_GETATTR(file->vp, &vap, 0, 0, NULL);
 	if (rc)
 		return (rc);
 
-        *size = vap.va_size;
+	*size = vap.va_size;
 
-        return (rc);
+	return (rc);
 } /* kobj_get_filesize() */
 EXPORT_SYMBOL(kobj_get_filesize);

--- a/module/spl/spl-kstat.c
+++ b/module/spl/spl-kstat.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Kstat Implementation.
  */
 
@@ -30,7 +30,7 @@
 #include <sys/cmn_err.h>
 
 #ifndef HAVE_PDE_DATA
-#define PDE_DATA(x) (PDE(x)->data)
+#define	PDE_DATA(x) (PDE(x)->data)
 #endif
 
 static kmutex_t kstat_module_lock;
@@ -41,13 +41,13 @@ static int
 kstat_resize_raw(kstat_t *ksp)
 {
 	if (ksp->ks_raw_bufsize == KSTAT_RAW_MAX)
-		return ENOMEM;
+		return (ENOMEM);
 
 	vmem_free(ksp->ks_raw_buf, ksp->ks_raw_bufsize);
 	ksp->ks_raw_bufsize = MIN(ksp->ks_raw_bufsize * 2, KSTAT_RAW_MAX);
 	ksp->ks_raw_buf = vmem_alloc(ksp->ks_raw_bufsize, KM_SLEEP);
 
-	return 0;
+	return (0);
 }
 
 void
@@ -119,210 +119,212 @@ EXPORT_SYMBOL(kstat_runq_exit);
 static int
 kstat_seq_show_headers(struct seq_file *f)
 {
-        kstat_t *ksp = (kstat_t *)f->private;
+	kstat_t *ksp = (kstat_t *)f->private;
 	int rc = 0;
 
-        ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT(ksp->ks_magic == KS_MAGIC);
 
-        seq_printf(f, "%d %d 0x%02x %d %d %lld %lld\n",
-		   ksp->ks_kid, ksp->ks_type, ksp->ks_flags,
-		   ksp->ks_ndata, (int)ksp->ks_data_size,
-		   ksp->ks_crtime, ksp->ks_snaptime);
+	seq_printf(f, "%d %d 0x%02x %d %d %lld %lld\n",
+	    ksp->ks_kid, ksp->ks_type, ksp->ks_flags,
+	    ksp->ks_ndata, (int)ksp->ks_data_size,
+	    ksp->ks_crtime, ksp->ks_snaptime);
 
 	switch (ksp->ks_type) {
-                case KSTAT_TYPE_RAW:
+		case KSTAT_TYPE_RAW:
 restart:
-                        if (ksp->ks_raw_ops.headers) {
-                                rc = ksp->ks_raw_ops.headers(
-                                    ksp->ks_raw_buf, ksp->ks_raw_bufsize);
+			if (ksp->ks_raw_ops.headers) {
+				rc = ksp->ks_raw_ops.headers(
+				    ksp->ks_raw_buf, ksp->ks_raw_bufsize);
 				if (rc == ENOMEM && !kstat_resize_raw(ksp))
 					goto restart;
 				if (!rc)
-	                                seq_puts(f, ksp->ks_raw_buf);
-                        } else {
-                                seq_printf(f, "raw data\n");
-                        }
-                        break;
-                case KSTAT_TYPE_NAMED:
-                        seq_printf(f, "%-31s %-4s %s\n",
-                                   "name", "type", "data");
-                        break;
-                case KSTAT_TYPE_INTR:
-                        seq_printf(f, "%-8s %-8s %-8s %-8s %-8s\n",
-                                   "hard", "soft", "watchdog",
-                                   "spurious", "multsvc");
-                        break;
-                case KSTAT_TYPE_IO:
-                        seq_printf(f,
-                                   "%-8s %-8s %-8s %-8s %-8s %-8s "
-                                   "%-8s %-8s %-8s %-8s %-8s %-8s\n",
-                                   "nread", "nwritten", "reads", "writes",
-                                   "wtime", "wlentime", "wupdate",
-                                   "rtime", "rlentime", "rupdate",
-                                   "wcnt", "rcnt");
-                        break;
-                case KSTAT_TYPE_TIMER:
-                        seq_printf(f,
-                                   "%-31s %-8s "
-                                   "%-8s %-8s %-8s %-8s %-8s\n",
-                                   "name", "events", "elapsed",
-                                   "min", "max", "start", "stop");
-                        break;
-                default:
-                        PANIC("Undefined kstat type %d\n", ksp->ks_type);
-        }
+					seq_puts(f, ksp->ks_raw_buf);
+			} else {
+				seq_printf(f, "raw data\n");
+			}
+			break;
+		case KSTAT_TYPE_NAMED:
+			seq_printf(f, "%-31s %-4s %s\n",
+			    "name", "type", "data");
+			break;
+		case KSTAT_TYPE_INTR:
+			seq_printf(f, "%-8s %-8s %-8s %-8s %-8s\n",
+			    "hard", "soft", "watchdog",
+			    "spurious", "multsvc");
+			break;
+		case KSTAT_TYPE_IO:
+			seq_printf(f,
+			    "%-8s %-8s %-8s %-8s %-8s %-8s "
+			    "%-8s %-8s %-8s %-8s %-8s %-8s\n",
+			    "nread", "nwritten", "reads", "writes",
+			    "wtime", "wlentime", "wupdate",
+			    "rtime", "rlentime", "rupdate",
+			    "wcnt", "rcnt");
+			break;
+		case KSTAT_TYPE_TIMER:
+			seq_printf(f,
+			    "%-31s %-8s "
+			    "%-8s %-8s %-8s %-8s %-8s\n",
+			    "name", "events", "elapsed",
+			    "min", "max", "start", "stop");
+			break;
+		default:
+			PANIC("Undefined kstat type %d\n", ksp->ks_type);
+	}
 
-	return -rc;
+	return (-rc);
 }
 
 static int
 kstat_seq_show_raw(struct seq_file *f, unsigned char *p, int l)
 {
-        int i, j;
+	int i, j;
 
-        for (i = 0; ; i++) {
-                seq_printf(f, "%03x:", i);
+	for (i = 0; ; i++) {
+		seq_printf(f, "%03x:", i);
 
-                for (j = 0; j < 16; j++) {
-                        if (i * 16 + j >= l) {
-                                seq_printf(f, "\n");
-                                goto out;
-                        }
+		for (j = 0; j < 16; j++) {
+			if (i * 16 + j >= l) {
+				seq_printf(f, "\n");
+				goto out;
+			}
 
-                        seq_printf(f, " %02x", (unsigned char)p[i * 16 + j]);
-                }
-                seq_printf(f, "\n");
-        }
+			seq_printf(f, " %02x", (unsigned char)p[i * 16 + j]);
+		}
+		seq_printf(f, "\n");
+	}
 out:
-        return 0;
+	return (0);
 }
 
 static int
 kstat_seq_show_named(struct seq_file *f, kstat_named_t *knp)
 {
-        seq_printf(f, "%-31s %-4d ", knp->name, knp->data_type);
+	seq_printf(f, "%-31s %-4d ", knp->name, knp->data_type);
 
-        switch (knp->data_type) {
-                case KSTAT_DATA_CHAR:
-                        knp->value.c[15] = '\0'; /* NULL terminate */
-                        seq_printf(f, "%-16s", knp->value.c);
-                        break;
-                /* XXX - We need to be more careful able what tokens are
-                 * used for each arch, for now this is correct for x86_64.
-                 */
-                case KSTAT_DATA_INT32:
-                        seq_printf(f, "%d", knp->value.i32);
-                        break;
-                case KSTAT_DATA_UINT32:
-                        seq_printf(f, "%u", knp->value.ui32);
-                        break;
-                case KSTAT_DATA_INT64:
-                        seq_printf(f, "%lld", (signed long long)knp->value.i64);
-                        break;
-                case KSTAT_DATA_UINT64:
-                        seq_printf(f, "%llu", (unsigned long long)knp->value.ui64);
-                        break;
-                case KSTAT_DATA_LONG:
-                        seq_printf(f, "%ld", knp->value.l);
-                        break;
-                case KSTAT_DATA_ULONG:
-                        seq_printf(f, "%lu", knp->value.ul);
-                        break;
-                case KSTAT_DATA_STRING:
-                        KSTAT_NAMED_STR_PTR(knp)
-                                [KSTAT_NAMED_STR_BUFLEN(knp)-1] = '\0';
-                        seq_printf(f, "%s", KSTAT_NAMED_STR_PTR(knp));
-                        break;
-                default:
-                        PANIC("Undefined kstat data type %d\n", knp->data_type);
-        }
+	switch (knp->data_type) {
+		case KSTAT_DATA_CHAR:
+			knp->value.c[15] = '\0'; /* NULL terminate */
+			seq_printf(f, "%-16s", knp->value.c);
+			break;
+		/*
+		 * NOTE - We need to be more careful able what tokens are
+		 * used for each arch, for now this is correct for x86_64.
+		 */
+		case KSTAT_DATA_INT32:
+			seq_printf(f, "%d", knp->value.i32);
+			break;
+		case KSTAT_DATA_UINT32:
+			seq_printf(f, "%u", knp->value.ui32);
+			break;
+		case KSTAT_DATA_INT64:
+			seq_printf(f, "%lld", (signed long long)knp->value.i64);
+			break;
+		case KSTAT_DATA_UINT64:
+			seq_printf(f, "%llu",
+			    (unsigned long long)knp->value.ui64);
+			break;
+		case KSTAT_DATA_LONG:
+			seq_printf(f, "%ld", knp->value.l);
+			break;
+		case KSTAT_DATA_ULONG:
+			seq_printf(f, "%lu", knp->value.ul);
+			break;
+		case KSTAT_DATA_STRING:
+			KSTAT_NAMED_STR_PTR(knp)
+				[KSTAT_NAMED_STR_BUFLEN(knp)-1] = '\0';
+			seq_printf(f, "%s", KSTAT_NAMED_STR_PTR(knp));
+			break;
+		default:
+			PANIC("Undefined kstat data type %d\n", knp->data_type);
+	}
 
-        seq_printf(f, "\n");
+	seq_printf(f, "\n");
 
-        return 0;
+	return (0);
 }
 
 static int
 kstat_seq_show_intr(struct seq_file *f, kstat_intr_t *kip)
 {
-        seq_printf(f, "%-8u %-8u %-8u %-8u %-8u\n",
-                   kip->intrs[KSTAT_INTR_HARD],
-                   kip->intrs[KSTAT_INTR_SOFT],
-                   kip->intrs[KSTAT_INTR_WATCHDOG],
-                   kip->intrs[KSTAT_INTR_SPURIOUS],
-                   kip->intrs[KSTAT_INTR_MULTSVC]);
+	seq_printf(f, "%-8u %-8u %-8u %-8u %-8u\n",
+	    kip->intrs[KSTAT_INTR_HARD],
+	    kip->intrs[KSTAT_INTR_SOFT],
+	    kip->intrs[KSTAT_INTR_WATCHDOG],
+	    kip->intrs[KSTAT_INTR_SPURIOUS],
+	    kip->intrs[KSTAT_INTR_MULTSVC]);
 
-        return 0;
+	return (0);
 }
 
 static int
 kstat_seq_show_io(struct seq_file *f, kstat_io_t *kip)
 {
-        seq_printf(f,
-                   "%-8llu %-8llu %-8u %-8u %-8lld %-8lld "
-                   "%-8lld %-8lld %-8lld %-8lld %-8u %-8u\n",
-                   kip->nread, kip->nwritten,
-                   kip->reads, kip->writes,
-                   kip->wtime, kip->wlentime, kip->wlastupdate,
-                   kip->rtime, kip->rlentime, kip->rlastupdate,
-                   kip->wcnt,  kip->rcnt);
+	seq_printf(f,
+	    "%-8llu %-8llu %-8u %-8u %-8lld %-8lld "
+	    "%-8lld %-8lld %-8lld %-8lld %-8u %-8u\n",
+	    kip->nread, kip->nwritten,
+	    kip->reads, kip->writes,
+	    kip->wtime, kip->wlentime, kip->wlastupdate,
+	    kip->rtime, kip->rlentime, kip->rlastupdate,
+	    kip->wcnt,  kip->rcnt);
 
-        return 0;
+	return (0);
 }
 
 static int
 kstat_seq_show_timer(struct seq_file *f, kstat_timer_t *ktp)
 {
-        seq_printf(f,
-                   "%-31s %-8llu %-8lld %-8lld %-8lld %-8lld %-8lld\n",
-                   ktp->name, ktp->num_events, ktp->elapsed_time,
-                   ktp->min_time, ktp->max_time,
-                   ktp->start_time, ktp->stop_time);
+	seq_printf(f,
+	    "%-31s %-8llu %-8lld %-8lld %-8lld %-8lld %-8lld\n",
+	    ktp->name, ktp->num_events, ktp->elapsed_time,
+	    ktp->min_time, ktp->max_time,
+	    ktp->start_time, ktp->stop_time);
 
-        return 0;
+	return (0);
 }
 
 static int
 kstat_seq_show(struct seq_file *f, void *p)
 {
-        kstat_t *ksp = (kstat_t *)f->private;
-        int rc = 0;
+	kstat_t *ksp = (kstat_t *)f->private;
+	int rc = 0;
 
-        ASSERT(ksp->ks_magic == KS_MAGIC);
+	ASSERT(ksp->ks_magic == KS_MAGIC);
 
 	switch (ksp->ks_type) {
-                case KSTAT_TYPE_RAW:
+		case KSTAT_TYPE_RAW:
 restart:
-                        if (ksp->ks_raw_ops.data) {
-                                rc = ksp->ks_raw_ops.data(
+			if (ksp->ks_raw_ops.data) {
+				rc = ksp->ks_raw_ops.data(
 				    ksp->ks_raw_buf, ksp->ks_raw_bufsize, p);
 				if (rc == ENOMEM && !kstat_resize_raw(ksp))
 					goto restart;
 				if (!rc)
-	                                seq_puts(f, ksp->ks_raw_buf);
-                        } else {
-                                ASSERT(ksp->ks_ndata == 1);
-                                rc = kstat_seq_show_raw(f, ksp->ks_data,
-                                                        ksp->ks_data_size);
-                        }
-                        break;
-                case KSTAT_TYPE_NAMED:
-                        rc = kstat_seq_show_named(f, (kstat_named_t *)p);
-                        break;
-                case KSTAT_TYPE_INTR:
-                        rc = kstat_seq_show_intr(f, (kstat_intr_t *)p);
-                        break;
-                case KSTAT_TYPE_IO:
-                        rc = kstat_seq_show_io(f, (kstat_io_t *)p);
-                        break;
-                case KSTAT_TYPE_TIMER:
-                        rc = kstat_seq_show_timer(f, (kstat_timer_t *)p);
-                        break;
-                default:
-                        PANIC("Undefined kstat type %d\n", ksp->ks_type);
-        }
+					seq_puts(f, ksp->ks_raw_buf);
+			} else {
+				ASSERT(ksp->ks_ndata == 1);
+				rc = kstat_seq_show_raw(f, ksp->ks_data,
+							ksp->ks_data_size);
+			}
+			break;
+		case KSTAT_TYPE_NAMED:
+			rc = kstat_seq_show_named(f, (kstat_named_t *)p);
+			break;
+		case KSTAT_TYPE_INTR:
+			rc = kstat_seq_show_intr(f, (kstat_intr_t *)p);
+			break;
+		case KSTAT_TYPE_IO:
+			rc = kstat_seq_show_io(f, (kstat_io_t *)p);
+			break;
+		case KSTAT_TYPE_TIMER:
+			rc = kstat_seq_show_timer(f, (kstat_timer_t *)p);
+			break;
+		default:
+			PANIC("Undefined kstat type %d\n", ksp->ks_type);
+	}
 
-        return -rc;
+	return (-rc);
 }
 
 int
@@ -333,79 +335,79 @@ kstat_default_update(kstat_t *ksp, int rw)
 	if (rw == KSTAT_WRITE)
 		return (EACCES);
 
-	return 0;
+	return (0);
 }
 
 static void *
 kstat_seq_data_addr(kstat_t *ksp, loff_t n)
 {
-        void *rc = NULL;
+	void *rc = NULL;
 
 	switch (ksp->ks_type) {
-                case KSTAT_TYPE_RAW:
-                        if (ksp->ks_raw_ops.addr)
-                                rc = ksp->ks_raw_ops.addr(ksp, n);
-                        else
-                                rc = ksp->ks_data;
-                        break;
-                case KSTAT_TYPE_NAMED:
-                        rc = ksp->ks_data + n * sizeof(kstat_named_t);
-                        break;
-                case KSTAT_TYPE_INTR:
-                        rc = ksp->ks_data + n * sizeof(kstat_intr_t);
-                        break;
-                case KSTAT_TYPE_IO:
-                        rc = ksp->ks_data + n * sizeof(kstat_io_t);
-                        break;
-                case KSTAT_TYPE_TIMER:
-                        rc = ksp->ks_data + n * sizeof(kstat_timer_t);
-                        break;
-                default:
-                        PANIC("Undefined kstat type %d\n", ksp->ks_type);
-        }
+		case KSTAT_TYPE_RAW:
+			if (ksp->ks_raw_ops.addr)
+				rc = ksp->ks_raw_ops.addr(ksp, n);
+			else
+				rc = ksp->ks_data;
+			break;
+		case KSTAT_TYPE_NAMED:
+			rc = ksp->ks_data + n * sizeof (kstat_named_t);
+			break;
+		case KSTAT_TYPE_INTR:
+			rc = ksp->ks_data + n * sizeof (kstat_intr_t);
+			break;
+		case KSTAT_TYPE_IO:
+			rc = ksp->ks_data + n * sizeof (kstat_io_t);
+			break;
+		case KSTAT_TYPE_TIMER:
+			rc = ksp->ks_data + n * sizeof (kstat_timer_t);
+			break;
+		default:
+			PANIC("Undefined kstat type %d\n", ksp->ks_type);
+	}
 
-        return (rc);
+	return (rc);
 }
 
 static void *
 kstat_seq_start(struct seq_file *f, loff_t *pos)
 {
-        loff_t n = *pos;
-        kstat_t *ksp = (kstat_t *)f->private;
-        ASSERT(ksp->ks_magic == KS_MAGIC);
+	loff_t n = *pos;
+	kstat_t *ksp = (kstat_t *)f->private;
+	ASSERT(ksp->ks_magic == KS_MAGIC);
 
 	mutex_enter(ksp->ks_lock);
 
-        if (ksp->ks_type == KSTAT_TYPE_RAW) {
-                ksp->ks_raw_bufsize = PAGE_SIZE;
-                ksp->ks_raw_buf = vmem_alloc(ksp->ks_raw_bufsize, KM_SLEEP);
-        }
+	if (ksp->ks_type == KSTAT_TYPE_RAW) {
+		ksp->ks_raw_bufsize = PAGE_SIZE;
+		ksp->ks_raw_buf = vmem_alloc(ksp->ks_raw_bufsize, KM_SLEEP);
+	}
 
-        /* Dynamically update kstat, on error existing kstats are used */
-        (void) ksp->ks_update(ksp, KSTAT_READ);
+	/* Dynamically update kstat, on error existing kstats are used */
+	(void) ksp->ks_update(ksp, KSTAT_READ);
 
 	ksp->ks_snaptime = gethrtime();
 
-        if (!n && kstat_seq_show_headers(f))
+	if (!n && kstat_seq_show_headers(f))
 		return (NULL);
 
-        if (n >= ksp->ks_ndata)
-                return (NULL);
+	if (n >= ksp->ks_ndata)
+		return (NULL);
 
-        return (kstat_seq_data_addr(ksp, n));
+	return (kstat_seq_data_addr(ksp, n));
 }
 
 static void *
 kstat_seq_next(struct seq_file *f, void *p, loff_t *pos)
 {
-        kstat_t *ksp = (kstat_t *)f->private;
-        ASSERT(ksp->ks_magic == KS_MAGIC);
+	kstat_t *ksp = (kstat_t *)f->private;
+	ASSERT(ksp->ks_magic == KS_MAGIC);
 
-        ++*pos;
-        if (*pos >= ksp->ks_ndata)
-                return (NULL);
+	++*pos;
+	if (*pos >= ksp->ks_ndata)
+		return (NULL);
 
-        return (kstat_seq_data_addr(ksp, *pos));
+	return (kstat_seq_data_addr(ksp, *pos));
 }
 
 static void
@@ -421,10 +423,10 @@ kstat_seq_stop(struct seq_file *f, void *v)
 }
 
 static struct seq_operations kstat_seq_ops = {
-        .show  = kstat_seq_show,
-        .start = kstat_seq_start,
-        .next  = kstat_seq_next,
-        .stop  = kstat_seq_stop,
+	.show  = kstat_seq_show,
+	.start = kstat_seq_start,
+	.next  = kstat_seq_next,
+	.stop  = kstat_seq_stop,
 };
 
 static kstat_module_t *
@@ -465,28 +467,28 @@ kstat_delete_module(kstat_module_t *module)
 	ASSERT(list_empty(&module->ksm_kstat_list));
 	remove_proc_entry(module->ksm_name, proc_spl_kstat);
 	list_del(&module->ksm_module_list);
-	kmem_free(module, sizeof(kstat_module_t));
+	kmem_free(module, sizeof (kstat_module_t));
 }
 
 static int
 proc_kstat_open(struct inode *inode, struct file *filp)
 {
-        struct seq_file *f;
-        int rc;
+	struct seq_file *f;
+	int rc;
 
-        rc = seq_open(filp, &kstat_seq_ops);
-        if (rc)
-                return rc;
+	rc = seq_open(filp, &kstat_seq_ops);
+	if (rc)
+		return (rc);
 
-        f = filp->private_data;
-        f->private = PDE_DATA(inode);
+	f = filp->private_data;
+	f->private = PDE_DATA(inode);
 
-        return rc;
+	return (rc);
 }
 
 static ssize_t
-proc_kstat_write(struct file *filp, const char __user *buf,
-		 size_t len, loff_t *ppos)
+proc_kstat_write(struct file *filp, const char __user *buf, size_t len,
+    loff_t *ppos)
 {
 	struct seq_file *f = filp->private_data;
 	kstat_t *ksp = f->private;
@@ -527,8 +529,8 @@ EXPORT_SYMBOL(__kstat_set_raw_ops);
 
 kstat_t *
 __kstat_create(const char *ks_module, int ks_instance, const char *ks_name,
-             const char *ks_class, uchar_t ks_type, uint_t ks_ndata,
-             uchar_t ks_flags)
+    const char *ks_class, uchar_t ks_type, uint_t ks_ndata,
+    uchar_t ks_flags)
 {
 	kstat_t *ksp;
 
@@ -538,24 +540,24 @@ __kstat_create(const char *ks_module, int ks_instance, const char *ks_name,
 	ASSERT(!(ks_flags & KSTAT_FLAG_UNSUPPORTED));
 
 	if ((ks_type == KSTAT_TYPE_INTR) || (ks_type == KSTAT_TYPE_IO))
-                ASSERT(ks_ndata == 1);
+		ASSERT(ks_ndata == 1);
 
-	ksp = kmem_zalloc(sizeof(*ksp), KM_SLEEP);
+	ksp = kmem_zalloc(sizeof (*ksp), KM_SLEEP);
 	if (ksp == NULL)
-		return ksp;
+		return (ksp);
 
 	mutex_enter(&kstat_module_lock);
 	ksp->ks_kid = kstat_id;
-        kstat_id++;
+	kstat_id++;
 	mutex_exit(&kstat_module_lock);
 
-        ksp->ks_magic = KS_MAGIC;
+	ksp->ks_magic = KS_MAGIC;
 	mutex_init(&ksp->ks_private_lock, NULL, MUTEX_DEFAULT, NULL);
 	ksp->ks_lock = &ksp->ks_private_lock;
 	INIT_LIST_HEAD(&ksp->ks_list);
 
 	ksp->ks_crtime = gethrtime();
-        ksp->ks_snaptime = ksp->ks_crtime;
+	ksp->ks_snaptime = ksp->ks_crtime;
 	strncpy(ksp->ks_module, ks_module, KSTAT_STRLEN);
 	ksp->ks_instance = ks_instance;
 	strncpy(ksp->ks_name, ks_name, KSTAT_STRLEN);
@@ -571,41 +573,41 @@ __kstat_create(const char *ks_module, int ks_instance, const char *ks_name,
 	ksp->ks_raw_bufsize = 0;
 
 	switch (ksp->ks_type) {
-                case KSTAT_TYPE_RAW:
-	                ksp->ks_ndata = 1;
-                        ksp->ks_data_size = ks_ndata;
-                        break;
-                case KSTAT_TYPE_NAMED:
-	                ksp->ks_ndata = ks_ndata;
-                        ksp->ks_data_size = ks_ndata * sizeof(kstat_named_t);
-                        break;
-                case KSTAT_TYPE_INTR:
-	                ksp->ks_ndata = ks_ndata;
-                        ksp->ks_data_size = ks_ndata * sizeof(kstat_intr_t);
-                        break;
-                case KSTAT_TYPE_IO:
-	                ksp->ks_ndata = ks_ndata;
-                        ksp->ks_data_size = ks_ndata * sizeof(kstat_io_t);
-                        break;
-                case KSTAT_TYPE_TIMER:
-	                ksp->ks_ndata = ks_ndata;
-                        ksp->ks_data_size = ks_ndata * sizeof(kstat_timer_t);
-                        break;
-                default:
-                        PANIC("Undefined kstat type %d\n", ksp->ks_type);
-        }
+		case KSTAT_TYPE_RAW:
+			ksp->ks_ndata = 1;
+			ksp->ks_data_size = ks_ndata;
+			break;
+		case KSTAT_TYPE_NAMED:
+			ksp->ks_ndata = ks_ndata;
+			ksp->ks_data_size = ks_ndata * sizeof (kstat_named_t);
+			break;
+		case KSTAT_TYPE_INTR:
+			ksp->ks_ndata = ks_ndata;
+			ksp->ks_data_size = ks_ndata * sizeof (kstat_intr_t);
+			break;
+		case KSTAT_TYPE_IO:
+			ksp->ks_ndata = ks_ndata;
+			ksp->ks_data_size = ks_ndata * sizeof (kstat_io_t);
+			break;
+		case KSTAT_TYPE_TIMER:
+			ksp->ks_ndata = ks_ndata;
+			ksp->ks_data_size = ks_ndata * sizeof (kstat_timer_t);
+			break;
+		default:
+			PANIC("Undefined kstat type %d\n", ksp->ks_type);
+	}
 
 	if (ksp->ks_flags & KSTAT_FLAG_VIRTUAL) {
-                ksp->ks_data = NULL;
-        } else {
-                ksp->ks_data = kmem_zalloc(ksp->ks_data_size, KM_SLEEP);
-                if (ksp->ks_data == NULL) {
-                        kmem_free(ksp, sizeof(*ksp));
-                        ksp = NULL;
-                }
-        }
+		ksp->ks_data = NULL;
+	} else {
+		ksp->ks_data = kmem_zalloc(ksp->ks_data_size, KM_SLEEP);
+		if (ksp->ks_data == NULL) {
+			kmem_free(ksp, sizeof (*ksp));
+			ksp = NULL;
+		}
+	}
 
-	return ksp;
+	return (ksp);
 }
 EXPORT_SYMBOL(__kstat_create);
 
@@ -706,9 +708,7 @@ __kstat_delete(kstat_t *ksp)
 
 	ksp->ks_lock = NULL;
 	mutex_destroy(&ksp->ks_private_lock);
-	kmem_free(ksp, sizeof(*ksp));
-
-	return;
+	kmem_free(ksp, sizeof (*ksp));
 }
 EXPORT_SYMBOL(__kstat_delete);
 
@@ -717,7 +717,7 @@ spl_kstat_init(void)
 {
 	mutex_init(&kstat_module_lock, NULL, MUTEX_DEFAULT, NULL);
 	INIT_LIST_HEAD(&kstat_module_list);
-        kstat_id = 0;
+	kstat_id = 0;
 	return (0);
 }
 
@@ -727,4 +727,3 @@ spl_kstat_fini(void)
 	ASSERT(list_empty(&kstat_module_list));
 	mutex_destroy(&kstat_module_lock);
 }
-

--- a/module/spl/spl-mutex.c
+++ b/module/spl/spl-mutex.c
@@ -20,17 +20,11 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Mutex Implementation.
  */
 
 #include <sys/mutex.h>
-
-#ifdef DEBUG_SUBSYSTEM
-#undef DEBUG_SUBSYSTEM
-#endif
-
-#define DEBUG_SUBSYSTEM S_MUTEX
 
 int spl_mutex_init(void) { return 0; }
 void spl_mutex_fini(void) { }

--- a/module/spl/spl-proc.c
+++ b/module/spl/spl-proc.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Proc Implementation.
  */
 
@@ -37,7 +37,7 @@
 #include <linux/uaccess.h>
 #include <linux/version.h>
 
-#if defined(CONSTIFY_PLUGIN) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0)
+#if defined(CONSTIFY_PLUGIN) && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
 typedef struct ctl_table __no_const spl_ctl_table;
 #else
 typedef struct ctl_table spl_ctl_table;
@@ -55,56 +55,57 @@ static struct proc_dir_entry *proc_spl_taskq = NULL;
 struct proc_dir_entry *proc_spl_kstat = NULL;
 
 static int
-proc_copyin_string(char *kbuffer, int kbuffer_size,
-                   const char *ubuffer, int ubuffer_size)
+proc_copyin_string(char *kbuffer, int kbuffer_size, const char *ubuffer,
+    int ubuffer_size)
 {
-        int size;
+	int size;
 
-        if (ubuffer_size > kbuffer_size)
-                return -EOVERFLOW;
+	if (ubuffer_size > kbuffer_size)
+		return (-EOVERFLOW);
 
-        if (copy_from_user((void *)kbuffer, (void *)ubuffer, ubuffer_size))
-                return -EFAULT;
+	if (copy_from_user((void *)kbuffer, (void *)ubuffer, ubuffer_size))
+		return (-EFAULT);
 
-        /* strip trailing whitespace */
-        size = strnlen(kbuffer, ubuffer_size);
-        while (size-- >= 0)
-                if (!isspace(kbuffer[size]))
-                        break;
+	/* strip trailing whitespace */
+	size = strnlen(kbuffer, ubuffer_size);
+	while (size-- >= 0)
+		if (!isspace(kbuffer[size]))
+			break;
 
-        /* empty string */
-        if (size < 0)
-                return -EINVAL;
+	/* empty string */
+	if (size < 0)
+		return (-EINVAL);
 
-        /* no space to terminate */
-        if (size == kbuffer_size)
-                return -EOVERFLOW;
+	/* no space to terminate */
+	if (size == kbuffer_size)
+		return (-EOVERFLOW);
 
-        kbuffer[size + 1] = 0;
-        return 0;
+	kbuffer[size + 1] = 0;
+	return (0);
 }
 
 static int
 proc_copyout_string(char *ubuffer, int ubuffer_size,
-                    const char *kbuffer, char *append)
+		    const char *kbuffer, char *append)
 {
-        /* NB if 'append' != NULL, it's a single character to append to the
-         * copied out string - usually "\n", for /proc entries and
-         * (i.e. a terminating zero byte) for sysctl entries
-         */
-        int size = MIN(strlen(kbuffer), ubuffer_size);
+	/*
+	 * NB if 'append' != NULL, it's a single character to append to the
+	 * copied out string - usually "\n", for /proc entries and
+	 * (i.e. a terminating zero byte) for sysctl entries
+	 */
+	int size = MIN(strlen(kbuffer), ubuffer_size);
 
-        if (copy_to_user(ubuffer, kbuffer, size))
-                return -EFAULT;
+	if (copy_to_user(ubuffer, kbuffer, size))
+		return (-EFAULT);
 
-        if (append != NULL && size < ubuffer_size) {
-                if (copy_to_user(ubuffer + size, append, 1))
-                        return -EFAULT;
+	if (append != NULL && size < ubuffer_size) {
+		if (copy_to_user(ubuffer + size, append, 1))
+			return (-EFAULT);
 
-                size++;
-        }
+		size++;
+	}
 
-        return size;
+	return (size);
 }
 
 #ifdef DEBUG_KMEM
@@ -112,27 +113,27 @@ static int
 proc_domemused(struct ctl_table *table, int write,
     void __user *buffer, size_t *lenp, loff_t *ppos)
 {
-        int rc = 0;
-        unsigned long min = 0, max = ~0, val;
-        spl_ctl_table dummy = *table;
+	int rc = 0;
+	unsigned long min = 0, max = ~0, val;
+	spl_ctl_table dummy = *table;
 
-        dummy.data = &val;
-        dummy.proc_handler = &proc_dointvec;
-        dummy.extra1 = &min;
-        dummy.extra2 = &max;
+	dummy.data = &val;
+	dummy.proc_handler = &proc_dointvec;
+	dummy.extra1 = &min;
+	dummy.extra2 = &max;
 
-        if (write) {
-                *ppos += *lenp;
-        } else {
-# ifdef HAVE_ATOMIC64_T
-                val = atomic64_read((atomic64_t *)table->data);
-# else
-                val = atomic_read((atomic_t *)table->data);
-# endif /* HAVE_ATOMIC64_T */
-                rc = proc_doulongvec_minmax(&dummy, write, buffer, lenp, ppos);
-        }
+	if (write) {
+		*ppos += *lenp;
+	} else {
+#ifdef HAVE_ATOMIC64_T
+		val = atomic64_read((atomic64_t *)table->data);
+#else
+		val = atomic_read((atomic_t *)table->data);
+#endif /* HAVE_ATOMIC64_T */
+		rc = proc_doulongvec_minmax(&dummy, write, buffer, lenp, ppos);
+	}
 
-        return (rc);
+	return (rc);
 }
 #endif /* DEBUG_KMEM */
 
@@ -140,23 +141,23 @@ static int
 proc_doslab(struct ctl_table *table, int write,
     void __user *buffer, size_t *lenp, loff_t *ppos)
 {
-        int rc = 0;
-        unsigned long min = 0, max = ~0, val = 0, mask;
-        spl_ctl_table dummy = *table;
-        spl_kmem_cache_t *skc;
+	int rc = 0;
+	unsigned long min = 0, max = ~0, val = 0, mask;
+	spl_ctl_table dummy = *table;
+	spl_kmem_cache_t *skc;
 
-        dummy.data = &val;
-        dummy.proc_handler = &proc_dointvec;
-        dummy.extra1 = &min;
-        dummy.extra2 = &max;
+	dummy.data = &val;
+	dummy.proc_handler = &proc_dointvec;
+	dummy.extra1 = &min;
+	dummy.extra2 = &max;
 
-        if (write) {
-                *ppos += *lenp;
-        } else {
-                down_read(&spl_kmem_cache_sem);
-                mask = (unsigned long)table->data;
+	if (write) {
+		*ppos += *lenp;
+	} else {
+		down_read(&spl_kmem_cache_sem);
+		mask = (unsigned long)table->data;
 
-                list_for_each_entry(skc, &spl_kmem_cache_list, skc_list) {
+		list_for_each_entry(skc, &spl_kmem_cache_list, skc_list) {
 
 			/* Only use slabs of the correct kmem/vmem type */
 			if (!(skc->skc_flags & mask))
@@ -165,58 +166,61 @@ proc_doslab(struct ctl_table *table, int write,
 			/* Sum the specified field for selected slabs */
 			switch (mask & (KMC_TOTAL | KMC_ALLOC | KMC_MAX)) {
 			case KMC_TOTAL:
-	                        val += skc->skc_slab_size * skc->skc_slab_total;
+				val += skc->skc_slab_size * skc->skc_slab_total;
 				break;
 			case KMC_ALLOC:
-	                        val += skc->skc_obj_size * skc->skc_obj_alloc;
+				val += skc->skc_obj_size * skc->skc_obj_alloc;
 				break;
 			case KMC_MAX:
-	                        val += skc->skc_obj_size * skc->skc_obj_max;
+				val += skc->skc_obj_size * skc->skc_obj_max;
 				break;
 			}
-                }
+		}
 
-                up_read(&spl_kmem_cache_sem);
-                rc = proc_doulongvec_minmax(&dummy, write, buffer, lenp, ppos);
-        }
+		up_read(&spl_kmem_cache_sem);
+		rc = proc_doulongvec_minmax(&dummy, write, buffer, lenp, ppos);
+	}
 
-        return (rc);
+	return (rc);
 }
 
 static int
 proc_dohostid(struct ctl_table *table, int write,
     void __user *buffer, size_t *lenp, loff_t *ppos)
 {
-        int len, rc = 0;
-        char *end, str[32];
+	int len, rc = 0;
+	char *end, str[32];
 
-        if (write) {
-                /* We can't use proc_doulongvec_minmax() in the write
-                 * case here because hostid while a hex value has no
-                 * leading 0x which confuses the helper function. */
-                rc = proc_copyin_string(str, sizeof(str), buffer, *lenp);
-                if (rc < 0)
-                        return (rc);
+	if (write) {
+		/*
+		 * We can't use proc_doulongvec_minmax() in the write
+		 * case here because hostid while a hex value has no
+		 * leading 0x which confuses the helper function.
+		 */
+		rc = proc_copyin_string(str, sizeof (str), buffer, *lenp);
+		if (rc < 0)
+			return (rc);
 
-                spl_hostid = simple_strtoul(str, &end, 16);
-                if (str == end)
-                        return (-EINVAL);
+		spl_hostid = simple_strtoul(str, &end, 16);
+		if (str == end)
+			return (-EINVAL);
 
-        } else {
-                len = snprintf(str, sizeof(str), "%lx",
+	} else {
+		len = snprintf(str, sizeof (str), "%lx",
 		    (unsigned long) zone_get_hostid(NULL));
-                if (*ppos >= len)
-                        rc = 0;
-                else
-                        rc = proc_copyout_string(buffer,*lenp,str+*ppos,"\n");
+		if (*ppos >= len)
+			rc = 0;
+		else
+			rc = proc_copyout_string(buffer,
+			    *lenp, str + *ppos, "\n");
 
-                if (rc >= 0) {
-                        *lenp = rc;
-                        *ppos += rc;
-                }
-        }
+		if (rc >= 0) {
+			*lenp = rc;
+			*ppos += rc;
+		}
+	}
 
-        return (rc);
+	return (rc);
 }
 
 static void
@@ -229,11 +233,11 @@ taskq_seq_show_headers(struct seq_file *f)
 
 /* indices into the lheads array below */
 #define	LHEAD_PEND	0
-#define LHEAD_PRIO	1
-#define LHEAD_DELAY	2
-#define LHEAD_WAIT	3
-#define LHEAD_ACTIVE	4
-#define LHEAD_SIZE	5
+#define	LHEAD_PRIO	1
+#define	LHEAD_DELAY	2
+#define	LHEAD_WAIT	3
+#define	LHEAD_ACTIVE	4
+#define	LHEAD_SIZE	5
 
 static unsigned int spl_max_show_tasks = 512;
 module_param(spl_max_show_tasks, uint, 0644);
@@ -287,7 +291,7 @@ taskq_seq_show_impl(struct seq_file *f, void *p, boolean_t allflag)
 		spin_unlock_irqrestore(&tq->tq_wait_waitq.lock, wflags);
 
 	/* show the base taskq contents */
-	snprintf(name, sizeof(name), "%s/%d", tq->tq_name, tq->tq_instance);
+	snprintf(name, sizeof (name), "%s/%d", tq->tq_name, tq->tq_instance);
 	seq_printf(f, "%-25s ", name);
 	seq_printf(f, "%5d %5d %5d %5d %5d %5d %12d %5d %10x\n",
 	    tq->tq_nactive, tq->tq_nthreads, tq->tq_nspawn,
@@ -299,7 +303,8 @@ taskq_seq_show_impl(struct seq_file *f, void *p, boolean_t allflag)
 		j = 0;
 		list_for_each_entry(tqt, &tq->tq_active_list, tqt_active_list) {
 			if (j == 0)
-				seq_printf(f, "\t%s:", list_names[LHEAD_ACTIVE]);
+				seq_printf(f, "\t%s:",
+				    list_names[LHEAD_ACTIVE]);
 			else if (j == 2) {
 				seq_printf(f, "\n\t       ");
 				j = 0;
@@ -403,32 +408,32 @@ taskq_seq_next(struct seq_file *f, void *p, loff_t *pos)
 
 	++*pos;
 	return ((tq->tq_taskqs.next == &tq_list) ?
-	       NULL : list_entry(tq->tq_taskqs.next, taskq_t, tq_taskqs));
+	    NULL : list_entry(tq->tq_taskqs.next, taskq_t, tq_taskqs));
 }
 
 static void
 slab_seq_show_headers(struct seq_file *f)
 {
-        seq_printf(f,
-            "--------------------- cache ----------"
-            "---------------------------------------------  "
-            "----- slab ------  "
-            "---- object -----  "
-            "--- emergency ---\n");
-        seq_printf(f,
-            "name                                  "
-            "  flags      size     alloc slabsize  objsize  "
-            "total alloc   max  "
-            "total alloc   max  "
-            "dlock alloc   max\n");
+	seq_printf(f,
+	    "--------------------- cache ----------"
+	    "---------------------------------------------  "
+	    "----- slab ------  "
+	    "---- object -----  "
+	    "--- emergency ---\n");
+	seq_printf(f,
+	    "name                                  "
+	    "  flags      size     alloc slabsize  objsize  "
+	    "total alloc   max  "
+	    "total alloc   max  "
+	    "dlock alloc   max\n");
 }
 
 static int
 slab_seq_show(struct seq_file *f, void *p)
 {
-        spl_kmem_cache_t *skc = p;
+	spl_kmem_cache_t *skc = p;
 
-        ASSERT(skc->skc_magic == SKC_MAGIC);
+	ASSERT(skc->skc_magic == SKC_MAGIC);
 
 	/*
 	 * Backed by Linux slab see /proc/slabinfo.
@@ -436,48 +441,48 @@ slab_seq_show(struct seq_file *f, void *p)
 	if (skc->skc_flags & KMC_SLAB)
 		return (0);
 
-        spin_lock(&skc->skc_lock);
-        seq_printf(f, "%-36s  ", skc->skc_name);
-        seq_printf(f, "0x%05lx %9lu %9lu %8u %8u  "
-            "%5lu %5lu %5lu  %5lu %5lu %5lu  %5lu %5lu %5lu\n",
-            (long unsigned)skc->skc_flags,
-            (long unsigned)(skc->skc_slab_size * skc->skc_slab_total),
-            (long unsigned)(skc->skc_obj_size * skc->skc_obj_alloc),
-            (unsigned)skc->skc_slab_size,
-            (unsigned)skc->skc_obj_size,
-            (long unsigned)skc->skc_slab_total,
-            (long unsigned)skc->skc_slab_alloc,
-            (long unsigned)skc->skc_slab_max,
-            (long unsigned)skc->skc_obj_total,
-            (long unsigned)skc->skc_obj_alloc,
-            (long unsigned)skc->skc_obj_max,
-            (long unsigned)skc->skc_obj_deadlock,
-            (long unsigned)skc->skc_obj_emergency,
-            (long unsigned)skc->skc_obj_emergency_max);
+	spin_lock(&skc->skc_lock);
+	seq_printf(f, "%-36s  ", skc->skc_name);
+	seq_printf(f, "0x%05lx %9lu %9lu %8u %8u  "
+	    "%5lu %5lu %5lu  %5lu %5lu %5lu  %5lu %5lu %5lu\n",
+	    (long unsigned)skc->skc_flags,
+	    (long unsigned)(skc->skc_slab_size * skc->skc_slab_total),
+	    (long unsigned)(skc->skc_obj_size * skc->skc_obj_alloc),
+	    (unsigned)skc->skc_slab_size,
+	    (unsigned)skc->skc_obj_size,
+	    (long unsigned)skc->skc_slab_total,
+	    (long unsigned)skc->skc_slab_alloc,
+	    (long unsigned)skc->skc_slab_max,
+	    (long unsigned)skc->skc_obj_total,
+	    (long unsigned)skc->skc_obj_alloc,
+	    (long unsigned)skc->skc_obj_max,
+	    (long unsigned)skc->skc_obj_deadlock,
+	    (long unsigned)skc->skc_obj_emergency,
+	    (long unsigned)skc->skc_obj_emergency_max);
 
-        spin_unlock(&skc->skc_lock);
+	spin_unlock(&skc->skc_lock);
 
-        return 0;
+	return (0);
 }
 
 static void *
 slab_seq_start(struct seq_file *f, loff_t *pos)
 {
-        struct list_head *p;
-        loff_t n = *pos;
+	struct list_head *p;
+	loff_t n = *pos;
 
 	down_read(&spl_kmem_cache_sem);
-        if (!n)
-                slab_seq_show_headers(f);
+	if (!n)
+		slab_seq_show_headers(f);
 
-        p = spl_kmem_cache_list.next;
-        while (n--) {
-                p = p->next;
-                if (p == &spl_kmem_cache_list)
-                        return (NULL);
-        }
+	p = spl_kmem_cache_list.next;
+	while (n--) {
+		p = p->next;
+		if (p == &spl_kmem_cache_list)
+			return (NULL);
+	}
 
-        return (list_entry(p, spl_kmem_cache_t, skc_list));
+	return (list_entry(p, spl_kmem_cache_t, skc_list));
 }
 
 static void *
@@ -485,9 +490,9 @@ slab_seq_next(struct seq_file *f, void *p, loff_t *pos)
 {
 	spl_kmem_cache_t *skc = p;
 
-        ++*pos;
-        return ((skc->skc_list.next == &spl_kmem_cache_list) ?
-	       NULL : list_entry(skc->skc_list.next,spl_kmem_cache_t,skc_list));
+	++*pos;
+	return ((skc->skc_list.next == &spl_kmem_cache_list) ?
+	    NULL : list_entry(skc->skc_list.next, spl_kmem_cache_t, skc_list));
 }
 
 static void
@@ -497,23 +502,23 @@ slab_seq_stop(struct seq_file *f, void *v)
 }
 
 static struct seq_operations slab_seq_ops = {
-        .show  = slab_seq_show,
-        .start = slab_seq_start,
-        .next  = slab_seq_next,
-        .stop  = slab_seq_stop,
+	.show  = slab_seq_show,
+	.start = slab_seq_start,
+	.next  = slab_seq_next,
+	.stop  = slab_seq_stop,
 };
 
 static int
 proc_slab_open(struct inode *inode, struct file *filp)
 {
-        return seq_open(filp, &slab_seq_ops);
+	return (seq_open(filp, &slab_seq_ops));
 }
 
 static struct file_operations proc_slab_operations = {
-        .open           = proc_slab_open,
-        .read           = seq_read,
-        .llseek         = seq_lseek,
-        .release        = seq_release,
+	.open	   = proc_slab_open,
+	.read	   = seq_read,
+	.llseek	 = seq_lseek,
+	.release	= seq_release,
 };
 
 static void
@@ -523,122 +528,122 @@ taskq_seq_stop(struct seq_file *f, void *v)
 }
 
 static struct seq_operations taskq_all_seq_ops = {
-	.show  = taskq_all_seq_show,
-	.start = taskq_seq_start,
-	.next  = taskq_seq_next,
-	.stop  = taskq_seq_stop,
+	.show	= taskq_all_seq_show,
+	.start	= taskq_seq_start,
+	.next	= taskq_seq_next,
+	.stop	= taskq_seq_stop,
 };
 
 static struct seq_operations taskq_seq_ops = {
-	.show  = taskq_seq_show,
-	.start = taskq_seq_start,
-	.next  = taskq_seq_next,
-	.stop  = taskq_seq_stop,
+	.show	= taskq_seq_show,
+	.start	= taskq_seq_start,
+	.next	= taskq_seq_next,
+	.stop	= taskq_seq_stop,
 };
 
 static int
 proc_taskq_all_open(struct inode *inode, struct file *filp)
 {
-	return seq_open(filp, &taskq_all_seq_ops);
+	return (seq_open(filp, &taskq_all_seq_ops));
 }
 
 static int
 proc_taskq_open(struct inode *inode, struct file *filp)
 {
-	return seq_open(filp, &taskq_seq_ops);
+	return (seq_open(filp, &taskq_seq_ops));
 }
 
 static struct file_operations proc_taskq_all_operations = {
-	.open           = proc_taskq_all_open,
-	.read           = seq_read,
-	.llseek         = seq_lseek,
-	.release        = seq_release,
+	.open		= proc_taskq_all_open,
+	.read		= seq_read,
+	.llseek		= seq_lseek,
+	.release	= seq_release,
 };
 
 static struct file_operations proc_taskq_operations = {
-	.open           = proc_taskq_open,
-	.read           = seq_read,
-	.llseek         = seq_lseek,
-	.release        = seq_release,
+	.open		= proc_taskq_open,
+	.read		= seq_read,
+	.llseek		= seq_lseek,
+	.release	= seq_release,
 };
 
 static struct ctl_table spl_kmem_table[] = {
 #ifdef DEBUG_KMEM
-        {
-                .procname = "kmem_used",
-                .data     = &kmem_alloc_used,
-# ifdef HAVE_ATOMIC64_T
-                .maxlen   = sizeof(atomic64_t),
-# else
-                .maxlen   = sizeof(atomic_t),
-# endif /* HAVE_ATOMIC64_T */
-                .mode     = 0444,
-                .proc_handler = &proc_domemused,
-        },
-        {
-                .procname = "kmem_max",
-                .data     = &kmem_alloc_max,
-                .maxlen   = sizeof(unsigned long),
-                .extra1   = &table_min,
-                .extra2   = &table_max,
-                .mode     = 0444,
-                .proc_handler = &proc_doulongvec_minmax,
-        },
+	{
+		.procname	= "kmem_used",
+		.data		= &kmem_alloc_used,
+#ifdef HAVE_ATOMIC64_T
+		.maxlen		= sizeof (atomic64_t),
+#else
+		.maxlen		= sizeof (atomic_t),
+#endif /* HAVE_ATOMIC64_T */
+		.mode		= 0444,
+		.proc_handler	= &proc_domemused,
+	},
+	{
+		.procname	= "kmem_max",
+		.data		= &kmem_alloc_max,
+		.maxlen		= sizeof (unsigned long),
+		.extra1		= &table_min,
+		.extra2		= &table_max,
+		.mode		= 0444,
+		.proc_handler	= &proc_doulongvec_minmax,
+	},
 #endif /* DEBUG_KMEM */
-        {
-                .procname = "slab_kmem_total",
-		.data     = (void *)(KMC_KMEM | KMC_TOTAL),
-                .maxlen   = sizeof(unsigned long),
-                .extra1   = &table_min,
-                .extra2   = &table_max,
-                .mode     = 0444,
-                .proc_handler = &proc_doslab,
-        },
-        {
-                .procname = "slab_kmem_alloc",
-		.data     = (void *)(KMC_KMEM | KMC_ALLOC),
-                .maxlen   = sizeof(unsigned long),
-                .extra1   = &table_min,
-                .extra2   = &table_max,
-                .mode     = 0444,
-                .proc_handler = &proc_doslab,
-        },
-        {
-                .procname = "slab_kmem_max",
-		.data     = (void *)(KMC_KMEM | KMC_MAX),
-                .maxlen   = sizeof(unsigned long),
-                .extra1   = &table_min,
-                .extra2   = &table_max,
-                .mode     = 0444,
-                .proc_handler = &proc_doslab,
-        },
-        {
-                .procname = "slab_vmem_total",
-		.data     = (void *)(KMC_VMEM | KMC_TOTAL),
-                .maxlen   = sizeof(unsigned long),
-                .extra1   = &table_min,
-                .extra2   = &table_max,
-                .mode     = 0444,
-                .proc_handler = &proc_doslab,
-        },
-        {
-                .procname = "slab_vmem_alloc",
-		.data     = (void *)(KMC_VMEM | KMC_ALLOC),
-                .maxlen   = sizeof(unsigned long),
-                .extra1   = &table_min,
-                .extra2   = &table_max,
-                .mode     = 0444,
-                .proc_handler = &proc_doslab,
-        },
-        {
-                .procname = "slab_vmem_max",
-		.data     = (void *)(KMC_VMEM | KMC_MAX),
-                .maxlen   = sizeof(unsigned long),
-                .extra1   = &table_min,
-                .extra2   = &table_max,
-                .mode     = 0444,
-                .proc_handler = &proc_doslab,
-        },
+	{
+		.procname	= "slab_kmem_total",
+		.data		= (void *)(KMC_KMEM | KMC_TOTAL),
+		.maxlen		= sizeof (unsigned long),
+		.extra1		= &table_min,
+		.extra2		= &table_max,
+		.mode		= 0444,
+		.proc_handler = &proc_doslab,
+	},
+	{
+		.procname	= "slab_kmem_alloc",
+		.data		= (void *)(KMC_KMEM | KMC_ALLOC),
+		.maxlen		= sizeof (unsigned long),
+		.extra1		= &table_min,
+		.extra2		= &table_max,
+		.mode		= 0444,
+		.proc_handler	= &proc_doslab,
+	},
+	{
+		.procname	= "slab_kmem_max",
+		.data		= (void *)(KMC_KMEM | KMC_MAX),
+		.maxlen		= sizeof (unsigned long),
+		.extra1		= &table_min,
+		.extra2		= &table_max,
+		.mode		= 0444,
+		.proc_handler	= &proc_doslab,
+	},
+	{
+		.procname	= "slab_vmem_total",
+		.data		= (void *)(KMC_VMEM | KMC_TOTAL),
+		.maxlen		= sizeof (unsigned long),
+		.extra1		= &table_min,
+		.extra2		= &table_max,
+		.mode		= 0444,
+		.proc_handler	= &proc_doslab,
+	},
+	{
+		.procname	= "slab_vmem_alloc",
+		.data		= (void *)(KMC_VMEM | KMC_ALLOC),
+		.maxlen		= sizeof (unsigned long),
+		.extra1		= &table_min,
+		.extra2		= &table_max,
+		.mode		= 0444,
+		.proc_handler	= &proc_doslab,
+	},
+	{
+		.procname	= "slab_vmem_max",
+		.data		= (void *)(KMC_VMEM | KMC_MAX),
+		.maxlen		= sizeof (unsigned long),
+		.extra1		= &table_min,
+		.extra2		= &table_max,
+		.mode		= 0444,
+		.proc_handler	= &proc_doslab,
+	},
 	{},
 };
 
@@ -647,43 +652,44 @@ static struct ctl_table spl_kstat_table[] = {
 };
 
 static struct ctl_table spl_table[] = {
-        /* NB No .strategy entries have been provided since
-         * sysctl(8) prefers to go via /proc for portability.
-         */
-        {
-                .procname = "version",
-                .data     = spl_version,
-                .maxlen   = sizeof(spl_version),
-                .mode     = 0444,
-                .proc_handler = &proc_dostring,
-        },
-        {
-                .procname = "hostid",
-                .data     = &spl_hostid,
-                .maxlen   = sizeof(unsigned long),
-                .mode     = 0644,
-                .proc_handler = &proc_dohostid,
-        },
+	/*
+	 * NB No .strategy entries have been provided since
+	 * sysctl(8) prefers to go via /proc for portability.
+	 */
 	{
-		.procname = "kmem",
-		.mode     = 0555,
-		.child    = spl_kmem_table,
+		.procname	= "version",
+		.data		= spl_version,
+		.maxlen		= sizeof (spl_version),
+		.mode		= 0444,
+		.proc_handler	= &proc_dostring,
 	},
 	{
-		.procname = "kstat",
-		.mode     = 0555,
-		.child    = spl_kstat_table,
+		.procname	= "hostid",
+		.data		= &spl_hostid,
+		.maxlen		= sizeof (unsigned long),
+		.mode		= 0644,
+		.proc_handler	= &proc_dohostid,
 	},
-        {},
+	{
+		.procname	= "kmem",
+		.mode		= 0555,
+		.child		= spl_kmem_table,
+	},
+	{
+		.procname	= "kstat",
+		.mode		= 0555,
+		.child		= spl_kstat_table,
+	},
+	{},
 };
 
 static struct ctl_table spl_dir[] = {
-        {
-                .procname = "spl",
-                .mode     = 0555,
-                .child    = spl_table,
-        },
-        {}
+	{
+		.procname	= "spl",
+		.mode		= 0555,
+		.child		= spl_table,
+	},
+	{}
 };
 
 static struct ctl_table spl_root[] = {
@@ -703,7 +709,7 @@ spl_proc_init(void)
 {
 	int rc = 0;
 
-        spl_header = register_sysctl_table(spl_root);
+	spl_header = register_sysctl_table(spl_root);
 	if (spl_header == NULL)
 		return (-EUNATCH);
 
@@ -727,48 +733,48 @@ spl_proc_init(void)
 		goto out;
 	}
 
-        proc_spl_kmem = proc_mkdir("kmem", proc_spl);
-        if (proc_spl_kmem == NULL) {
-                rc = -EUNATCH;
+	proc_spl_kmem = proc_mkdir("kmem", proc_spl);
+	if (proc_spl_kmem == NULL) {
+		rc = -EUNATCH;
 		goto out;
 	}
 
 	proc_spl_kmem_slab = proc_create_data("slab", 0444,
 		proc_spl_kmem, &proc_slab_operations, NULL);
-        if (proc_spl_kmem_slab == NULL) {
+	if (proc_spl_kmem_slab == NULL) {
 		rc = -EUNATCH;
 		goto out;
 	}
 
-        proc_spl_kstat = proc_mkdir("kstat", proc_spl);
-        if (proc_spl_kstat == NULL) {
-                rc = -EUNATCH;
+	proc_spl_kstat = proc_mkdir("kstat", proc_spl);
+	if (proc_spl_kstat == NULL) {
+		rc = -EUNATCH;
 		goto out;
 	}
 out:
 	if (rc) {
 		remove_proc_entry("kstat", proc_spl);
-	        remove_proc_entry("slab", proc_spl_kmem);
+		remove_proc_entry("slab", proc_spl_kmem);
 		remove_proc_entry("kmem", proc_spl);
 		remove_proc_entry("taskq-all", proc_spl);
 		remove_proc_entry("taskq", proc_spl);
 		remove_proc_entry("spl", NULL);
-	        unregister_sysctl_table(spl_header);
+		unregister_sysctl_table(spl_header);
 	}
 
-        return (rc);
+	return (rc);
 }
 
 void
 spl_proc_fini(void)
 {
 	remove_proc_entry("kstat", proc_spl);
-        remove_proc_entry("slab", proc_spl_kmem);
+	remove_proc_entry("slab", proc_spl_kmem);
 	remove_proc_entry("kmem", proc_spl);
 	remove_proc_entry("taskq-all", proc_spl);
 	remove_proc_entry("taskq", proc_spl);
 	remove_proc_entry("spl", NULL);
 
-        ASSERT(spl_header != NULL);
-        unregister_sysctl_table(spl_header);
+	ASSERT(spl_header != NULL);
+	unregister_sysctl_table(spl_header);
 }

--- a/module/spl/spl-rwlock.c
+++ b/module/spl/spl-rwlock.c
@@ -20,17 +20,11 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Reader/Writer Lock Implementation.
  */
 
 #include <sys/rwlock.h>
-
-#ifdef DEBUG_SUBSYSTEM
-#undef DEBUG_SUBSYSTEM
-#endif
-
-#define DEBUG_SUBSYSTEM S_RWLOCK
 
 #if defined(CONFIG_PREEMPT_RT_FULL)
 
@@ -94,7 +88,7 @@ __rwsem_tryupgrade(struct rw_semaphore *rwsem)
 static int
 __rwsem_tryupgrade(struct rw_semaphore *rwsem)
 {
-	typeof (rwsem->count) val;
+	typeof(rwsem->count) val;
 	val = cmpxchg(&rwsem->count, SPL_RWSEM_SINGLE_READER_VALUE,
 	    SPL_RWSEM_SINGLE_WRITER_VALUE);
 	return (val == SPL_RWSEM_SINGLE_READER_VALUE);

--- a/module/spl/spl-taskq.c
+++ b/module/spl/spl-taskq.c
@@ -87,7 +87,7 @@ taskq_find_by_name(const char *name)
 	list_for_each_prev(tql, &tq_list) {
 		tq = list_entry(tql, taskq_t, tq_taskqs);
 		if (strcmp(name, tq->tq_name) == 0)
-			return tq->tq_instance;
+			return (tq->tq_instance);
 	}
 	return (-1);
 }
@@ -573,7 +573,8 @@ taskq_dispatch(taskq_t *tq, task_func_t func, void *arg, uint_t flags)
 	ASSERT(tq->tq_nactive <= tq->tq_nthreads);
 	if ((flags & TQ_NOQUEUE) && (tq->tq_nactive == tq->tq_nthreads)) {
 		/* Dynamic taskq may be able to spawn another thread */
-		if (!(tq->tq_flags & TASKQ_DYNAMIC) || taskq_thread_spawn(tq) == 0)
+		if (!(tq->tq_flags & TASKQ_DYNAMIC) ||
+		    taskq_thread_spawn(tq) == 0)
 			goto out;
 	}
 
@@ -686,7 +687,8 @@ taskq_dispatch_ent(taskq_t *tq, task_func_t func, void *arg, uint_t flags,
 
 	if ((flags & TQ_NOQUEUE) && (tq->tq_nactive == tq->tq_nthreads)) {
 		/* Dynamic taskq may be able to spawn another thread */
-		if (!(tq->tq_flags & TASKQ_DYNAMIC) || taskq_thread_spawn(tq) == 0)
+		if (!(tq->tq_flags & TASKQ_DYNAMIC) ||
+		    taskq_thread_spawn(tq) == 0)
 			goto out2;
 		flags |= TQ_FRONT;
 	}
@@ -786,7 +788,8 @@ taskq_thread_spawn_task(void *arg)
 
 	if (taskq_thread_create(tq) == NULL) {
 		/* restore spawning count if failed */
-		spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
+		spin_lock_irqsave_nested(&tq->tq_lock, flags,
+		    tq->tq_lock_class);
 		tq->tq_nspawn--;
 		spin_unlock_irqrestore(&tq->tq_lock, flags);
 	}
@@ -1146,7 +1149,8 @@ taskq_destroy(taskq_t *tq)
 	while (tq->tq_nspawn) {
 		spin_unlock_irqrestore(&tq->tq_lock, flags);
 		schedule_timeout_interruptible(1);
-		spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
+		spin_lock_irqsave_nested(&tq->tq_lock, flags,
+		    tq->tq_lock_class);
 	}
 
 	/*
@@ -1239,16 +1243,16 @@ param_set_taskq_kick(const char *val, struct kernel_param *kp)
 
 #ifdef module_param_cb
 static const struct kernel_param_ops param_ops_taskq_kick = {
-        .set = param_set_taskq_kick,
-        .get = param_get_uint,
+	.set = param_set_taskq_kick,
+	.get = param_get_uint,
 };
 module_param_cb(spl_taskq_kick, &param_ops_taskq_kick, &spl_taskq_kick, 0644);
 #else
 module_param_call(spl_taskq_kick, param_set_taskq_kick, param_get_uint,
-    &spl_taskq_kick, 0644);
+	&spl_taskq_kick, 0644);
 #endif
 MODULE_PARM_DESC(spl_taskq_kick,
-    "Write nonzero to kick stuck taskqs to spawn more threads");
+	"Write nonzero to kick stuck taskqs to spawn more threads");
 
 int
 spl_taskq_init(void)

--- a/module/spl/spl-thread.c
+++ b/module/spl/spl-thread.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Thread Implementation.
  */
 
@@ -33,8 +33,8 @@
  */
 typedef struct thread_priv_s {
 	unsigned long tp_magic;		/* Magic */
-        int tp_name_size;		/* Name size */
-        char *tp_name;			/* Name (without _thread suffix) */
+	int tp_name_size;		/* Name size */
+	char *tp_name;			/* Name (without _thread suffix) */
 	void (*tp_func)(void *);	/* Registered function */
 	void *tp_args;			/* Args to be passed to function */
 	size_t tp_len;			/* Len to be passed to function */
@@ -55,12 +55,12 @@ thread_generic_wrapper(void *arg)
 	set_current_state(tp->tp_state);
 	set_user_nice((kthread_t *)current, PRIO_TO_NICE(tp->tp_pri));
 	kmem_free(tp->tp_name, tp->tp_name_size);
-	kmem_free(tp, sizeof(thread_priv_t));
+	kmem_free(tp, sizeof (thread_priv_t));
 
 	if (func)
 		func(args);
 
-	return 0;
+	return (0);
 }
 
 void
@@ -72,9 +72,11 @@ __thread_exit(void)
 }
 EXPORT_SYMBOL(__thread_exit);
 
-/* thread_create() may block forever if it cannot create a thread or
+/*
+ * thread_create() may block forever if it cannot create a thread or
  * allocate memory.  This is preferable to returning a NULL which Solaris
- * style callers likely never check for... since it can't fail. */
+ * style callers likely never check for... since it can't fail.
+ */
 kthread_t *
 __thread_create(caddr_t stk, size_t  stksize, thread_func_t func,
 		const char *name, void *args, size_t len, proc_t *pp,
@@ -88,7 +90,7 @@ __thread_create(caddr_t stk, size_t  stksize, thread_func_t func,
 	/* Variable stack size unsupported */
 	ASSERT(stk == NULL);
 
-	tp = kmem_alloc(sizeof(thread_priv_t), KM_PUSHPAGE);
+	tp = kmem_alloc(sizeof (thread_priv_t), KM_PUSHPAGE);
 	if (tp == NULL)
 		return (NULL);
 
@@ -96,14 +98,15 @@ __thread_create(caddr_t stk, size_t  stksize, thread_func_t func,
 	tp->tp_name_size = strlen(name) + 1;
 
 	tp->tp_name = kmem_alloc(tp->tp_name_size, KM_PUSHPAGE);
-        if (tp->tp_name == NULL) {
-		kmem_free(tp, sizeof(thread_priv_t));
+	if (tp->tp_name == NULL) {
+		kmem_free(tp, sizeof (thread_priv_t));
 		return (NULL);
 	}
 
 	strncpy(tp->tp_name, name, tp->tp_name_size);
 
-	/* Strip trailing "_thread" from passed name which will be the func
+	/*
+	 * Strip trailing "_thread" from passed name which will be the func
 	 * name since the exposed API has no parameter for passing a name.
 	 */
 	p = strstr(tp->tp_name, "_thread");
@@ -117,7 +120,7 @@ __thread_create(caddr_t stk, size_t  stksize, thread_func_t func,
 	tp->tp_pri   = pri;
 
 	tsk = spl_kthread_create(thread_generic_wrapper, (void *)tp,
-			     "%s", tp->tp_name);
+	    "%s", tp->tp_name);
 	if (IS_ERR(tsk))
 		return (NULL);
 
@@ -139,7 +142,7 @@ spl_kthread_create(int (*func)(void *), void *data, const char namefmt[], ...)
 	char name[TASK_COMM_LEN];
 
 	va_start(args, namefmt);
-	vsnprintf(name, sizeof(name), namefmt, args);
+	vsnprintf(name, sizeof (name), namefmt, args);
 	va_end(args);
 	do {
 		tsk = kthread_create(func, data, "%s", name);

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) Vnode Implementation.
  */
 
@@ -43,27 +43,27 @@ vtype_t
 vn_mode_to_vtype(mode_t mode)
 {
 	if (S_ISREG(mode))
-		return VREG;
+		return (VREG);
 
 	if (S_ISDIR(mode))
-		return VDIR;
+		return (VDIR);
 
 	if (S_ISCHR(mode))
-		return VCHR;
+		return (VCHR);
 
 	if (S_ISBLK(mode))
-		return VBLK;
+		return (VBLK);
 
 	if (S_ISFIFO(mode))
-		return VFIFO;
+		return (VFIFO);
 
 	if (S_ISLNK(mode))
-		return VLNK;
+		return (VLNK);
 
 	if (S_ISSOCK(mode))
-		return VSOCK;
+		return (VSOCK);
 
-	return VNON;
+	return (VNON);
 } /* vn_mode_to_vtype() */
 EXPORT_SYMBOL(vn_mode_to_vtype);
 
@@ -71,27 +71,27 @@ mode_t
 vn_vtype_to_mode(vtype_t vtype)
 {
 	if (vtype == VREG)
-		return S_IFREG;
+		return (S_IFREG);
 
 	if (vtype == VDIR)
-		return S_IFDIR;
+		return (S_IFDIR);
 
 	if (vtype == VCHR)
-		return S_IFCHR;
+		return (S_IFCHR);
 
 	if (vtype == VBLK)
-		return S_IFBLK;
+		return (S_IFBLK);
 
 	if (vtype == VFIFO)
-		return S_IFIFO;
+		return (S_IFIFO);
 
 	if (vtype == VLNK)
-		return S_IFLNK;
+		return (S_IFLNK);
 
 	if (vtype == VSOCK)
-		return S_IFSOCK;
+		return (S_IFSOCK);
 
-	return VNON;
+	return (VNON);
 } /* vn_vtype_to_mode() */
 EXPORT_SYMBOL(vn_vtype_to_mode);
 
@@ -135,7 +135,8 @@ vn_open(const char *path, uio_seg_t seg, int flags, int mode,
 	if (!(flags & FCREAT) && (flags & FWRITE))
 		flags |= FEXCL;
 
-	/* Note for filp_open() the two low bits must be remapped to mean:
+	/*
+	 * Note for filp_open() the two low bits must be remapped to mean:
 	 * 01 - read-only  -> 00 read-only
 	 * 10 - write-only -> 01 write-only
 	 * 11 - read-write -> 10 read-write
@@ -148,7 +149,7 @@ vn_open(const char *path, uio_seg_t seg, int flags, int mode,
 	fp = filp_open(path, flags, mode);
 
 	if (flags & FCREAT)
-		(void)xchg(&current->fs->umask, saved_umask);
+		(void) xchg(&current->fs->umask, saved_umask);
 
 	if (IS_ERR(fp))
 		return (-PTR_ERR(fp));
@@ -187,7 +188,7 @@ EXPORT_SYMBOL(vn_open);
 
 int
 vn_openat(const char *path, uio_seg_t seg, int flags, int mode,
-	  vnode_t **vpp, int x1, void *x2, vnode_t *vp, int fd)
+    vnode_t **vpp, int x1, void *x2, vnode_t *vp, int fd)
 {
 	char *realpath;
 	int len, rc;
@@ -199,7 +200,7 @@ vn_openat(const char *path, uio_seg_t seg, int flags, int mode,
 	if (!realpath)
 		return (ENOMEM);
 
-	(void)snprintf(realpath, len, "/%s", path);
+	(void) snprintf(realpath, len, "/%s", path);
 	rc = vn_open(realpath, seg, flags, mode, vpp, x1, x2);
 	kfree(realpath);
 
@@ -259,9 +260,11 @@ vn_close(vnode_t *vp, int flags, int x1, int x2, void *x3, void *x4)
 } /* vn_close() */
 EXPORT_SYMBOL(vn_close);
 
-/* vn_seek() does not actually seek it only performs bounds checking on the
+/*
+ * vn_seek() does not actually seek it only performs bounds checking on the
  * proposed seek.  We perform minimal checking and allow vn_rdwr() to catch
- * anything more serious. */
+ * anything more serious.
+ */
 int
 vn_seek(vnode_t *vp, offset_t ooff, offset_t *noffp, void *ct)
 {
@@ -293,26 +296,27 @@ vn_getattr(vnode_t *vp, vattr_t *vap, int flags, void *x3, void *x4)
 	if (rc)
 		return (-rc);
 
-	vap->va_type          = vn_mode_to_vtype(stat.mode);
-	vap->va_mode          = stat.mode;
-	vap->va_uid           = KUID_TO_SUID(stat.uid);
-	vap->va_gid           = KGID_TO_SGID(stat.gid);
-	vap->va_fsid          = 0;
-	vap->va_nodeid        = stat.ino;
-	vap->va_nlink         = stat.nlink;
-        vap->va_size          = stat.size;
-	vap->va_blksize       = stat.blksize;
-	vap->va_atime         = stat.atime;
-	vap->va_mtime         = stat.mtime;
-	vap->va_ctime         = stat.ctime;
-	vap->va_rdev          = stat.rdev;
-	vap->va_nblocks       = stat.blocks;
+	vap->va_type	= vn_mode_to_vtype(stat.mode);
+	vap->va_mode	= stat.mode;
+	vap->va_uid	= KUID_TO_SUID(stat.uid);
+	vap->va_gid	= KGID_TO_SGID(stat.gid);
+	vap->va_fsid	= 0;
+	vap->va_nodeid	= stat.ino;
+	vap->va_nlink	= stat.nlink;
+	vap->va_size	= stat.size;
+	vap->va_blksize	= stat.blksize;
+	vap->va_atime	= stat.atime;
+	vap->va_mtime	= stat.mtime;
+	vap->va_ctime	= stat.ctime;
+	vap->va_rdev	= stat.rdev;
+	vap->va_nblocks	= stat.blocks;
 
 	return (0);
 }
 EXPORT_SYMBOL(vn_getattr);
 
-int vn_fsync(vnode_t *vp, int flags, void *x3, void *x4)
+int
+vn_fsync(vnode_t *vp, int flags, void *x3, void *x4)
 {
 	int datasync = 0;
 	int error;
@@ -412,22 +416,22 @@ EXPORT_SYMBOL(vn_space);
 static file_t *
 file_find(int fd, struct task_struct *task)
 {
-        file_t *fp;
+	file_t *fp;
 
-        list_for_each_entry(fp, &vn_file_list,  f_list) {
+	list_for_each_entry(fp, &vn_file_list,  f_list) {
 		if (fd == fp->f_fd && fp->f_task == task) {
 			ASSERT(atomic_read(&fp->f_ref) != 0);
-                        return fp;
+			return (fp);
 		}
 	}
 
-        return NULL;
+	return (NULL);
 } /* file_find() */
 
 file_t *
 vn_getf(int fd)
 {
-        struct kstat stat;
+	struct kstat stat;
 	struct file *lfp;
 	file_t *fp;
 	vnode_t *vp;
@@ -482,13 +486,14 @@ vn_getf(int fd)
 		goto out_fget;
 
 #if defined(HAVE_4ARGS_VFS_GETATTR)
-	rc = vfs_getattr(&lfp->f_path, &stat, STATX_TYPE, AT_STATX_SYNC_AS_STAT);
+	rc = vfs_getattr(&lfp->f_path, &stat, STATX_TYPE,
+	    AT_STATX_SYNC_AS_STAT);
 #elif defined(HAVE_2ARGS_VFS_GETATTR)
 	rc = vfs_getattr(&lfp->f_path, &stat);
 #else
 	rc = vfs_getattr(lfp->f_path.mnt, lfp->f_dentry, &stat);
 #endif
-        if (rc)
+	if (rc)
 		goto out_vnode;
 
 	mutex_enter(&vp->v_lock);
@@ -515,7 +520,7 @@ out_mutex:
 	mutex_exit(&fp->f_lock);
 	kmem_cache_free(vn_file_cache, fp);
 out:
-        return (NULL);
+	return (NULL);
 } /* getf() */
 EXPORT_SYMBOL(getf);
 
@@ -556,12 +561,10 @@ vn_areleasef(int fd, uf_info_t *fip)
 			return;
 		}
 
-	        list_del(&fp->f_list);
+		list_del(&fp->f_list);
 		releasef_locked(fp);
 	}
 	spin_unlock(&vn_file_lock);
-
-	return;
 } /* releasef() */
 EXPORT_SYMBOL(areleasef);
 
@@ -596,34 +599,34 @@ vn_set_fs_pwd(struct fs_struct *fs, struct path *path)
 int
 vn_set_pwd(const char *filename)
 {
-        struct path path;
-        mm_segment_t saved_fs;
-        int rc;
+	struct path path;
+	mm_segment_t saved_fs;
+	int rc;
 
-        /*
-         * user_path_dir() and __user_walk() both expect 'filename' to be
-         * a user space address so we must briefly increase the data segment
-         * size to ensure strncpy_from_user() does not fail with -EFAULT.
-         */
-        saved_fs = get_fs();
-        set_fs(get_ds());
+	/*
+	 * user_path_dir() and __user_walk() both expect 'filename' to be
+	 * a user space address so we must briefly increase the data segment
+	 * size to ensure strncpy_from_user() does not fail with -EFAULT.
+	 */
+	saved_fs = get_fs();
+	set_fs(get_ds());
 
-        rc = user_path_dir(filename, &path);
-        if (rc)
+	rc = user_path_dir(filename, &path);
+	if (rc)
 		goto out;
 
-        rc = inode_permission(path.dentry->d_inode, MAY_EXEC | MAY_ACCESS);
-        if (rc)
+	rc = inode_permission(path.dentry->d_inode, MAY_EXEC | MAY_ACCESS);
+	if (rc)
 		goto dput_and_out;
 
-        vn_set_fs_pwd(current->fs, &path);
+	vn_set_fs_pwd(current->fs, &path);
 
 dput_and_out:
-        path_put(&path);
+	path_put(&path);
 out:
 	set_fs(saved_fs);
 
-        return (-rc);
+	return (-rc);
 } /* vn_set_pwd() */
 EXPORT_SYMBOL(vn_set_pwd);
 
@@ -651,10 +654,10 @@ vn_file_cache_constructor(void *buf, void *cdrarg, int kmflags)
 	file_t *fp = buf;
 
 	atomic_set(&fp->f_ref, 0);
-        mutex_init(&fp->f_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&fp->f_lock, NULL, MUTEX_DEFAULT, NULL);
 	INIT_LIST_HEAD(&fp->f_list);
 
-        return (0);
+	return (0);
 } /* file_cache_constructor() */
 
 static void
@@ -669,29 +672,26 @@ int
 spl_vn_init(void)
 {
 	vn_cache = kmem_cache_create("spl_vn_cache",
-				     sizeof(struct vnode), 64,
-	                             vn_cache_constructor,
-				     vn_cache_destructor,
-				     NULL, NULL, NULL, 0);
+	    sizeof (struct vnode), 64, vn_cache_constructor,
+	    vn_cache_destructor, NULL, NULL, NULL, 0);
 
 	vn_file_cache = kmem_cache_create("spl_vn_file_cache",
-					  sizeof(file_t), 64,
-				          vn_file_cache_constructor,
-				          vn_file_cache_destructor,
-				          NULL, NULL, NULL, 0);
+	    sizeof (file_t), 64, vn_file_cache_constructor,
+	    vn_file_cache_destructor, NULL, NULL, NULL, 0);
+
 	return (0);
 } /* vn_init() */
 
 void
 spl_vn_fini(void)
 {
-        file_t *fp, *next_fp;
+	file_t *fp, *next_fp;
 	int leaked = 0;
 
 	spin_lock(&vn_file_lock);
 
-        list_for_each_entry_safe(fp, next_fp, &vn_file_list,  f_list) {
-	        list_del(&fp->f_list);
+	list_for_each_entry_safe(fp, next_fp, &vn_file_list,  f_list) {
+		list_del(&fp->f_list);
 		releasef_locked(fp);
 		leaked++;
 	}
@@ -703,6 +703,4 @@ spl_vn_fini(void)
 
 	kmem_cache_destroy(vn_file_cache);
 	kmem_cache_destroy(vn_cache);
-
-	return;
 } /* vn_fini() */

--- a/module/spl/spl-xdr.c
+++ b/module/spl/spl-xdr.c
@@ -17,7 +17,7 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
  *  Solaris Porting Layer (SPL) XDR Implementation.
  */
 
@@ -163,12 +163,12 @@ xdrmem_control(XDR *xdrs, int req, void *info)
 	struct xdr_bytesrec *rec = (struct xdr_bytesrec *) info;
 
 	if (req != XDR_GET_BYTES_AVAIL)
-		return FALSE;
+		return (FALSE);
 
 	rec->xc_is_last_record = TRUE; /* always TRUE in xdrmem streams */
 	rec->xc_num_avail = xdrs->x_addr_end - xdrs->x_addr;
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
@@ -178,13 +178,13 @@ xdrmem_enc_bytes(XDR *xdrs, caddr_t cp, const uint_t cnt)
 	uint_t pad;
 
 	if (size < cnt)
-		return FALSE; /* Integer overflow */
+		return (FALSE); /* Integer overflow */
 
 	if (xdrs->x_addr > xdrs->x_addr_end)
-		return FALSE;
+		return (FALSE);
 
 	if (xdrs->x_addr_end - xdrs->x_addr < size)
-		return FALSE;
+		return (FALSE);
 
 	memcpy(xdrs->x_addr, cp, cnt);
 
@@ -196,7 +196,7 @@ xdrmem_enc_bytes(XDR *xdrs, caddr_t cp, const uint_t cnt)
 		xdrs->x_addr += pad;
 	}
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
@@ -207,13 +207,13 @@ xdrmem_dec_bytes(XDR *xdrs, caddr_t cp, const uint_t cnt)
 	uint_t pad;
 
 	if (size < cnt)
-		return FALSE; /* Integer overflow */
+		return (FALSE); /* Integer overflow */
 
 	if (xdrs->x_addr > xdrs->x_addr_end)
-		return FALSE;
+		return (FALSE);
 
 	if (xdrs->x_addr_end - xdrs->x_addr < size)
-		return FALSE;
+		return (FALSE);
 
 	memcpy(cp, xdrs->x_addr, cnt);
 	xdrs->x_addr += cnt;
@@ -222,38 +222,38 @@ xdrmem_dec_bytes(XDR *xdrs, caddr_t cp, const uint_t cnt)
 	if (pad > 0) {
 		/* An inverted memchr() would be useful here... */
 		if (memcmp(&zero, xdrs->x_addr, pad) != 0)
-			return FALSE;
+			return (FALSE);
 
 		xdrs->x_addr += pad;
 	}
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
 xdrmem_enc_uint32(XDR *xdrs, uint32_t val)
 {
-	if (xdrs->x_addr + sizeof(uint32_t) > xdrs->x_addr_end)
-		return FALSE;
+	if (xdrs->x_addr + sizeof (uint32_t) > xdrs->x_addr_end)
+		return (FALSE);
 
 	*((uint32_t *) xdrs->x_addr) = cpu_to_be32(val);
 
-	xdrs->x_addr += sizeof(uint32_t);
+	xdrs->x_addr += sizeof (uint32_t);
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
 xdrmem_dec_uint32(XDR *xdrs, uint32_t *val)
 {
-	if (xdrs->x_addr + sizeof(uint32_t) > xdrs->x_addr_end)
-		return FALSE;
+	if (xdrs->x_addr + sizeof (uint32_t) > xdrs->x_addr_end)
+		return (FALSE);
 
 	*val = be32_to_cpu(*((uint32_t *) xdrs->x_addr));
 
-	xdrs->x_addr += sizeof(uint32_t);
+	xdrs->x_addr += sizeof (uint32_t);
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
@@ -261,10 +261,10 @@ xdrmem_enc_char(XDR *xdrs, char *cp)
 {
 	uint32_t val;
 
-	BUILD_BUG_ON(sizeof(char) != 1);
+	BUILD_BUG_ON(sizeof (char) != 1);
 	val = *((unsigned char *) cp);
 
-	return xdrmem_enc_uint32(xdrs, val);
+	return (xdrmem_enc_uint32(xdrs, val));
 }
 
 static bool_t
@@ -272,10 +272,10 @@ xdrmem_dec_char(XDR *xdrs, char *cp)
 {
 	uint32_t val;
 
-	BUILD_BUG_ON(sizeof(char) != 1);
+	BUILD_BUG_ON(sizeof (char) != 1);
 
 	if (!xdrmem_dec_uint32(xdrs, &val))
-		return FALSE;
+		return (FALSE);
 
 	/*
 	 * If any of the 3 other bytes are non-zero then val will be greater
@@ -283,19 +283,19 @@ xdrmem_dec_char(XDR *xdrs, char *cp)
 	 * not have a char encoded in it.
 	 */
 	if (val > 0xff)
-		return FALSE;
+		return (FALSE);
 
 	*((unsigned char *) cp) = val;
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
 xdrmem_enc_ushort(XDR *xdrs, unsigned short *usp)
 {
-	BUILD_BUG_ON(sizeof(unsigned short) != 2);
+	BUILD_BUG_ON(sizeof (unsigned short) != 2);
 
-	return xdrmem_enc_uint32(xdrs, *usp);
+	return (xdrmem_enc_uint32(xdrs, *usp));
 }
 
 static bool_t
@@ -303,48 +303,48 @@ xdrmem_dec_ushort(XDR *xdrs, unsigned short *usp)
 {
 	uint32_t val;
 
-	BUILD_BUG_ON(sizeof(unsigned short) != 2);
+	BUILD_BUG_ON(sizeof (unsigned short) != 2);
 
 	if (!xdrmem_dec_uint32(xdrs, &val))
-		return FALSE;
+		return (FALSE);
 
 	/*
 	 * Short ints are not in the RFC, but we assume similar logic as in
 	 * xdrmem_dec_char().
 	 */
 	if (val > 0xffff)
-		return FALSE;
+		return (FALSE);
 
 	*usp = val;
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
 xdrmem_enc_uint(XDR *xdrs, unsigned *up)
 {
-	BUILD_BUG_ON(sizeof(unsigned) != 4);
+	BUILD_BUG_ON(sizeof (unsigned) != 4);
 
-	return xdrmem_enc_uint32(xdrs, *up);
+	return (xdrmem_enc_uint32(xdrs, *up));
 }
 
 static bool_t
 xdrmem_dec_uint(XDR *xdrs, unsigned *up)
 {
-	BUILD_BUG_ON(sizeof(unsigned) != 4);
+	BUILD_BUG_ON(sizeof (unsigned) != 4);
 
-	return xdrmem_dec_uint32(xdrs, (uint32_t *) up);
+	return (xdrmem_dec_uint32(xdrs, (uint32_t *) up));
 }
 
 static bool_t
 xdrmem_enc_ulonglong(XDR *xdrs, u_longlong_t *ullp)
 {
-	BUILD_BUG_ON(sizeof(u_longlong_t) != 8);
+	BUILD_BUG_ON(sizeof (u_longlong_t) != 8);
 
 	if (!xdrmem_enc_uint32(xdrs, *ullp >> 32))
-		return FALSE;
+		return (FALSE);
 
-	return xdrmem_enc_uint32(xdrs, *ullp & 0xffffffff);
+	return (xdrmem_enc_uint32(xdrs, *ullp & 0xffffffff));
 }
 
 static bool_t
@@ -352,16 +352,16 @@ xdrmem_dec_ulonglong(XDR *xdrs, u_longlong_t *ullp)
 {
 	uint32_t low, high;
 
-	BUILD_BUG_ON(sizeof(u_longlong_t) != 8);
+	BUILD_BUG_ON(sizeof (u_longlong_t) != 8);
 
 	if (!xdrmem_dec_uint32(xdrs, &high))
-		return FALSE;
+		return (FALSE);
 	if (!xdrmem_dec_uint32(xdrs, &low))
-		return FALSE;
+		return (FALSE);
 
 	*ullp = ((u_longlong_t) high << 32) | low;
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
@@ -372,18 +372,18 @@ xdr_enc_array(XDR *xdrs, caddr_t *arrp, uint_t *sizep, const uint_t maxsize,
 	caddr_t addr = *arrp;
 
 	if (*sizep > maxsize || *sizep > UINT_MAX / elsize)
-		return FALSE;
+		return (FALSE);
 
 	if (!xdrmem_enc_uint(xdrs, sizep))
-		return FALSE;
+		return (FALSE);
 
 	for (i = 0; i < *sizep; i++) {
 		if (!elproc(xdrs, addr))
-			return FALSE;
+			return (FALSE);
 		addr += elsize;
 	}
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
@@ -395,23 +395,23 @@ xdr_dec_array(XDR *xdrs, caddr_t *arrp, uint_t *sizep, const uint_t maxsize,
 	caddr_t addr;
 
 	if (!xdrmem_dec_uint(xdrs, sizep))
-		return FALSE;
+		return (FALSE);
 
 	size = *sizep;
 
 	if (size > maxsize || size > UINT_MAX / elsize)
-		return FALSE;
+		return (FALSE);
 
 	/*
 	 * The Solaris man page says: "If *arrp is NULL when decoding,
 	 * xdr_array() allocates memory and *arrp points to it".
 	 */
 	if (*arrp == NULL) {
-		BUILD_BUG_ON(sizeof(uint_t) > sizeof(size_t));
+		BUILD_BUG_ON(sizeof (uint_t) > sizeof (size_t));
 
 		*arrp = kmem_alloc(size * elsize, KM_NOSLEEP);
 		if (*arrp == NULL)
-			return FALSE;
+			return (FALSE);
 
 		alloc = TRUE;
 	}
@@ -422,12 +422,12 @@ xdr_dec_array(XDR *xdrs, caddr_t *arrp, uint_t *sizep, const uint_t maxsize,
 		if (!elproc(xdrs, addr)) {
 			if (alloc)
 				kmem_free(*arrp, size * elsize);
-			return FALSE;
+			return (FALSE);
 		}
 		addr += elsize;
 	}
 
-	return TRUE;
+	return (TRUE);
 }
 
 static bool_t
@@ -437,14 +437,14 @@ xdr_enc_string(XDR *xdrs, char **sp, const uint_t maxsize)
 	uint_t len;
 
 	if (slen > maxsize)
-		return FALSE;
+		return (FALSE);
 
 	len = slen;
 
 	if (!xdrmem_enc_uint(xdrs, &len))
-		return FALSE;
+		return (FALSE);
 
-	return xdrmem_enc_bytes(xdrs, *sp, len);
+	return (xdrmem_enc_bytes(xdrs, *sp, len));
 }
 
 static bool_t
@@ -454,21 +454,21 @@ xdr_dec_string(XDR *xdrs, char **sp, const uint_t maxsize)
 	bool_t alloc = FALSE;
 
 	if (!xdrmem_dec_uint(xdrs, &size))
-		return FALSE;
+		return (FALSE);
 
 	if (size > maxsize || size > UINT_MAX - 1)
-		return FALSE;
+		return (FALSE);
 
 	/*
 	 * Solaris man page: "If *sp is NULL when decoding, xdr_string()
 	 * allocates memory and *sp points to it".
 	 */
 	if (*sp == NULL) {
-		BUILD_BUG_ON(sizeof(uint_t) > sizeof(size_t));
+		BUILD_BUG_ON(sizeof (uint_t) > sizeof (size_t));
 
 		*sp = kmem_alloc(size + 1, KM_NOSLEEP);
 		if (*sp == NULL)
-			return FALSE;
+			return (FALSE);
 
 		alloc = TRUE;
 	}
@@ -481,34 +481,33 @@ xdr_dec_string(XDR *xdrs, char **sp, const uint_t maxsize)
 
 	(*sp)[size] = '\0';
 
-	return TRUE;
+	return (TRUE);
 
 fail:
 	if (alloc)
 		kmem_free(*sp, size + 1);
 
-	return FALSE;
+	return (FALSE);
 }
 
 static struct xdr_ops xdrmem_encode_ops = {
-	.xdr_control      = xdrmem_control,
-	.xdr_char         = xdrmem_enc_char,
-	.xdr_u_short      = xdrmem_enc_ushort,
-	.xdr_u_int        = xdrmem_enc_uint,
-	.xdr_u_longlong_t = xdrmem_enc_ulonglong,
-	.xdr_opaque       = xdrmem_enc_bytes,
-	.xdr_string       = xdr_enc_string,
-	.xdr_array        = xdr_enc_array
+	.xdr_control		= xdrmem_control,
+	.xdr_char		= xdrmem_enc_char,
+	.xdr_u_short		= xdrmem_enc_ushort,
+	.xdr_u_int		= xdrmem_enc_uint,
+	.xdr_u_longlong_t	= xdrmem_enc_ulonglong,
+	.xdr_opaque		= xdrmem_enc_bytes,
+	.xdr_string		= xdr_enc_string,
+	.xdr_array		= xdr_enc_array
 };
 
 static struct xdr_ops xdrmem_decode_ops = {
-	.xdr_control      = xdrmem_control,
-	.xdr_char         = xdrmem_dec_char,
-	.xdr_u_short      = xdrmem_dec_ushort,
-	.xdr_u_int        = xdrmem_dec_uint,
-	.xdr_u_longlong_t = xdrmem_dec_ulonglong,
-	.xdr_opaque       = xdrmem_dec_bytes,
-	.xdr_string       = xdr_dec_string,
-	.xdr_array        = xdr_dec_array
+	.xdr_control		= xdrmem_control,
+	.xdr_char		= xdrmem_dec_char,
+	.xdr_u_short		= xdrmem_dec_ushort,
+	.xdr_u_int		= xdrmem_dec_uint,
+	.xdr_u_longlong_t	= xdrmem_dec_ulonglong,
+	.xdr_opaque		= xdrmem_dec_bytes,
+	.xdr_string		= xdr_dec_string,
+	.xdr_array		= xdr_dec_array
 };
-

--- a/module/spl/spl-zlib.c
+++ b/module/spl/spl-zlib.c
@@ -20,7 +20,8 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with the SPL.  If not, see <http://www.gnu.org/licenses/>.
- *****************************************************************************
+ *
+ *
  *  z_compress_level/z_uncompress are nearly identical copies of the
  *  compress2/uncompress functions provided by the official zlib package
  *  available at http://zlib.net/.  The only changes made we to slightly
@@ -72,7 +73,7 @@ static spl_kmem_cache_t *zlib_workspace_cache;
 static void *
 zlib_workspace_alloc(int flags)
 {
-	return kmem_cache_alloc(zlib_workspace_cache, flags & ~(__GFP_FS));
+	return (kmem_cache_alloc(zlib_workspace_cache, flags & ~(__GFP_FS)));
 }
 
 static void
@@ -94,7 +95,7 @@ zlib_workspace_free(void *workspace)
  */
 int
 z_compress_level(void *dest, size_t *destLen, const void *source,
-                 size_t sourceLen, int level)
+    size_t sourceLen, int level)
 {
 	z_stream stream;
 	int err;
@@ -105,30 +106,30 @@ z_compress_level(void *dest, size_t *destLen, const void *source,
 	stream.avail_out = (uInt)*destLen;
 
 	if ((size_t)stream.avail_out != *destLen)
-		return Z_BUF_ERROR;
+		return (Z_BUF_ERROR);
 
 	stream.workspace = zlib_workspace_alloc(KM_SLEEP);
 	if (!stream.workspace)
-		return Z_MEM_ERROR;
+		return (Z_MEM_ERROR);
 
 	err = zlib_deflateInit(&stream, level);
 	if (err != Z_OK) {
 		zlib_workspace_free(stream.workspace);
-		return err;
+		return (err);
 	}
 
 	err = zlib_deflate(&stream, Z_FINISH);
 	if (err != Z_STREAM_END) {
 		zlib_deflateEnd(&stream);
 		zlib_workspace_free(stream.workspace);
-		return err == Z_OK ? Z_BUF_ERROR : err;
+		return (err == Z_OK ? Z_BUF_ERROR : err);
 	}
 	*destLen = stream.total_out;
 
 	err = zlib_deflateEnd(&stream);
 	zlib_workspace_free(stream.workspace);
 
-	return err;
+	return (err);
 }
 EXPORT_SYMBOL(z_compress_level);
 
@@ -159,16 +160,16 @@ z_uncompress(void *dest, size_t *destLen, const void *source, size_t sourceLen)
 	stream.avail_out = (uInt)*destLen;
 
 	if ((size_t)stream.avail_out != *destLen)
-		return Z_BUF_ERROR;
+		return (Z_BUF_ERROR);
 
 	stream.workspace = zlib_workspace_alloc(KM_SLEEP);
 	if (!stream.workspace)
-		return Z_MEM_ERROR;
+		return (Z_MEM_ERROR);
 
 	err = zlib_inflateInit(&stream);
 	if (err != Z_OK) {
 		zlib_workspace_free(stream.workspace);
-		return err;
+		return (err);
 	}
 
 	err = zlib_inflate(&stream, Z_FINISH);
@@ -177,17 +178,17 @@ z_uncompress(void *dest, size_t *destLen, const void *source, size_t sourceLen)
 		zlib_workspace_free(stream.workspace);
 
 		if (err == Z_NEED_DICT ||
-		   (err == Z_BUF_ERROR && stream.avail_in == 0))
-			return Z_DATA_ERROR;
+		    (err == Z_BUF_ERROR && stream.avail_in == 0))
+			return (Z_DATA_ERROR);
 
-		return err;
+		return (err);
 	}
 	*destLen = stream.total_out;
 
 	err = zlib_inflateEnd(&stream);
 	zlib_workspace_free(stream.workspace);
 
-	return err;
+	return (err);
 }
 EXPORT_SYMBOL(z_uncompress);
 
@@ -203,15 +204,15 @@ spl_zlib_init(void)
 	    "spl_zlib_workspace_cache",
 	    size, 0, NULL, NULL, NULL, NULL, NULL,
 	    KMC_VMEM | KMC_NOEMERGENCY);
-        if (!zlib_workspace_cache)
+	if (!zlib_workspace_cache)
 		return (1);
 
-        return (0);
+	return (0);
 }
 
 void
 spl_zlib_fini(void)
 {
 	kmem_cache_destroy(zlib_workspace_cache);
-        zlib_workspace_cache = NULL;
+	zlib_workspace_cache = NULL;
 }


### PR DESCRIPTION
This patch contains no functional changes.  It is solely intended
to resolve cstyle warnings in order to facilitate moving the spl
source code in to the zfs repository.