### PR TITLE
Fix spl-kmod builds when using rpm >= 4.14

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -231,6 +231,7 @@ AC_DEFUN([SPL_AC_RPM], [
 	RPM_DEFINE_COMMON='--define "$(DEBUG_SPL) 1" --define "$(DEBUG_KMEM) 1" --define "$(DEBUG_KMEM_TRACKING) 1"'
 	RPM_DEFINE_UTIL=
 	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)"'
+	RPM_DEFINE_KMOD+=' --define "_wrong_version_format_terminate_build 0"'
 	RPM_DEFINE_DKMS=
 
 	SRPM_DEFINE_COMMON='--define "build_src_rpm 1"'


### PR DESCRIPTION
With rpm-software-management/rpm@5e94633 a package version containing invalid characters (most commonly a double '-') causes the kmod package generation to terminate with an error.  This change takes advantage of the newly introduced rpm macro "_wrong_version_format_terminate_build"
to allow kmod packages to be built.

This should fix https://github.com/zfsonlinux/spl/issues/673

Tested on Debian Buster:

```
root@linux:~/rpmbuild/SPECS# dpkg -l rpm
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                           Version                      Architecture                 Description
+++-==============================================-============================-============================-==================================================================================================
ii  rpm                                            4.14.0+dfsg1-2               amd64                        package manager for RPM
root@linux:~/rpmbuild/SPECS# rpmbuild -bb spl-kmod.spec 
error: line 68: Invalid version (double separator '-'): 4.15.0-1-amd64: Provides:         kernel-modules-for-kernel = 4.15.0-1-amd64
root@linux:~/rpmbuild/SPECS# rpmbuild --define "_wrong_version_format_terminate_build 0" -bb spl-kmod.spec 
warning: line 68: Invalid version (double separator '-'): 4.15.0-1-amd64: Provides:         kernel-modules-for-kernel = 4.15.0-1-amd64
warning: line 68: Invalid version (double separator '-'): 4.15.0-1-amd64: Provides:         kmod-spl-uname-r = 4.15.0-1-amd64
warning: line 68: Invalid version (double separator '-'): 4.15.0-1-amd64: Provides:         kernel-objects-for-kernel = 4.15.0-1-amd64
warning: line 68: Invalid version (double separator '-'): 4.15.0-1-amd64: Provides:         kmod-spl-devel-uname-r = 4.15.0-1-amd64
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.nthHUu
+ umask 022
+ cd /root/rpmbuild/BUILD
+ bash /root/rpmbuild/SOURCES/kmodtool --target x86_64 --kmodname spl-kmod --newest --devel --for-kernels 4.15.0-1-amd64
%package       -n kmod-spl-4.15.0-1-amd64
Summary:          spl kernel module(s) for 4.15.0-1-amd64
Group:            System Environment/Kernel
Provides:         kernel-modules-for-kernel = 4.15.0-1-amd64
Provides:         kmod-spl-uname-r = 4.15.0-1-amd64
Provides:         spl-kmod = %{?epoch:%{epoch}:}%{version}-%{release}
Requires:         spl-kmod-common >= %{?epoch:%{epoch}:}%{version}
Requires(post):   /sbin/depmod
Requires(postun): /sbin/depmod
%post          -n kmod-spl-4.15.0-1-amd64
[[ "4.15.0-1-amd64" == "4.15.0-1-amd64"  ]] && /sbin/depmod -a > /dev/null || :
%postun        -n kmod-spl-4.15.0-1-amd64
[[ "4.15.0-1-amd64" == "4.15.0-1-amd64"  ]] && /sbin/depmod -a > /dev/null || :

%description  -n kmod-spl-4.15.0-1-amd64
This package provides the spl kernel modules built for the Linux
kernel 4.15.0-1-amd64 for the %{_target_cpu} family of processors.
%files        -n kmod-spl-4.15.0-1-amd64
%defattr(644,root,root,755)
%dir /lib/modules/4.15.0-1-amd64/extra
/lib/modules/4.15.0-1-amd64/extra/spl/


%package       -n kmod-spl-devel
Summary:          spl kernel module(s) devel common
Group:            System Environment/Kernel
Provides:         spl-devel-kmod = %{?epoch:%{epoch}:}%{version}-%{release}
%description  -n kmod-spl-devel
This package provides the common header files to build kernel modules
which depend on the spl kernel module.  It may optionally require
the spl-devel-<kernel> objects for the newest kernel.

%files        -n kmod-spl-devel
%defattr(644,root,root,755)
%{_usrsrc}/spl-%{version}
%exclude %{_usrsrc}/spl-%{version}/4.15.0-1-amd64


%package       -n kmod-spl-devel-4.15.0-1-amd64
Summary:          spl kernel module(s) devel for 4.15.0-1-amd64
Group:            System Environment/Kernel
Provides:         kernel-objects-for-kernel = 4.15.0-1-amd64
Provides:         spl-devel-kmod = %{?epoch:%{epoch}:}%{version}-%{release}
Provides:         kmod-spl-devel-uname-r = 4.15.0-1-amd64
%description  -n kmod-spl-devel-4.15.0-1-amd64
This package provides objects and symbols required to build kernel modules
which depend on the spl kernel modules built for the Linux
kernel 4.15.0-1-amd64 for the %{_target_cpu} family of processors.
%files        -n kmod-spl-devel-4.15.0-1-amd64
%defattr(644,root,root,755)
%{_usrsrc}/spl-%{version}/4.15.0-1-amd64



%global kmodinstdir_prefix  /lib/modules/
%global kmodinstdir_postfix /extra/spl/
%global kernel_versions     4.15.0-1-amd64___/lib/modules/4.15.0-1-amd64/build/

+ cd /root/rpmbuild/BUILD
+ rm -rf spl-kmod-0.7.0
+ /bin/mkdir -p spl-kmod-0.7.0
+ cd spl-kmod-0.7.0
+ + /bin/tar/bin/gzip -xof -dc - /root/rpmbuild/SOURCES/spl-0.7.0.tar.gz

+ STATUS=0
+ [ 0 -ne 0 ]
+ /bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ /bin/mkdir _kmod_build_4.15.0-1-amd64
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.28GwBJ
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd spl-kmod-0.7.0
+ cd _kmod_build_4.15.0-1-amd64
+ CFLAGS=-O2 -g
+ export CFLAGS
+ CXXFLAGS=-O2 -g
+ export CXXFLAGS
+ FFLAGS=-O2 -g
+ export FFLAGS
+ [ -e /lib/modules/4.15.0-1-amd64/source ]
+ echo /lib/modules/4.15.0-1-amd64/source
+ ../spl-0.7.0/configure --host=x86_64-pc-linux-gnu --build=x86_64-pc-linux-gnu --program-prefix= --disable-dependency-tracking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --includedir=/usr/include --libdir=/usr/lib64 --libexecdir=/usr/lib/x86_64-linux-gnu --localstatedir=/var --sharedstatedir=/usr/com --mandir=/usr/share/man --infodir=/usr/share/info --with-config=kernel --with-linux=/lib/modules/4.15.0-1-amd64/source --with-linux-obj=/lib/modules/4.15.0-1-amd64/build --disable-debug --disable-debug-log --disable-debug-kmem --disable-debug-kmem-tracking --disable-atomic-spinlocks
...
```