### PR TITLE
Exclude python scripts from RPM shebang check

### DIFF
--- a/rpm/generic/spl-dkms.spec.in
+++ b/rpm/generic/spl-dkms.spec.in
@@ -7,6 +7,16 @@
 %define module  @PACKAGE@
 %define mkconf  scripts/dkms.mkconf
 
+# Python permits the !/usr/bin/python shebang for scripts that are cross
+# compatible between python2 and python3, but Fedora 28 does not.  Fedora
+# wants us to choose python3 for cross-compatible scripts.  Since we want
+# to support python2 and python3 users, exclude our scripts from Fedora 28's
+# RPM build check, so that we don't get a bunch of build warnings.
+#
+# Details: https://github.com/zfsonlinux/zfs/issues/7360
+#
+%global __brp_mangle_shebangs_exclude_from      splslab.py
+
 Name:           %{module}-dkms
 
 Version:        @VERSION@

--- a/rpm/generic/spl.spec.in
+++ b/rpm/generic/spl.spec.in
@@ -1,3 +1,13 @@
+# Python permits the !/usr/bin/python shebang for scripts that are cross
+# compatible between python2 and python3, but Fedora 28 does not.  Fedora
+# wants us to choose python3 for cross-compatible scripts.  Since we want
+# to support python2 and python3 users, exclude our scripts from Fedora 28's
+# RPM build check, so that we don't get a bunch of build warnings.
+#
+# Details: https://github.com/zfsonlinux/zfs/issues/7360
+#
+%global __brp_mangle_shebangs_exclude_from	splslab.py
+
 Name:           @PACKAGE@
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}


### PR DESCRIPTION
The newest Fedora packaging rules print warnings for scripts using the
/usr/bin/python shebang:
```
  *** WARNING: mangling shebang in /usr/src/spl-0.7.0/cmd/splslab/splslab.py
  from #!/usr/bin/python to #!/usr/bin/python2. This will become an ERROR,
  fix it manually!
```
Fedora wants all cross compatible scripts to pick python3.  Since we
don't want our users to have to pick a specific version of python, we
exclude our scripts from the RPM build check.

Closes: #699