### PR TITLE
SECTOR_SIZE now in linux/blkdev.h

### DIFF
--- a/include/sys/sunldi.h
+++ b/include/sys/sunldi.h
@@ -32,6 +32,12 @@
 #include <linux/bio.h>
 #include <linux/blkdev.h>
 
+/*
+ * SECTOR_SIZE can be defined in blkdev.h. See
+ * https://github.com/torvalds/linux/commit/233bde21.
+ */
+#ifndef SECTOR_SIZE
 #define	SECTOR_SIZE 512
+#endif
 
 #endif /* SPL_SUNLDI_H */


### PR DESCRIPTION
As of https://github.com/torvalds/linux/commit/233bde21,
SECTOR_SIZE is defined in linux/blkdev.h. Define SECTOR_SIZE
in sunldi.h only if it's not already defined.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>