### PR TITLE
Add KSTAT_FLAG_NO_HEADERS for kstats

### DIFF
--- a/include/sys/kstat.h
+++ b/include/sys/kstat.h
@@ -73,6 +73,22 @@
 	(KSTAT_FLAG_VAR_SIZE | KSTAT_FLAG_WRITABLE | \
 	KSTAT_FLAG_PERSISTENT | KSTAT_FLAG_DORMANT)
 
+/*
+ * The normal kstat output includes two metadata headers before the actual
+ * value:
+ *
+ *     $ cat /proc/spl/kstat/zfs/foo
+ *     31 0 0x01 1 0 1336141223666 1816471471871
+ *     raw value
+ *     foo
+ *
+ * You can omit those headers by setting KSTAT_FLAG_NO_HEADERS:
+ *
+ *     $ cat /proc/spl/kstat/zfs/foo
+ *     foo
+ *
+ */
+#define KSTAT_FLAG_NO_HEADERS	0x20
 
 #define	KS_MAGIC		0x9d9d9d9d
 

--- a/module/spl/spl-kstat.c
+++ b/module/spl/spl-kstat.c
@@ -388,7 +388,8 @@ kstat_seq_start(struct seq_file *f, loff_t *pos)
 
 	ksp->ks_snaptime = gethrtime();
 
-	if (!n && kstat_seq_show_headers(f))
+	if (!(ksp->ks_flags & KSTAT_FLAG_NO_HEADERS) && !n &&
+	    kstat_seq_show_headers(f))
 		return (NULL);
 
 	if (n >= ksp->ks_ndata)


### PR DESCRIPTION
The normal kstat output includes two metadata headers before the actual value:
```
    $ cat /proc/spl/kstat/zfs/foo
    31 0 0x01 1 0 1336141223666 1816471471871
    raw value
    foo
```
With this patch, you can omit those headers by setting `KSTAT_FLAG_NO_HEADERS`:
```
    $ cat /proc/spl/kstat/zfs/foo
    foo
```
This will be used by an upcoming ZFS patch that I'm working on.