### PR TITLE
Use autoconf variable for C preprocessor

### DIFF
--- a/config/spl-build.m4
+++ b/config/spl-build.m4
@@ -156,7 +156,7 @@ AC_DEFUN([SPL_AC_KERNEL], [
 	if test "$utsrelease"; then
 		kernsrcver=`(echo "#include <$utsrelease>";
 		             echo "kernsrcver=UTS_RELEASE") | 
-		             cpp -I $kernelbuild/include |
+		             ${CPP} -I $kernelbuild/include - |
 		             grep "^kernsrcver=" | cut -d \" -f 2`
 
 		if test -z "$kernsrcver"; then


### PR DESCRIPTION
This fixes the same issue as in https://github.com/zfsonlinux/zfs/pull/8180, except in the SPL. This fixes detection of the kernel version when cross-compiling without access to a native compiler.